### PR TITLE
refactor: move classes to definition package.

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -197,6 +197,20 @@ Here is sample snippet to associate the `XML` language with the `myLanguageServe
   </extensions>
 ```
 
+Some language servers uses the language field to know the language, you can declare it with the `languageId` attribute:
+
+```xml
+</idea-plugin>
+
+  <extensions defaultExtensionNs="com.redhat.devtools.lsp4ij">
+
+    <languageMapping language="XML"
+                     serverId="myLanguageServerId"
+                     languageId="xml" />
+
+  </extensions>
+```
+
 If the language check is not enough, you can implement a custom [DocumentMatcher](https://github.com/redhat-developer/lsp4ij/blob/main/src/main/java/com/redhat/devtools/lsp4ij/DocumentMatcher.java).
 For instance your language server could be mapped to the `Java` language, and you could implement a DocumentMatcher 
 to check if the module containing the file contains certain Java classes in its classpath.

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -30,6 +30,7 @@ import com.redhat.devtools.lsp4ij.internal.SupportedFeatures;
 import com.redhat.devtools.lsp4ij.lifecycle.LanguageServerLifecycleManager;
 import com.redhat.devtools.lsp4ij.lifecycle.NullLanguageServerLifecycleManager;
 import com.redhat.devtools.lsp4ij.server.*;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
@@ -163,7 +164,7 @@ public class LanguageServerWrapper implements Disposable {
     private MessageBusConnection messageBusConnection;
 
     @NotNull
-    public final LanguageServersRegistry.LanguageServerDefinition serverDefinition;
+    public final LanguageServerDefinition serverDefinition;
     @Nullable
     protected final Project initialProject;
     @NotNull
@@ -205,18 +206,18 @@ public class LanguageServerWrapper implements Disposable {
     private boolean initiallySupportsWorkspaceFolders = false;
 
     /* Backwards compatible constructor */
-    public LanguageServerWrapper(@NotNull Project project, @NotNull LanguageServersRegistry.LanguageServerDefinition serverDefinition) {
+    public LanguageServerWrapper(@NotNull Project project, @NotNull LanguageServerDefinition serverDefinition) {
         this(project, serverDefinition, null);
     }
 
-    public LanguageServerWrapper(@NotNull LanguageServersRegistry.LanguageServerDefinition serverDefinition, @Nullable URI initialPath) {
+    public LanguageServerWrapper(@NotNull LanguageServerDefinition serverDefinition, @Nullable URI initialPath) {
         this(null, serverDefinition, initialPath);
     }
 
     /**
      * Unified private constructor to set sensible defaults in all cases
      */
-    private LanguageServerWrapper(@Nullable Project project, @NotNull LanguageServersRegistry.LanguageServerDefinition serverDefinition,
+    private LanguageServerWrapper(@Nullable Project project, @NotNull LanguageServerDefinition serverDefinition,
                                   @Nullable URI initialPath) {
         this.initialProject = project;
         this.initialPath = initialPath;

--- a/src/main/java/com/redhat/devtools/lsp4ij/commands/CommandExecutor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/commands/CommandExecutor.java
@@ -25,6 +25,7 @@ import com.redhat.devtools.lsp4ij.JSONUtils;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.ExecuteCommandParams;
@@ -109,7 +110,7 @@ public class CommandExecutor {
         if (languageServerId == null) {
             return false;
         }
-        LanguageServersRegistry.LanguageServerDefinition languageServerDefinition = LanguageServersRegistry.getInstance()
+        LanguageServerDefinition languageServerDefinition = LanguageServersRegistry.getInstance()
                 .getServerDefinition(languageServerId);
         if (languageServerDefinition == null) {
             return false;
@@ -139,7 +140,7 @@ public class CommandExecutor {
 
     private static CompletableFuture<LanguageServer> getLanguageServerForCommand(Project project,
                                                                                  Command command,
-                                                                                 URI documentUri, LanguageServersRegistry.LanguageServerDefinition languageServerDefinition) throws IOException {
+                                                                                 URI documentUri, LanguageServerDefinition languageServerDefinition) throws IOException {
         VirtualFile file = LSPIJUtils.findResourceFor(documentUri);
         if (file == null) {
             return null;

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
@@ -31,10 +31,10 @@ import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UI;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
-import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.console.explorer.LanguageServerExplorer;
 import com.redhat.devtools.lsp4ij.console.explorer.LanguageServerProcessTreeNode;
 import com.redhat.devtools.lsp4ij.console.explorer.LanguageServerTreeNode;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings;
 import org.jetbrains.annotations.NotNull;
@@ -174,7 +174,7 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
         }
 
         private JComponent createDetailPanel(LanguageServerTreeNode key) {
-            LanguageServersRegistry.LanguageServerDefinition serverDefinition = key.getServerDefinition();
+            LanguageServerDefinition serverDefinition = key.getServerDefinition();
             Project project = LSPConsoleToolWindowPanel.this.project;
             ComboBox<ServerTrace> serverTraceComboBox = new ComboBox<>(new DefaultComboBoxModel<>(ServerTrace.values()));
             UserDefinedLanguageServerSettings.LanguageServerDefinitionSettings initialSettings = UserDefinedLanguageServerSettings.getInstance(project).getLanguageServerSettings(serverDefinition.id);
@@ -225,7 +225,7 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
             };
         }
 
-        private JComponent createTitleComponent(LanguageServersRegistry.LanguageServerDefinition languageServerDefinition) {
+        private JComponent createTitleComponent(LanguageServerDefinition languageServerDefinition) {
             JLabel title = new JLabel(languageServerDefinition.getDisplayName());
             String description = languageServerDefinition.description;
             if (description != null && description.length() > 0) {
@@ -273,7 +273,7 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
         }
     }
 
-    private ConsoleView createConsoleView(@NotNull LanguageServersRegistry.LanguageServerDefinition serverDefinition, @NotNull Project project) {
+    private ConsoleView createConsoleView(@NotNull LanguageServerDefinition serverDefinition, @NotNull Project project) {
         var builder = new LSPTextConsoleBuilderImpl(serverDefinition, project);
         builder.setViewer(true);
         return builder.getConsole();

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleView.java
@@ -20,9 +20,9 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.editor.actions.ScrollToTheEndToolbarAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.search.GlobalSearchScope;
-import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.console.actions.AutoFoldingAction;
 import com.redhat.devtools.lsp4ij.console.actions.ClearThisConsoleAction;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings;
 import org.jetbrains.annotations.NotNull;
@@ -35,9 +35,9 @@ import java.util.List;
  */
 public class LSPConsoleView extends ConsoleViewImpl {
 
-    private final LanguageServersRegistry.LanguageServerDefinition serverDefinition;
+    private final LanguageServerDefinition serverDefinition;
 
-    public LSPConsoleView(@NotNull LanguageServersRegistry.LanguageServerDefinition serverDefinition, @NotNull Project project,
+    public LSPConsoleView(@NotNull LanguageServerDefinition serverDefinition, @NotNull Project project,
                           @NotNull GlobalSearchScope searchScope,
                           boolean viewer,
                           boolean usePredefinedMessageFilter) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/LSPTextConsoleBuilderImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/LSPTextConsoleBuilderImpl.java
@@ -16,7 +16,7 @@ package com.redhat.devtools.lsp4ij.console;
 import com.intellij.execution.filters.TextConsoleBuilderImpl;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
-import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -24,9 +24,9 @@ import org.jetbrains.annotations.NotNull;
  */
 public class LSPTextConsoleBuilderImpl extends TextConsoleBuilderImpl {
 
-    private final LanguageServersRegistry.LanguageServerDefinition serverDefinition;
+    private final LanguageServerDefinition serverDefinition;
 
-    public LSPTextConsoleBuilderImpl(@NotNull LanguageServersRegistry.LanguageServerDefinition serverDefinition, @NotNull Project project) {
+    public LSPTextConsoleBuilderImpl(@NotNull LanguageServerDefinition serverDefinition, @NotNull Project project) {
         super(project);
         this.serverDefinition = serverDefinition;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorer.java
@@ -28,6 +28,7 @@ import com.redhat.devtools.lsp4ij.console.explorer.actions.RestartServerAction;
 import com.redhat.devtools.lsp4ij.console.explorer.actions.PauseServerAction;
 import com.redhat.devtools.lsp4ij.console.explorer.actions.StopServerAction;
 import com.redhat.devtools.lsp4ij.lifecycle.LanguageServerLifecycleManager;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -102,7 +103,7 @@ public class LanguageServerExplorer extends SimpleToolWindowPanel implements Dis
 
         // Fill tree will all language server definitions, ordered alphabetically
         LanguageServersRegistry.getInstance().getServerDefinitions().stream()
-                .sorted(Comparator.comparing(LanguageServersRegistry.LanguageServerDefinition::getDisplayName))
+                .sorted(Comparator.comparing(LanguageServerDefinition::getDisplayName))
                 .map(LanguageServerTreeNode::new)
                 .forEach(top::add);
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerTreeNode.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerTreeNode.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package com.redhat.devtools.lsp4ij.console.explorer;
 
-import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -23,13 +23,13 @@ import javax.swing.tree.DefaultMutableTreeNode;
  */
 public class LanguageServerTreeNode extends DefaultMutableTreeNode {
 
-    private final LanguageServersRegistry.LanguageServerDefinition serverDefinition;
+    private final LanguageServerDefinition serverDefinition;
 
-    public LanguageServerTreeNode(LanguageServersRegistry.LanguageServerDefinition serverDefinition) {
+    public LanguageServerTreeNode(LanguageServerDefinition serverDefinition) {
         this.serverDefinition = serverDefinition;
     }
 
-    public LanguageServersRegistry.LanguageServerDefinition getServerDefinition() {
+    public LanguageServerDefinition getServerDefinition() {
         return serverDefinition;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ContentTypeToLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ContentTypeToLanguageServerDefinition.java
@@ -8,22 +8,24 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package com.redhat.devtools.lsp4ij;
+package com.redhat.devtools.lsp4ij.server.definition;
 
 import com.intellij.lang.Language;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.lsp4ij.DocumentMatcher;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.AbstractMap;
 import java.util.concurrent.CompletableFuture;
 
-public class ContentTypeToLanguageServerDefinition extends AbstractMap.SimpleEntry<Language, LanguageServersRegistry.LanguageServerDefinition> {
+public class ContentTypeToLanguageServerDefinition extends AbstractMap.SimpleEntry<Language, LanguageServerDefinition> {
 
     private final DocumentMatcher documentMatcher;
 
     public ContentTypeToLanguageServerDefinition(@NotNull Language language,
-                                                 @NotNull LanguageServersRegistry.LanguageServerDefinition provider,
+                                                 @NotNull LanguageServerDefinition provider,
                                                  @NotNull DocumentMatcher documentMatcher) {
         super(language, provider);
         this.documentMatcher = documentMatcher;

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.server.definition;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.lightEdit.LightEdit;
+import com.intellij.lang.Language;
+import com.intellij.openapi.project.Project;
+import com.redhat.devtools.lsp4ij.LanguageServerFactory;
+import com.redhat.devtools.lsp4ij.client.LanguageClientImpl;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Base class for Language server definition.
+ */
+public abstract class LanguageServerDefinition implements LanguageServerFactory {
+
+    private static final int DEFAULT_LAST_DOCUMENTED_DISCONNECTED_TIMEOUT = 5;
+
+    public final @NotNull
+    String id;
+    public final @NotNull
+    String label;
+    public final boolean isSingleton;
+    public final @NotNull
+    Map<Language, String> languageIdMappings;
+    public final String description;
+    public final int lastDocumentDisconnectedTimeout;
+    private boolean enabled;
+
+    public final boolean supportsLightEdit;
+
+    public LanguageServerDefinition(@NotNull String id, @NotNull String label, String description, boolean isSingleton, Integer lastDocumentDisconnectedTimeout, boolean supportsLightEdit) {
+        this.id = id;
+        this.label = label;
+        this.description = description;
+        this.isSingleton = isSingleton;
+        this.lastDocumentDisconnectedTimeout = lastDocumentDisconnectedTimeout != null && lastDocumentDisconnectedTimeout > 0 ? lastDocumentDisconnectedTimeout : DEFAULT_LAST_DOCUMENTED_DISCONNECTED_TIMEOUT;
+        this.languageIdMappings = new ConcurrentHashMap<>();
+        this.supportsLightEdit = supportsLightEdit;
+        setEnabled(true);
+    }
+
+
+    /**
+     * Returns true if the language server definition is enabled and false otherwise.
+     *
+     * @return true if the language server definition is enabled and false otherwise.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Set enabled the language server definition.
+     *
+     * @param enabled enabled the language server definition.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void registerAssociation(@NotNull Language language, @NotNull String serverId) {
+        this.languageIdMappings.put(language, serverId);
+    }
+
+    @NotNull
+    public String getDisplayName() {
+        return label != null ? label : id;
+    }
+
+    @Override
+    public @NotNull LanguageClientImpl createLanguageClient(@NotNull Project project) {
+        return new LanguageClientImpl(project);
+    }
+
+    @Override
+    public @NotNull Class<? extends LanguageServer> getServerInterface() {
+        return LanguageServer.class;
+    }
+
+    public <S extends LanguageServer> Launcher.Builder<S> createLauncherBuilder() {
+        return new Launcher.Builder<>();
+    }
+
+    public boolean supportsCurrentEditMode(@NotNull Project project) {
+        return project != null && (supportsLightEdit || !LightEdit.owns(project));
+    }
+
+    public Icon getIcon() {
+        return AllIcons.Webreferences.Server;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ServerLanguageMapping.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ServerLanguageMapping.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.server.definition;
+
+import com.intellij.lang.Language;
+import com.redhat.devtools.lsp4ij.DocumentMatcher;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Language mapping between a language server ID and an IntelliJ language.
+ */
+public class ServerLanguageMapping extends ServerMapping {
+
+    @NotNull
+    private final Language language;
+
+    public ServerLanguageMapping(@NotNull Language language, @NotNull String serverId, @NotNull String languageId, @NotNull DocumentMatcher documentMatcher) {
+        super(serverId, languageId, documentMatcher);
+        this.language = language;
+    }
+
+    @NotNull
+    public Language getLanguage() {
+        return language;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ServerMapping.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ServerMapping.java
@@ -1,0 +1,39 @@
+package com.redhat.devtools.lsp4ij.server.definition;
+
+import com.redhat.devtools.lsp4ij.DocumentMatcher;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * internal class to capture content-type mappings for language servers
+ */
+public class ServerMapping {
+
+    @NotNull
+    private final String serverId;
+    @NotNull
+    private final String languageId;
+    @NotNull
+    private final DocumentMatcher documentMatcher;
+
+    public ServerMapping(@NotNull String serverId, @NotNull String languageId, @NotNull DocumentMatcher documentMatcher) {
+        this.serverId = serverId;
+        this.languageId = languageId;
+        this.documentMatcher = documentMatcher;
+    }
+
+    @NotNull
+    public String getServerId() {
+        return serverId;
+    }
+
+    @NotNull
+    public String getLanguageId() {
+        return languageId;
+    }
+
+    @NotNull
+    public DocumentMatcher getDocumentMatcher() {
+        return documentMatcher;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/ExtensionLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/ExtensionLanguageServerDefinition.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.server.definition.extension;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.IconLoader;
+import com.redhat.devtools.lsp4ij.LanguageServerFactory;
+import com.redhat.devtools.lsp4ij.client.LanguageClientImpl;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
+import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+
+/**
+ * Language server definition coming from the {@link ServerExtensionPointBean server extension point}.
+ */
+public class ExtensionLanguageServerDefinition extends LanguageServerDefinition {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExtensionLanguageServerDefinition.class);
+
+    private final ServerExtensionPointBean extension;
+
+    private Icon icon;
+
+    public ExtensionLanguageServerDefinition(ServerExtensionPointBean element) {
+        super(element.id, element.getLabel(), element.getDescription(), element.singleton, element.lastDocumentDisconnectedTimeout, element.supportsLightEdit);
+        this.extension = element;
+    }
+
+    @Override
+    public @NotNull StreamConnectionProvider createConnectionProvider(@NotNull Project project) {
+        try {
+            return getFactory().createConnectionProvider(project);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Exception occurred while creating an instance of the stream connection provider", e); //$NON-NLS-1$
+        }
+    }
+
+    @Override
+    public @NotNull LanguageClientImpl createLanguageClient(@NotNull Project project) {
+        LanguageClientImpl languageClient = null;
+        try {
+            languageClient = getFactory().createLanguageClient(project);
+        } catch (Exception e) {
+            LOGGER.warn("Exception occurred while creating an instance of the language client", e); //$NON-NLS-1$
+        }
+        if (languageClient == null) {
+            languageClient = super.createLanguageClient(project);
+        }
+        return languageClient;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Class<? extends LanguageServer> getServerInterface() {
+        Class<? extends LanguageServer> serverInterface = null;
+        try {
+            serverInterface = getFactory().getServerInterface();
+        } catch (Exception e) {
+            LOGGER.warn("Exception occurred while getting server interface", e); //$NON-NLS-1$
+        }
+        if (serverInterface == null) {
+            serverInterface = super.getServerInterface();
+        }
+        return serverInterface;
+    }
+
+    private @NotNull LanguageServerFactory getFactory() {
+        String serverFactory = extension.getImplementationClassName();
+        if (serverFactory == null || serverFactory.isEmpty()) {
+            throw new RuntimeException(
+                    "Exception occurred while creating an instance of server factory, you have to define server/@factory attribute in the extension point."); //$NON-NLS-1$
+        }
+        return extension.getInstance();
+    }
+
+    @Override
+    public Icon getIcon() {
+        if (icon == null) {
+            icon = findIcon();
+        }
+        return icon;
+    }
+
+    private synchronized Icon findIcon() {
+        if (icon != null) {
+            return icon;
+        }
+        if (!StringUtils.isEmpty(extension.icon)) {
+            try {
+                return IconLoader.findIcon(extension.icon, extension.getPluginDescriptor().getPluginClassLoader());
+            } catch (Exception e) {
+                LOGGER.error("Error while loading custom server icon for server id='" + extension.id + "'.", e);
+            }
+        }
+        return super.getIcon();
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/LanguageMappingExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/LanguageMappingExtensionPointBean.java
@@ -11,17 +11,29 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.lsp4ij;
+package com.redhat.devtools.lsp4ij.server.definition.extension;
 
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.extensions.RequiredElement;
 import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
+import com.redhat.devtools.lsp4ij.DocumentMatcher;
+import org.eclipse.lsp4j.TextDocumentItem;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Language mapping extension point.
+ *
+ * <pre>
+ *   <extensions defaultExtensionNs="com.redhat.devtools.lsp4ij">
+ *
+ *     <languageMapping language="XML"
+ *                      serverId="myLanguageServerId"
+ *                      languageId="xml" />
+ *
+ *   </extensions>
+ * </pre>
  */
 public class LanguageMappingExtensionPointBean extends BaseKeyedLazyInstance<DocumentMatcher> {
 
@@ -30,18 +42,25 @@ public class LanguageMappingExtensionPointBean extends BaseKeyedLazyInstance<Doc
     public static final ExtensionPointName<LanguageMappingExtensionPointBean> EP_NAME = ExtensionPointName.create("com.redhat.devtools.lsp4ij.languageMapping");
 
     /**
-     * The language mapped with the language server {{@link #serverId}server id}.
-     */
-    @Attribute("language")
-    @RequiredElement
-    public String languageId;
-
-    /**
-     * The language server mapped with the language {{@link #languageId}language id}.
+     * The language server mapped with the language {@link #language IntelliJ language}.
      */
     @Attribute("serverId")
     @RequiredElement
     public String serverId;
+
+    /**
+     * The IntelliJ language mapped with the language server {@link #serverId server id}.
+     */
+    @Attribute("language")
+    @RequiredElement
+    public String language;
+
+    /**
+     * The LSP language ID which must be used in the LSP {@link TextDocumentItem#getLanguageId()}. If it is not defined
+     * the languageId used will be the IntelliJ {#link language}.
+     */
+    @Attribute("languageId")
+    public String languageId;
 
     /**
      * The {@link DocumentMatcher document matcher}.

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/ServerExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/ServerExtensionPointBean.java
@@ -11,18 +11,17 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.lsp4ij;
+package com.redhat.devtools.lsp4ij.server.definition.extension;
 
 import com.intellij.AbstractBundle;
-import com.intellij.BundleBase;
 import com.intellij.DynamicBundle;
 import com.intellij.openapi.extensions.ExtensionPointName;
 import com.intellij.openapi.extensions.PluginDescriptor;
 import com.intellij.openapi.extensions.RequiredElement;
-import com.intellij.openapi.util.NlsContexts;
 import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
 import com.intellij.util.xmlb.annotations.Tag;
+import com.redhat.devtools.lsp4ij.LanguageServerFactory;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,7 +31,20 @@ import org.slf4j.LoggerFactory;
 import java.util.ResourceBundle;
 
 /**
- * Server extension point.
+ * Server extension point bean.
+ *
+ * <pre>
+ *   <extensions defaultExtensionNs="com.redhat.devtools.lsp4ij">
+ *     <server id="myLanguageServerId"
+ *         label="My Language Server"
+ *         factoryClass="my.language.server.MyLanguageServerFactory">
+ *     <description><![CDATA[
+ *      Some description written in HTML to display it in LSP consoles and Language Servers settings.
+ *      ]]>
+ *     </description>
+ *   </server>
+ * </extensions>
+ * </pre>
  */
 public class ServerExtensionPointBean extends BaseKeyedLazyInstance<LanguageServerFactory> {
 
@@ -42,7 +54,7 @@ public class ServerExtensionPointBean extends BaseKeyedLazyInstance<LanguageServ
 
     /**
      * The language server id used to associate language
-     * with 'com.redhat.devtools.lsp4ij.languageMapping' extension point.
+     * with {@link LanguageMappingExtensionPointBean language mapping} extension point.
      */
     @Attribute("id")
     @RequiredElement

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerConfigurable.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerConfigurable.java
@@ -18,7 +18,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.NamedConfigurable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.NlsContexts;
-import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
@@ -31,14 +31,14 @@ import javax.swing.*;
  *     <li>Suspend and wait for a debugger</li>
  * </ul>
  */
-public class LanguageServerConfigurable extends NamedConfigurable<LanguageServersRegistry.LanguageServerDefinition> {
+public class LanguageServerConfigurable extends NamedConfigurable<LanguageServerDefinition> {
 
-    private final LanguageServersRegistry.LanguageServerDefinition languageServerDefinition;
+    private final LanguageServerDefinition languageServerDefinition;
     private final Project project;
 
     private LanguageServerView myView;
 
-    public LanguageServerConfigurable(LanguageServersRegistry.LanguageServerDefinition languageServerDefinition, Runnable updater, Project project) {
+    public LanguageServerConfigurable(LanguageServerDefinition languageServerDefinition, Runnable updater, Project project) {
         super(false, updater);
         this.languageServerDefinition = languageServerDefinition;
         this.project = project;
@@ -50,7 +50,7 @@ public class LanguageServerConfigurable extends NamedConfigurable<LanguageServer
     }
 
     @Override
-    public LanguageServersRegistry.LanguageServerDefinition getEditableObject() {
+    public LanguageServerDefinition getEditableObject() {
         return languageServerDefinition;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerListConfigurable.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerListConfigurable.java
@@ -21,6 +21,7 @@ import com.intellij.ui.TreeUIHelper;
 import com.intellij.ui.speedSearch.SpeedSearchSupply;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,7 +44,7 @@ public class LanguageServerListConfigurable extends MasterDetailsComponent imple
     private static final String ID = "LanguageServers";
 
     private final Project project;
-    private final Collection<LanguageServersRegistry.LanguageServerDefinition> languageServeDefinitions;
+    private final Collection<LanguageServerDefinition> languageServeDefinitions;
 
     private boolean isTreeInitialized;
 
@@ -85,14 +86,14 @@ public class LanguageServerListConfigurable extends MasterDetailsComponent imple
                 .installTreeSpeedSearch(myTree, treePath -> ((MyNode) treePath.getLastPathComponent()).getDisplayName(), true);
     }
 
-    private void addLanguageServerDefinitionNode(LanguageServersRegistry.LanguageServerDefinition languageServerDefinition) {
+    private void addLanguageServerDefinitionNode(LanguageServerDefinition languageServerDefinition) {
         MyNode node = new MyNode(new LanguageServerConfigurable(languageServerDefinition, TREE_UPDATER, project));
         addNode(node, myRoot);
     }
 
     private void reloadTree() {
         myRoot.removeAllChildren();
-        for (LanguageServersRegistry.LanguageServerDefinition languageServeDefinition : languageServeDefinitions) {
+        for (LanguageServerDefinition languageServeDefinition : languageServeDefinitions) {
             addLanguageServerDefinitionNode(languageServeDefinition);
         }
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
@@ -22,7 +22,7 @@ import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UI;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
-import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
@@ -42,7 +42,7 @@ public class LanguageServerView implements Disposable {
     private final JBCheckBox debugSuspendCheckBox = new JBCheckBox(LanguageServerBundle.message("language.server.debug.suspend"));
     private final ComboBox<ServerTrace> serverTraceComboBox = new ComboBox<>(new DefaultComboBoxModel<>(ServerTrace.values()));
 
-    public LanguageServerView(LanguageServersRegistry.LanguageServerDefinition languageServerDefinition) {
+    public LanguageServerView(LanguageServerDefinition languageServerDefinition) {
         JComponent descriptionPanel = createDescription(languageServerDefinition.description.trim());
         JPanel settingsPanel = createSettings(descriptionPanel);
         TitledBorder title = IdeBorderFactory.createTitledBorder(languageServerDefinition.getDisplayName());

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,12 +59,12 @@
     <extensionPoints>
         <extensionPoint
                 name="server"
-                beanClass="com.redhat.devtools.lsp4ij.ServerExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.ServerExtensionPointBean">
             <with attribute="factoryClass" implements="com.redhat.devtools.lsp4ij.LanguageServerFactory"/>
         </extensionPoint>
         <extensionPoint
                 name="languageMapping"
-                beanClass="com.redhat.devtools.lsp4ij.LanguageMappingExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.LanguageMappingExtensionPointBean">
             <with attribute="documentMatcher" implements="com.redhat.devtools.lsp4ij.DocumentMatcher"/>
         </extensionPoint>
     </extensionPoints>


### PR DESCRIPTION
As LanguageServerRegistry is very hard to read because it is a big class, this PR move inner class server definion, mapping, etc from LanguageServerRegistry to a proper package server.definition.

It provides too a new attribute languageId to use it when TextDocument is opened.

