### PR TITLE
fix: escape \$ for snippet completion

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/LspSnippetParser.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/LspSnippetParser.java
@@ -274,6 +274,12 @@ public class LspSnippetParser {
 
     private void handleText() throws IOException {
         String text = readString('$');
+        if (!text.isEmpty() && text.charAt(text.length() - 1) == '\\') {
+            if (readChar('$')) {
+                // Escape \$ to add '$' only as text.
+                text = text.substring(0, text.length() - 1) + '$';
+            }
+        }
         handler.text(text);
     }
 

--- a/src/test/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/PlaceholderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/operations/completion/snippet/PlaceholderTest.java
@@ -32,6 +32,10 @@ public class PlaceholderTest {
         assertEquals(actual, LspSnippetAssert.tabstop(1));
     }
 
-
-
+    @Test
+    public void placeholderWithEscapeDollar() {
+        LspSnippetNode[] actual = LspSnippetAssert.parse("\\$${1:var}");
+        assertEquals(actual, LspSnippetAssert.text("$"),
+                LspSnippetAssert.placeholder(1, "var", 1));
+    }
 }


### PR DESCRIPTION
fix: escape \$ for snippet completion

This PR takes care of `\$` which escape the `$` to add it as text. Here a demo with `@for` in scss file:

Before the PR:

![SCSSForSnippet](https://github.com/redhat-developer/lsp4ij/assets/1932211/7fe5cf47-cedf-47f2-9847-2853acf55fa2)

After the PR:

![SCSSForSnippet2](https://github.com/redhat-developer/lsp4ij/assets/1932211/7bb6d94a-afc0-46f8-a948-806388a43125)
