### PR TITLE
feat: Use inlayhint factory to avoid declaring LSP codelens/inlayhint support in an external plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Here are some projects that use LSP4IJ:
 
 ## Requirements
 
-* Intellij IDEA 2022.2 or more recent (we **try** to support the last 4 major IDEA releases)
+* Intellij IDEA 2022.3 or more recent (we **try** to support the last 4 major IDEA releases)
 * Java JDK (or JRE) 17 or more recent
 
 ## Contributing

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/AbstractLSPInlayHintsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/AbstractLSPInlayHintsProvider.java
@@ -12,10 +12,7 @@ package com.redhat.devtools.lsp4ij.operations;
 
 import com.intellij.codeInsight.hints.*;
 import com.intellij.codeInsight.hints.presentation.PresentationFactory;
-import com.intellij.ide.DataManager;
 import com.intellij.lang.Language;
-import com.intellij.openapi.actionSystem.*;
-import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
@@ -37,10 +34,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.concurrent.CancellationException;
 
-public abstract class AbstractLSPInlayProvider implements InlayHintsProvider<NoSettings> {
+public abstract class AbstractLSPInlayHintsProvider implements InlayHintsProvider<NoSettings> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLSPInlayProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLSPInlayHintsProvider.class);
 
     private static final InlayHintsCollector EMPTY_INLAY_HINTS_COLLECTOR = new InlayHintsCollector() {
 
@@ -53,7 +51,7 @@ public abstract class AbstractLSPInlayProvider implements InlayHintsProvider<NoS
 
     private final Key<CancellationSupport> cancellationSupportKey;
 
-    protected AbstractLSPInlayProvider(Key<CancellationSupport> cancellationSupportKey) {
+    protected AbstractLSPInlayHintsProvider(Key<CancellationSupport> cancellationSupportKey) {
         this.cancellationSupportKey = cancellationSupportKey;
     }
 
@@ -100,6 +98,8 @@ public abstract class AbstractLSPInlayProvider implements InlayHintsProvider<NoS
                 try {
                     doCollect(file, psiFile.getProject(), editor, getFactory(), inlayHintsSink, cancellationSupport);
                     cancellationSupport.checkCanceled();
+                } catch (CancellationException e) {
+                    // Do nothing
                 } catch (ProcessCanceledException e) {
                     // Cancel all LSP requests
                     cancellationSupport.cancel();

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/LSPInlayHintProvidersFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/LSPInlayHintProvidersFactory.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.operations;
+
+import com.intellij.codeInsight.hints.InlayHintsProviderFactory;
+import com.intellij.codeInsight.hints.ProviderInfo;
+import com.intellij.openapi.project.Project;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.operations.codelens.LSPCodelensProvider;
+import com.redhat.devtools.lsp4ij.operations.inlayhint.LSPInlayHintsProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * {@link InlayHintsProviderFactory inlay hint factory} implementation
+ * to register all languages mapped with a language server with {@link LSPInlayHintsProvider} and {@link LSPCodelensProvider}
+ * to avoid for the external plugin to declare in plugin.xml the 'codeInsight.inlayProvider'.
+ */
+public class LSPInlayHintProvidersFactory implements InlayHintsProviderFactory  {
+    @NotNull
+    @Override
+    public List<ProviderInfo<? extends Object>> getProvidersInfo(@NotNull Project project) {
+        return LanguageServersRegistry.getInstance().getInlayHintProviderInfos(project);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/codelens/LSPCodelensProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/codelens/LSPCodelensProvider.java
@@ -21,7 +21,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.redhat.devtools.lsp4ij.operations.AbstractLSPInlayProvider;
+import com.redhat.devtools.lsp4ij.operations.AbstractLSPInlayHintsProvider;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
@@ -46,12 +46,12 @@ import java.util.stream.Collectors;
 /**
  * LSP textDocument/codeLens support.
  */
-public class LSPCodelensInlayProvider extends AbstractLSPInlayProvider {
+public class LSPCodelensProvider extends AbstractLSPInlayHintsProvider {
 
-    private static final Key<CancellationSupport> CANCELLATION_SUPPORT_KEY = new Key<>(LSPCodelensInlayProvider.class.getName() + "-CancellationSupport");
+    private static final Key<CancellationSupport> CANCELLATION_SUPPORT_KEY = new Key<>(LSPCodelensProvider.class.getName() + "-CancellationSupport");
 
 
-    public LSPCodelensInlayProvider() {
+    public LSPCodelensProvider() {
         super(CANCELLATION_SUPPORT_KEY);
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/inlayhint/LSPInlayHintsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/inlayhint/LSPInlayHintsProvider.java
@@ -21,7 +21,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.redhat.devtools.lsp4ij.operations.AbstractLSPInlayProvider;
+import com.redhat.devtools.lsp4ij.operations.AbstractLSPInlayHintsProvider;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
@@ -44,11 +44,11 @@ import java.util.stream.Collectors;
 /**
  * LSP textDocument/inlayHint support.
  */
-public class LSPInlayHintInlayProvider extends AbstractLSPInlayProvider {
+public class LSPInlayHintsProvider extends AbstractLSPInlayHintsProvider {
 
-    private static final Key<CancellationSupport> CANCELLATION_SUPPORT_KEY = new Key<>(LSPInlayHintInlayProvider.class.getName() + "-CancellationSupport");
+    private static final Key<CancellationSupport> CANCELLATION_SUPPORT_KEY = new Key<>(LSPInlayHintsProvider.class.getName() + "-CancellationSupport");
 
-    public LSPInlayHintInlayProvider() {
+    public LSPInlayHintsProvider() {
         super(CANCELLATION_SUPPORT_KEY);
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -95,6 +95,11 @@
                 id="LSPHighlightUsagesHandlerFactory"
                 implementation="com.redhat.devtools.lsp4ij.operations.highlight.LSPHighlightUsagesHandlerFactory"/>
 
+        <!-- LSP textDocument/codeLens + textDocument/inlayHint requests support -->
+        <codeInsight.inlayProviderFactory
+                id="LSPInlayHintProvidersFactory"
+                implementation="com.redhat.devtools.lsp4ij.operations.LSPInlayHintProvidersFactory"/>
+
         <!-- LSP textDocument/hover request support -->
         <!-- language="any" doesn't work for hover.
             <lang.documentationProvider
@@ -102,19 +107,6 @@
                 language="any"
                 implementationClass="com.redhat.devtools.lsp4ij.operations.documentation.LSPDocumentationProvider"
                 order="first"/>-->
-
-        <!-- LSP textDocument/codeLens request support -->
-        <!-- language="any" doesn't work for inlay hint.
-            <codeInsight.inlayProvider
-                id="LSPCodelensInlayProvider"
-                language="any"
-                implementationClass="com.redhat.devtools.lsp4ij.operations.codelens.LSPCodelensInlayProvider"/>-->
-
-        <!-- LSP textDocument/inlayHint request support -->
-        <!-- language="any" doesn't work for inlay hint.
-                id="LSPInlayHintInlayProvider"
-                language="any"
-                implementationClass="com.redhat.devtools.lsp4ij.operations.inlayhint.LSPInlayHintInlayProvider"/>-->
 
         <notificationGroup
                 id="Language Server Protocol"


### PR DESCRIPTION
feat: Use inlayhint factory to avoid declaring LSP codelens/inlayhint support in an external plugin

This PR also fixes https://github.com/redhat-developer/lsp4ij/issues/10