### PR TITLE
fix: properly render markdown tables

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ group = prop("pluginGroup")
 version = prop("pluginVersion")
 
 val lsp4jVersion = prop("lsp4jVersion")
+val flexmarkVersion = prop("flexmarkVersion")
 
 // Configure project's dependencies
 repositories {
@@ -54,8 +55,10 @@ dependencies {
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:$lsp4jVersion")
     // Required by lsp4j as the version from IJ is incompatible
     implementation("com.google.code.gson:gson:2.10.1")
-    implementation("com.vladsch.flexmark:flexmark:0.64.8")
-
+    implementation("com.vladsch.flexmark:flexmark:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-tables:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-autolink:$flexmarkVersion")
+    implementation("com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:$flexmarkVersion")
     testImplementation("com.redhat.devtools.intellij:intellij-common-ui-test-library:0.2.0")
     testImplementation("org.assertj:assertj-core:3.19.0")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ platformPlugins=com.intellij.java, com.redhat.devtools.intellij.telemetry:1.0.0.
 gradleVersion=8.4
 channel=nightly
 lsp4jVersion=0.21.1
+flexmarkVersion=0.64.8
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/documentation/MarkdownConverter.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/documentation/MarkdownConverter.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.operations.documentation;
+
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+/**
+ * Converts Markdown to HTML
+ */
+public class MarkdownConverter {
+
+    private static final Parser htmlParser;
+    private static final HtmlRenderer htmlRenderer;
+
+    private MarkdownConverter() {}
+
+    static {
+        //Adding flexmark extensions requires adding them to build.gradle.kts. Make sure classes are not picked up from the IJ platform!
+        MutableDataSet options = new MutableDataSet().set(Parser.EXTENSIONS, Arrays.asList(
+                        AutolinkExtension.create(), //See flexmark-ext-autolink
+                        StrikethroughExtension.create(), //See flexmark-ext-gfm-strikethrough
+                        TablesExtension.create() //See flexmark-ext-tables
+                ))
+                // set GitHub table parsing options
+                .set(TablesExtension.WITH_CAPTION, false)
+                .set(TablesExtension.COLUMN_SPANS, false)
+                .set(TablesExtension.MIN_HEADER_ROWS, 1)
+                .set(TablesExtension.MAX_HEADER_ROWS, 1)
+                .set(TablesExtension.APPEND_MISSING_COLUMNS, true)
+                .set(TablesExtension.DISCARD_EXTRA_COLUMNS, true)
+                .set(TablesExtension.HEADER_SEPARATOR_COLUMN_MATCH, true)
+                ;
+
+        options.set(HtmlRenderer.SOFT_BREAK, "<br />\n");
+        options.set(HtmlRenderer.GENERATE_HEADER_ID, true);
+        htmlRenderer = HtmlRenderer.builder(options).build();
+        htmlParser = Parser.builder(options).build();
+    }
+
+    public static @NotNull String toHTML(@NotNull String markdown) {
+        return htmlRenderer.render(htmlParser.parse(markdown));
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/operations/documentation/MarkdownConverterTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/operations/documentation/MarkdownConverterTest.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.operations.documentation;
+
+import org.junit.Test;
+
+import static com.redhat.devtools.lsp4ij.operations.documentation.MarkdownConverter.toHTML;
+import static org.junit.Assert.*;
+
+/**
+ * Test Markdown conversion to HTML
+ */
+public class MarkdownConverterTest {
+
+    @Test
+    public void tablesConversion() {
+        String markdown = """
+                Does something, `somewhere`:
+                
+                |                    |                    |
+                |--------------------|--------------------|
+                | Row One - Cell One | Row One - Cell Two |
+                | Row Two - Cell One | Row Two - Cell Two |
+                """;
+
+        String html = """
+                <p>Does something, <code>somewhere</code>:</p>
+                <table>
+                <thead>
+                <tr><th> </th><th> </th></tr>
+                </thead>
+                <tbody>
+                <tr><td>Row One - Cell One</td><td>Row One - Cell Two</td></tr>
+                <tr><td>Row Two - Cell One</td><td>Row Two - Cell Two</td></tr>
+                </tbody>
+                </table>
+                """;
+        assertEquals(html, toHTML(markdown));
+    }
+
+    @Test
+    public void linksConversion() {
+        String markdown = "Here is a link [example](https://example.com)";
+        String html = "<p>Here is a link <a href=\"https://example.com\">example</a></p>\n";
+        assertEquals(html, toHTML(markdown));
+    }
+
+    @Test
+    public void codeBlockConversion() {
+        String markdown = """
+                Here's some java code:
+                
+                ```java
+                    @Test
+                    public void linksConversion() {
+                        String markdown = "Here is a link [example](https://example.com)";
+                        String html = "<p>Here is a link <a href=\\"https://example.com\\">example</a></p>\\n";
+                        assertEquals(html, convert(markdown));
+                    }
+                ```
+                """;
+        String html = """
+                <p>Here's some java code:</p>
+                <pre><code class="language-java">    @Test
+                    public void linksConversion() {
+                        String markdown = &quot;Here is a link [example](https://example.com)&quot;;
+                        String html = &quot;&lt;p&gt;Here is a link &lt;a href=\\&quot;https://example.com\\&quot;&gt;example&lt;/a&gt;&lt;/p&gt;\\n&quot;;
+                        assertEquals(html, convert(markdown));
+                    }
+                </code></pre>
+                """;
+        assertEquals(html, toHTML(markdown));
+
+        markdown = """
+                Here's some XML code:
+                
+                ```xml
+                <?xml version="1.0" encoding="UTF-8"?>
+                <note>
+                  <to>Angelo</to>
+                  <from>Fred</from>
+                  <heading>Tests</heading>
+                  <body>I wrote them!</body>
+                </note>
+                ```
+                """;
+        html = """
+                <p>Here's some XML code:</p>
+                <pre><code class="language-xml">&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+                &lt;note&gt;
+                  &lt;to&gt;Angelo&lt;/to&gt;
+                  &lt;from&gt;Fred&lt;/from&gt;
+                  &lt;heading&gt;Tests&lt;/heading&gt;
+                  &lt;body&gt;I wrote them!&lt;/body&gt;
+                &lt;/note&gt;
+                </code></pre>
+                """;
+        assertEquals(html, toHTML(markdown));
+    }
+
+    @Test
+    public void listsConversion() {
+        String markdown = """
+                 *  Coffee
+                 *  Tea
+                 *  Milk 
+                """;
+        String html = """
+                <ul>
+                <li>Coffee</li>
+                <li>Tea</li>
+                <li>Milk</li>
+                </ul>
+                """;
+        assertEquals(html, toHTML(markdown));
+    }
+    
+    @Test
+    public void miscellaneousConversions() {
+        assertEquals("<p>This <em>is</em> <code>my code</code></p>\n", toHTML("This _is_ `my code`"));
+        assertEquals("<p>The <code>&lt;project&gt;</code> element is the root of the descriptor.</p>\n", toHTML("The `<project>` element is the root of the descriptor."));
+        assertEquals("<h1>Hey Man</h1>\n", toHTML("# Hey Man #"));
+        assertEquals("<p>ONLY_THIS_TEXT</p>\n", toHTML("ONLY_THIS_TEXT"));
+        assertEquals("<p>This is<br />\n<strong>bold</strong></p>\n", toHTML("""
+                                                                                      This is
+                                                                                      **bold**
+                                                                                      """));
+    }
+
+    @Test
+    public void multiLineConversion() {
+        String markdown = """
+                multi
+                line
+                `HTML`
+                stuff
+                """;
+
+        String html = """
+                <p>multi<br />
+                line<br />
+                <code>HTML</code><br />
+                stuff</p>
+                """;
+        assertEquals(html, toHTML(markdown));
+
+        markdown = """
+                multi
+                
+                line `HTML` stuff
+                """;
+
+        html = """
+                <p>multi</p>
+                <p>line <code>HTML</code> stuff</p>
+                """;
+        assertEquals(html, toHTML(markdown));
+    }
+}


### PR DESCRIPTION
Before:
<img width="377" alt="Screenshot 2023-12-19 at 12 07 11" src="https://github.com/redhat-developer/lsp4ij/assets/148698/be8101ae-eb8b-4078-b12a-2caaeac95eca">

After:
<img width="399" alt="Screenshot 2023-12-19 at 15 14 04" src="https://github.com/redhat-developer/lsp4ij/assets/148698/d5162bff-53f2-460e-989d-19a90ef37440">

Also fixes #58 

Signed-off-by: Fred Bricon <fbricon@gmail.com>
