### PR TITLE
fix: NPE when codeaction is a command

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/codeactions/LSPLazyCodeActionIntentionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/codeactions/LSPLazyCodeActionIntentionAction.java
@@ -151,9 +151,9 @@ public class LSPLazyCodeActionIntentionAction implements IntentionAction {
                 codeAction = action.getRight();
                 title = action.getRight().getTitle();
                 familyName = StringUtils.isNotBlank(codeAction.getKind()) ? codeAction.getKind() : "LSP QuickFix";
-            } else {
+            } else if (action.isLeft()) {
                 command = action.getLeft();
-                title = action.getRight().getTitle();
+                title = command.getTitle();
                 familyName = "LSP Command";
             }
         }


### PR DESCRIPTION
When  codecation returns a command (left part), there is an NPE. I discover this use case with CSS whit:

```
a {
   colo: red;
}
```

The CSS LS provides a command which fixes colo into a known property.