### PR TITLE
feat: display source + code of LSP diagnostic as tooltip

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/SupportedFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/SupportedFeatures.java
@@ -29,6 +29,7 @@ public class SupportedFeatures {
         // Publish diagnostics capabilities
         final var publishDiagnosticsCapabilities = new PublishDiagnosticsCapabilities();
         publishDiagnosticsCapabilities.setDataSupport(Boolean.TRUE);
+        publishDiagnosticsCapabilities.setCodeDescriptionSupport(Boolean.TRUE);
         textDocumentClientCapabilities.setPublishDiagnostics(publishDiagnosticsCapabilities);
 
         // Code Action support


### PR DESCRIPTION
This PR defines a tooltip for annotation to show source + code of the LSP diagnostic. When code has a code description which defines an href (ex : go ls), it display the code as hyperlink:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/396aee87-a651-48e4-917e-6edda54c741a)

Here a screenshot with typescript ls (it doesn't support href for code)

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/c39187bb-f763-4322-86fe-16f1163e937a)
