### PR TITLE
fix: check if coalesceBy is not a an array of null Object

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/PromiseToCompletableFuture.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/PromiseToCompletableFuture.java
@@ -27,6 +27,7 @@ import org.jetbrains.concurrency.CancellablePromise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -150,7 +151,7 @@ public class PromiseToCompletableFuture<R> extends CompletableFuture<R> {
         if (executeInSmartMode) {
             action = action.inSmartMode(project);
         }
-        if (coalesceBy != null) {
+        if (coalesceBy != null && !(coalesceBy.length == 1 && Objects.isNull(coalesceBy[0]))) {
             action = action.coalesceBy(coalesceBy);
         }
         return action


### PR DESCRIPTION
fix: check if coalesceBy is not a an array of null Object

Fixes: #104