### PR TITLE
fix: workspace/applyEdit must be executed in write action

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -340,7 +340,15 @@ public class LSPIJUtils {
             }
         } else if (edit.getChanges() != null) {
             for (Map.Entry<String, List<TextEdit>> change : edit.getChanges().entrySet()) {
-                VirtualFile file = findResourceFor(change.getKey());
+                String fileUri = change.getKey();
+                VirtualFile file = findResourceFor(fileUri);
+                if (file == null) {
+                    try {
+                        file = createFile(fileUri);
+                    } catch (Exception e) {
+                        LOGGER.error("Cannot create file '" + fileUri + "'", e);
+                    }
+                }
                 if (file != null) {
                     Document document = getDocument(file);
                     if (document != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -11,9 +11,8 @@
 package com.redhat.devtools.lsp4ij.client;
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Disposer;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
 import com.redhat.devtools.lsp4ij.ServerMessageHandler;
@@ -88,7 +87,7 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     @Override
     public final CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
         CompletableFuture<ApplyWorkspaceEditResponse> future = new CompletableFuture<>();
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+        WriteCommandAction.runWriteCommandAction(getProject(), () -> {
             LSPIJUtils.applyWorkspaceEdit(params.getEdit());
             future.complete(new ApplyWorkspaceEditResponse(true));
         });

--- a/src/main/resources/templates/node/typescript-language-server.md
+++ b/src/main/resources/templates/node/typescript-language-server.md
@@ -1,6 +1,6 @@
 You can use the [TypeScript language server](https://github.com/typescript-language-server/typescript-language-server) by following these instructions:
 * [Install Node.js](https://nodejs.org/en/download)
-* [Read "Installing" section](https://github.com/typescript-language-server/typescript-language-server?tab=readme-ov-file#installing), basically, open a terminal and execute the following command:
+* [Read the "Installing" section](https://github.com/typescript-language-server/typescript-language-server?tab=readme-ov-file#installing), basically, open a terminal and execute the following command:
 
 **npm install -g typescript-language-server typescript**
 


### PR DESCRIPTION
Given this JavaScript / TypeScript file:

```
const a = "";
a.charA
```

The typescript-language-server provides two code actions:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/425bf8f8-e34a-4e94-8935-8a7c3de80db2)

which doesn't work.

# `Change spelling to charAt` code action

When you apply this code action, it doesn't nothing with an error, because the code action execute `workspace/applyEdit` which tries to update the document but in not in write action thread. The excution of the document update must be done in write action mode.

# `Move to a new file` code action

This code action must create a new file, the apply edit must create the file if it doesn't exist.

This PR fixes those é problems.