### PR TITLE
build: download IJ sources to debug it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,13 @@ intellij {
     plugins = properties("platformPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) }
 }
 
+idea {
+    module {
+        isDownloadJavadoc = true
+        isDownloadSources = true
+    }
+}
+
 configurations {
     runtimeClasspath {
         exclude(group = "org.slf4j", module = "slf4j-api")


### PR DESCRIPTION
This PR provides the capability to download the IJ sources which is very nice to debug it.

In my case, I spend my time to debug IJ:

 * to understand how to implement features (ex : signature help, etc)
 * understand why we have some new bugs with EAP versions since IJ breaks the behavior fo some features (like inlay hints).