### PR TITLE
fix: sort completion items by sortText

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/CompletionItemComparator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/CompletionItemComparator.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.operations.completion;
+
+import java.util.Comparator;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Compares {@link CompletionItem}s by their sortText property (falls back to comparing labels)
+ */
+public class CompletionItemComparator implements Comparator<CompletionItem> {
+	@Override
+	public int compare(CompletionItem item1, CompletionItem item2) {
+		if (item1 == item2) {
+			return 0;
+		} else if (item1 == null) {
+			return -1;
+		} else if (item2 == null) {
+			return 1;
+		}
+
+		int comparison = compareNullable(item1.getSortText(), item2.getSortText());
+
+		// If sortText is equal, fall back to comparing labels
+		if (comparison == 0) {
+			comparison = item1.getLabel().compareTo(item2.getLabel());
+		}
+
+		return comparison;
+	}
+
+	private int compareNullable(@Nullable String s1, @Nullable String s2) {
+		if (s1 == s2) {
+			return 0;
+		} else if (s1 == null) {
+			return -1;
+		} else if (s2 == null) {
+			return 1;
+		}
+		return s1.compareTo(s2);
+	}
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/operations/completion/CompletionItemComparatorTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/operations/completion/CompletionItemComparatorTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.operations.completion;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CompletionItemComparatorTest {
+    private final CompletionItemComparator comparator = new CompletionItemComparator();
+
+    private final CompletionItem one = newItem("one", "1");
+    private final CompletionItem nil = newItem("", null);
+    private final CompletionItem two = newItem("two", "2");
+    private final CompletionItem three = newItem("three", "3");
+    private final CompletionItem firstthree = newItem("first three", "3");
+
+    @Test
+    public void orderList() {
+        var items = new ArrayList<>(List.of(three, one, nil, two, firstthree));
+        var expected = List.of(nil, one, two, firstthree, three);
+        items.sort(comparator);
+        assertEquals(expected, items);
+    }
+
+    @Test
+    public void compareSortText() {
+        assertTrue(comparator.compare(one, two) < 0);
+        assertTrue(comparator.compare(two, one) > 0);
+    }
+
+    @Test
+    public void compareLabels() {
+        assertTrue(comparator.compare(newItem("one", null), newItem("two", null)) < 0);
+        assertTrue(comparator.compare(newItem("two", null), newItem("three", null)) > 0);
+    }
+
+    @Test
+    public void compareNulls() {
+        assertEquals(1,comparator.compare(one, null));
+        assertEquals(0,comparator.compare(nil, nil));
+        assertEquals(1,comparator.compare(nil, null));
+        assertEquals(0,comparator.compare(null, null));
+    }
+
+    private CompletionItem newItem(String label, String sortText) {
+        CompletionItem item = new CompletionItem(label);
+        item.setSortText(sortText);
+        return item;
+    }
+
+}


### PR DESCRIPTION
Fixes #69 

Same sort as VS Code appears to be used now:

<img width="289" alt="Screenshot 2024-01-10 at 11 49 14" src="https://github.com/redhat-developer/lsp4ij/assets/148698/620b0aaf-5c43-40ef-8e54-73a596405ba9">

vs 

<img width="475" alt="Screenshot 2024-01-09 at 10 53 28" src="https://github.com/redhat-developer/lsp4ij/assets/148698/738737d1-455e-4633-847c-b526488371eb">


