### PR TITLE
fix: display proper completion documentation

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/LSPCompletionProposal.java
@@ -396,7 +396,7 @@ public class LSPCompletionProposal extends LookupElement {
         }
         if (documentation.isLeft()) {
             String content = documentation.getLeft();
-            return new MarkupContent(content, MarkupKind.PLAINTEXT);
+            return new MarkupContent(MarkupKind.PLAINTEXT, content);
         }
         return documentation.getRight();
     }


### PR DESCRIPTION
Fixes #68 

<img width="637" alt="Screenshot 2024-01-09 at 17 49 08" src="https://github.com/redhat-developer/lsp4ij/assets/148698/c018d971-010b-400b-af1d-1a59aa45e6af">
