### PR TITLE
fix: LSP Hover support doesn't work without Psi

### DIFF
--- a/docs/LSPSupport.md
+++ b/docs/LSPSupport.md
@@ -125,8 +125,9 @@ Here is an example with the [Qute language server](https://github.com/redhat-dev
 #### Hover
 
 [textDocument/hover](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover) is implemented with `documentationProvider` extension point to support any language.
-However as IJ `documentationProvider` doesn't support aggregation of several documentationProvider, it takes
-the first `documentationProvider` which found.
+
+However, as IJ `documentationProvider` doesn't support aggregation of several documentationProvider, it takes
+the first `documentationProvider` that is found.
 
 If your language already supports `lang.documentationProvider` (`documentationProvider` for a given language),
 this `lang.documentationProvider` will be used instead of the LSP `documentationProvider`.
@@ -140,6 +141,10 @@ To fix this issue for the `JAVA` language, you need to declare in your `plugin.x
   implementationClass="com.redhat.devtools.lsp4ij.operations.documentation.LSPDocumentationProvider" 
   order="first"/>
 ```
+
+By default, LSP4IJ can support LSP hover when the file is associated with a `TextMate` grammar, but if your file
+is associated with the `TEXT` file type (ex : once you associate your file with a user-defined file type like `CSS` files)
+you will lose the LSP hover support. See some explanation [here](https://github.com/redhat-developer/lsp4ij/issues/97#issuecomment-1909804353).
 
 Here is an example with the [Qute language server](https://github.com/redhat-developer/quarkus-ls/tree/master/qute.ls) showing documentation while hovering over an `include` section:
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.fileTypes.PlainTextLanguage;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.internal.SimpleLanguageUtils;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
 import com.redhat.devtools.lsp4ij.launching.UserDefinedLanguageServerSettings;
@@ -146,13 +147,14 @@ public class LanguageServersRegistry {
                 .map(LanguageServerFileAssociation::getLanguage)
                 .filter(language -> language != null)
                 .collect(Collectors.toSet());
-        // When a file is not linked to a language (just with a file type) but with textmate
-        // to support syntax coloration,the language received in InlayHintProviders
-        // is "textmate", we add it to support
+        // When a file is not linked to a language
+        //  - if the file is associated to a textmate to support syntax coloration
+        //  - otherwise if the file is associated (by default) to plain/text file type
+        // the language received in InlayHintProviders
+        // is "textmate" / "TEXT" language, we add them to support
         // LSP codeLens, inlayHint, color for a file which is not linked to a language.
-        Language textMateLanguage = Language.findLanguageByID("textmate");
-        if (textMateLanguage != null) {
-            distinctLanguages.add(textMateLanguage);
+        for (var simpleLanguage : SimpleLanguageUtils.getSupportedSimpleLanguages()) {
+            distinctLanguages.add(simpleLanguage);
         }
         // When a file is not linked to a language (just with a file type) and not linked to a textmate,
         // the language received in InlayHintProviders is plain/text, we add it to support

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/SimpleLanguageUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/SimpleLanguageUtils.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.fileTypes.PlainTextLanguage;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Simple supported languages by LSP ('TEXT' and 'textmate').
+ */
+public class SimpleLanguageUtils {
+
+    private static final Set<Language> supportedSimpleLanguages;
+
+    static {
+        Set<Language> languages = new HashSet<>();
+        // plain/text
+        languages.add(PlainTextLanguage.INSTANCE);
+        // textmate
+        Language textMateLanguage = Language.findLanguageByID("textmate");
+        if (textMateLanguage != null) {
+            languages.add(textMateLanguage);
+        }
+        supportedSimpleLanguages = Collections.unmodifiableSet(languages);
+    }
+
+    private SimpleLanguageUtils() {
+
+    }
+
+    /**
+     * Returns the supported simple languages (TEXT, textmate) supported by default by LSP4IJ.
+     *
+     * @return the supported simple languages (TEXT, textmate) supported by default by LSP4IJ.
+     */
+    public static Set<Language> getSupportedSimpleLanguages() {
+        return supportedSimpleLanguages;
+    }
+
+    /**
+     * Returns true if the given <code>language</code> is a supported language (TEXT, textmate) and false otherwise.
+     *
+     * @param language the language.
+     * @return true if the given <code>language</code> is a supported language (TEXT, textmate) and false otherwise.
+     */
+    public static boolean isSupported(Language language) {
+        return supportedSimpleLanguages.contains(language);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/documentation/LSPDocumentationProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/documentation/LSPDocumentationProvider.java
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiManager;
 import com.intellij.util.io.URLUtil;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.internal.SimpleLanguageUtils;
 import com.redhat.devtools.lsp4ij.operations.completion.LSPCompletionProposal;
 import org.eclipse.lsp4j.MarkupContent;
 import org.jetbrains.annotations.NotNull;
@@ -60,6 +61,9 @@ public class LSPDocumentationProvider extends DocumentationProviderEx implements
         if (contextElement != null) {
             // Store the offset where the hover has been triggered
             contextElement.putUserData(TARGET_OFFSET_KEY, targetOffset);
+        }
+        if (contextElement != null && SimpleLanguageUtils.isSupported(file.getLanguage())) {
+            return contextElement;
         }
         return super.getCustomDocumentationElement(editor, file, contextElement, targetOffset);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/documentation/LSPTextHoverForFile.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/documentation/LSPTextHoverForFile.java
@@ -124,25 +124,28 @@ public class LSPTextHoverForFile implements Disposable {
             if (contents == null || contents.isEmpty()) {
                 return null;
             }
-            String s = contents.stream().map(content -> {
-                if (content.isLeft()) {
-                    return content.getLeft();
-                } else if (content.isRight()) {
-                    MarkedString markedString = content.getRight();
-                    // TODO this won't work fully until markup parser will support syntax
-                    // highlighting but will help display
-                    // strings with language tags, e.g. without it things after <?php tag aren't
-                    // displayed
-                    if (markedString.getLanguage() != null && !markedString.getLanguage().isEmpty()) {
-                        return String.format("```%s%n%s%n```", markedString.getLanguage(), markedString.getValue()); //$NON-NLS-1$
-                    } else {
-                        return markedString.getValue();
-                    }
-                } else {
-                    return ""; //$NON-NLS-1$
-                }
-            }).filter(((Predicate<String>) String::isEmpty).negate()).collect(Collectors.joining("\n\n"));
-            return new MarkupContent(s, MarkupKind.PLAINTEXT);
+            String s = contents.stream()
+                    .map(content -> {
+                        if (content.isLeft()) {
+                            return content.getLeft();
+                        } else if (content.isRight()) {
+                            MarkedString markedString = content.getRight();
+                            // TODO this won't work fully until markup parser will support syntax
+                            // highlighting but will help display
+                            // strings with language tags, e.g. without it things after <?php tag aren't
+                            // displayed
+                            if (markedString.getLanguage() != null && !markedString.getLanguage().isEmpty()) {
+                                return String.format("```%s%n%s%n```", markedString.getLanguage(), markedString.getValue()); //$NON-NLS-1$
+                            } else {
+                                return markedString.getValue();
+                            }
+                        } else {
+                            return ""; //$NON-NLS-1$
+                        }
+                    })
+                    .filter(((Predicate<String>) String::isEmpty).negate())
+                    .collect(Collectors.joining("\n\n"));
+            return new MarkupContent(MarkupKind.PLAINTEXT, s);
         } else {
             return hoverContent.getRight();
         }


### PR DESCRIPTION
fix: LSP Hover support doesn't work without Psi

Fixes #97

This PR activate the LSP hover when file is associated with TextMate. Here a screenshot with JDT LS

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/4cd271b9-5796-404f-8c8d-ace42575ea77)

There is a problem with the popup position which could hide the hovered element:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/e93cdcea-a07d-4ac5-a1ca-3ea3812a5292)
