### PR TITLE
feat: use server factory

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerFactory.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+import com.intellij.openapi.project.Project;
+import com.redhat.devtools.lsp4ij.client.LanguageClientImpl;
+import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Language server factory API.
+ */
+public interface LanguageServerFactory {
+
+    /**
+     * Returns ann instance of a connection provider to connect to the language server.
+     *
+     * @param project the project.
+     *
+     * @return an instance of a connection provider to connect to the language server.
+     */
+    @NotNull StreamConnectionProvider createConnectionProvider(@NotNull Project project);
+
+    /**
+     * Returns an instance of language client.
+     *
+     * @param project the project.
+     *
+     * @return an instance of language client.
+     */
+    @NotNull default LanguageClientImpl createLanguageClient(@NotNull Project project) {
+        return new LanguageClientImpl(project);
+    }
+
+    /**
+     * Returns the language server interface class API.
+     *
+     * @return the language server interface class API.
+     */
+    @NotNull default Class<? extends LanguageServer> getServerInterface() {
+        return LanguageServer.class;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/ServerExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ServerExtensionPointBean.java
@@ -14,25 +14,33 @@
 package com.redhat.devtools.lsp4ij;
 
 import com.intellij.openapi.extensions.ExtensionPointName;
-import com.intellij.openapi.extensions.PluginAware;
 import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
 import com.intellij.util.xmlb.annotations.Tag;
-import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Server extension point.
  */
-public class ServerExtensionPointBean extends BaseKeyedLazyInstance<StreamConnectionProvider> implements PluginAware {
+public class ServerExtensionPointBean extends BaseKeyedLazyInstance<LanguageServerFactory> {
     public static final ExtensionPointName<ServerExtensionPointBean> EP_NAME = ExtensionPointName.create("com.redhat.devtools.lsp4ij.server");
 
+    /**
+     * The language server id used to associate language
+     * with 'com.redhat.devtools.lsp4ij.languageMapping' extension point.
+     */
     @Attribute("id")
     public String id;
 
+    /**
+     * The language server label displayed on the LSP console and Language Servers preferences.
+     */
     @Attribute("label")
     public String label;
 
+    /**
+     * The language server description displayed on the LSP console and Language Servers preferences.
+     */
     @Tag("description")
     public String description;
 
@@ -43,58 +51,32 @@ public class ServerExtensionPointBean extends BaseKeyedLazyInstance<StreamConnec
     @Attribute("icon")
     public String icon;
 
-    @Attribute("class")
-    public String serverImpl;
-    private Class<?> serverImplClass;
-
-    @Attribute("clientImpl")
-    public String clientImpl;
-    private Class clientClass;
-
-    @Attribute("serverInterface")
-    public String serverInterface;
-    private Class serverClass;
+    /**
+     * The {@link LanguageServerFactory} implementation used to create connection, language client and server interface.
+     */
+    @Attribute("factoryClass")
+    public String factoryClass;
 
     /**
-     *  Valid values are <code>project</code> and <code>application</code><br/>
-     *  When <code>project</code> scope is selected, the implementation of {@link StreamConnectionProvider} requires a
-     *  constructor with a single {@link com.intellij.openapi.project.Project} parameter
+     * true if language server is a singleton and false otherwise.
      */
-    @Attribute("scope")
-    public String scope;
-
     @Attribute("singleton")
     public boolean singleton;
 
+    /**
+     * true if language server supports light edit and false otherwise.
+     */
     @Attribute("supportsLightEdit")
     public boolean supportsLightEdit;
 
+    /**
+     * Timeout used when all files are closed before stopping the language server.
+     */
     @Attribute("lastDocumentDisconnectedTimeout")
     public Integer lastDocumentDisconnectedTimeout;
 
-    public Class getClientImpl() throws ClassNotFoundException {
-        if (clientClass == null) {
-            clientClass = getPluginDescriptor().getPluginClassLoader().loadClass(clientImpl);
-        }
-        return clientClass;
-    }
-
-    public Class getServerImpl() throws ClassNotFoundException {
-        if (serverImplClass == null) {
-            serverImplClass = getPluginDescriptor().getPluginClassLoader().loadClass(serverImpl);
-        }
-        return serverImplClass;
-    }
-
-    public Class getServerInterface() throws ClassNotFoundException {
-        if (serverClass == null) {
-            serverClass = getPluginDescriptor().getPluginClassLoader().loadClass(serverInterface);
-        }
-        return serverClass;
-    }
-
     @Override
     protected @Nullable String getImplementationClassName() {
-        return serverImpl;
+        return factoryClass;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -44,7 +44,6 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
 
     public LanguageClientImpl(Project project) {
         this.project = project;
-        Disposer.register(project, this);
     }
 
     public Project getProject() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,18 +45,12 @@
     <extensionPoints>
         <extensionPoint
                 name="server"
-                beanClass="com.redhat.devtools.lsp4ij.ServerExtensionPointBean">
-            <with attribute="clientClass"
-                  implements="com.redhat.devtools.lsp4ij.client.LanguageClientImpl"/>
-            <with attribute="serverClass"
-                  implements="org.eclipse.lsp4j.services.LanguageServer"/>
+                beanClass="com.redhat.devtools.lsp4ij.ServerExtensionPointBean" >
+            <with attribute="factoryClass" implements="com.redhat.devtools.lsp4ij.LanguageServerFactory"/>
         </extensionPoint>
         <extensionPoint
                 name="languageMapping"
                 beanClass="com.redhat.devtools.lsp4ij.LanguageMappingExtensionPointBean"/>
-        <extensionPoint
-                name="serverIconProvider"
-                beanClass="com.redhat.devtools.lsp4ij.ServerIconProviderExtensionPointBean"/>
     </extensionPoints>
 
     <!-- Language Server support -->


### PR DESCRIPTION
feat: use server factory

This PR provides a new API LanguageServerFactory which takes care of to create StreamConnectionProvider, LanguageClientImpl instances and LanguageServer class (server interface). 

It means that there is now just one an attribute (factoryClass) which is used to declare server instead of 3 attributes (class, clientImpl, serverInterface), because it seems that IJ extension point can manage only one attribute to instanciate otherwise you need to use internal API to instanciate class.

This PR avoids to use internal API and it simplifies the code (no need to manage some scope project / application), because the instance are managed with Java.

See changes https://github.com/redhat-developer/intellij-quarkus/pull/1289/files#diff-6bfdea29cf5a3281628af3c42227a28ac4c8041a3d1177de0377b0a3ba3d1c70