### PR TITLE
fix: Change default highlight severity from Info to Error.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/diagnostics/SeverityMapping.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/diagnostics/SeverityMapping.java
@@ -38,7 +38,7 @@ public class SeverityMapping {
      */
     public static @NotNull HighlightSeverity toHighlightSeverity(@Nullable DiagnosticSeverity severity) {
         if (severity == null) {
-            return HighlightSeverity.INFORMATION;
+            return HighlightSeverity.ERROR;
         }
         switch (severity) {
             case Warning:


### PR DESCRIPTION
When the language server does not set the severity for a diagnostic we choose a default of Information. On IntelliJ this means no on-screen highlighting. It would be better to be like VS Code and use a red underline (Error) by default.