### PR TITLE
fix: "IllegalArgumentException: Invalid range specified" thrown on completion with the typescript language server

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/LSPCompletionProposal.java
@@ -178,9 +178,14 @@ public class LSPCompletionProposal extends LookupElement {
         }
         String insertText = getInsertText();
         try {
-            String subDoc = document.getText(new TextRange(
-                    Math.max(0, completionOffset - insertText.length()),
-                    Math.min(insertText.length(), completionOffset)));
+            // insertText= 'charAt'
+            // document= "".ch|a
+            // we have to return "".| as offset
+
+            // Search the offset between ["".ch|a]
+            int startOffset = Math.max(0, completionOffset - insertText.length());
+            int endOffset = startOffset + Math.min(insertText.length(), completionOffset);
+            String subDoc = document.getText(new TextRange(startOffset, endOffset)); // "".ch
             for (int i = 0; i < insertText.length() && i < completionOffset; i++) {
                 String tentativeCommonString = subDoc.substring(i);
                 if (insertText.startsWith(tentativeCommonString)) {


### PR DESCRIPTION
fix: "IllegalArgumentException: Invalid range specified" thrown on  completion with the typescript language server

Fixes #91

The PR fixes the issue and apply completion should work correctly:

![TSCompletion](https://github.com/redhat-developer/lsp4ij/assets/1932211/4ae74578-92a2-4c1d-9e6b-8543419d9e39)

