### PR TITLE
fix: Apply completion with placeholder which have no name ${1:}is bugged

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/SnippetTemplateLoader.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/SnippetTemplateLoader.java
@@ -106,7 +106,7 @@ public class SnippetTemplateLoader extends AbstractLspSnippetHandler {
                 // which will be updated by the previous add variable
                 template.addVariableSegment(name);
             } else {
-                // The variable doesn't exists, add a variable which can be updated
+                // The variable doesn't exist, add a variable which can be updated
                 // and which will replace other variables with the same name.
                 existingVariables.add(name);
                 template.addVariable(name, new ConstantNode(name), null, true, false);

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/LspSnippetParser.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/LspSnippetParser.java
@@ -184,19 +184,24 @@ public class LspSnippetParser {
                         // - ${1} <-- tabstop
                         int index = readInt();
                         if (readChar(':')) {
-                            // - ${1:name} <-- placeholder
-                            String name = readString('}', '$');
-                            nestingLevel++;
-                            handler.startPlaceholder(index, name, nestingLevel);
-                            // placeholder ::= '${' int ':' any '}'
-                            if (current == '}') {
-                                // read next character
-                                read();
+                            if (readChar('}')) {
+                                // - ${1:} <-- tabstop
+                                handleTabstop(index);
                             } else {
-                                readAny();
+                                // - ${1:name} <-- placeholder
+                                String name = readString('}', '$');
+                                nestingLevel++;
+                                handler.startPlaceholder(index, name, nestingLevel);
+                                // placeholder ::= '${' int ':' any '}'
+                                if (current == '}') {
+                                    // read next character
+                                    read();
+                                } else {
+                                    readAny();
+                                }
+                                handler.endPlaceholder(nestingLevel);
+                                nestingLevel--;
                             }
-                            handler.endPlaceholder(nestingLevel);
-                            nestingLevel--;
                         } else if (readChar('|')) {
                             // - ${1|one,two,three|} <-- choice
                             handleChoice(null, index);

--- a/src/test/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/PlaceholderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/PlaceholderTest.java
@@ -21,9 +21,17 @@ import static com.redhat.devtools.lsp4ij.operations.completion.snippet.LspSnippe
 public class PlaceholderTest {
 
     @Test
-    public void simpleText() {
+    public void placeholde() {
         LspSnippetNode[] actual = LspSnippetAssert.parse("${1:name}");
         assertEquals(actual, LspSnippetAssert.placeholder(1, "name", 1));
     }
+
+    @Test
+    public void placeholderWithoutName() {
+        LspSnippetNode[] actual = LspSnippetAssert.parse("${1:}");
+        assertEquals(actual, LspSnippetAssert.tabstop(1));
+    }
+
+
 
 }


### PR DESCRIPTION
fix: Apply completion with placeholder which have no name ${1:}is bugged

Fixes #82

Here a demo which fixes Go  completion:

![Go Completion Fix](https://github.com/redhat-developer/lsp4ij/assets/1932211/0a62806b-ecd6-4dca-960d-e5337a645818)
