### PR TITLE
fix: jump to proper location when no Psi element

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/LSPPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/LSPPsiElement.java
@@ -108,4 +108,5 @@ public class LSPPsiElement extends FakePsiElement {
     public boolean isValid() {
         return true;
     }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/LSPPsiElementFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/LSPPsiElementFactory.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.operations;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Range;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * LSP Psi element factory.
+ *
+ * @param <T> the {@link LSPPsiElement} class to instance.
+ */
+public interface LSPPsiElementFactory<T extends LSPPsiElement> {
+
+    public static final LSPPsiElementFactory<LSPPsiElement> DEFAULT = (psiFile, textRange) -> new LSPPsiElement(psiFile, textRange);
+
+    /**
+     * Create an instance of {@link LSPPsiElement}.
+     *
+     * @param psiFile   the Psi file.
+     * @param textRange the text range.
+     * @return an instance of {@link LSPPsiElement}.
+     */
+    T createPsiElement(@NotNull PsiFile psiFile, @NotNull TextRange textRange);
+
+    /**
+     * Create an instance of {@link LSPPsiElement} from the given LSP location and null otherwise.
+     *
+     * @param location the LSP location.
+     * @param project  the project.
+     * @return an instance of {@link LSPPsiElement} from the given LSP location and null otherwise.
+     */
+    @Nullable
+    public static LSPPsiElement toPsiElement(@NotNull Location location, @NotNull Project project) {
+        return toPsiElement(location, project, DEFAULT);
+    }
+
+    /**
+     * Create an instance of {@link LSPPsiElement}  by using the given factory from the given LSP location and null otherwise.
+     *
+     * @param location the LSP location.
+     * @param factory  the LSP Psi element factory.
+     * @param project  the project.
+     * @return an instance of {@link LSPPsiElement} from the given LSP location and null otherwise.
+     */
+    @Nullable
+    public static <T extends LSPPsiElement> T toPsiElement(@NotNull Location location,
+                                                           @NotNull Project project,
+                                                           @NotNull LSPPsiElementFactory<T> factory) {
+        if (ApplicationManager.getApplication().isReadAccessAllowed()) {
+            return doToPsiElement(location.getUri(), location.getRange(), project, factory);
+        }
+        return ReadAction.compute(() -> {
+            return doToPsiElement(location.getUri(), location.getRange(), project, factory);
+        });
+    }
+
+    /**
+     * Create an instance of {@link LSPPsiElement} from the given LSP location link and null otherwise.
+     *
+     * @param location the LSP location.
+     * @param project  the project.
+     * @return an instance of {@link LSPPsiElement} from the given LSP location link and null otherwise.
+     */
+    public static LSPPsiElement toPsiElement(@NotNull LocationLink location,
+                                             @NotNull Project project) {
+        return toPsiElement(location, project, DEFAULT);
+    }
+
+    /**
+     * Create an instance of {@link LSPPsiElement} by using the given factory from the given LSP location link and null otherwise.
+     *
+     * @param location the LSP location link.
+     * @param factory  the LSP Psi element factory.
+     * @param project  the project.
+     * @return an instance of {@link LSPPsiElement} by using the given factory from the given LSP location link and null otherwise.
+     */
+    @Nullable
+    public static <T extends LSPPsiElement> T toPsiElement(@NotNull LocationLink location,
+                                                           @NotNull Project project,
+                                                           @NotNull LSPPsiElementFactory<T> factory) {
+        if (ApplicationManager.getApplication().isReadAccessAllowed()) {
+            return doToPsiElement(location.getTargetUri(), location.getTargetRange(), project, factory);
+        }
+        return ReadAction.compute(() -> {
+            return doToPsiElement(location.getTargetUri(), location.getTargetRange(), project, factory);
+        });
+    }
+
+    @Nullable
+    private static <T extends LSPPsiElement> T doToPsiElement(@Nullable String uri,
+                                                              @Nullable Range range,
+                                                              @NotNull Project project,
+                                                              @NotNull LSPPsiElementFactory<T> factory) {
+        if (uri == null || range == null) {
+            return null;
+        }
+        VirtualFile file = LSPIJUtils.findResourceFor(uri);
+        if (file == null) {
+            return null;
+        }
+        Document document = LSPIJUtils.getDocument(file);
+        if (document == null) {
+            return null;
+        }
+        TextRange textRange = LSPIJUtils.toTextRange(range, document);
+        PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+        return factory.createPsiElement(psiFile, textRange);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsagePsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsagePsiElement.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class LSPUsagePsiElement extends LSPPsiElement {
 
-    private final UsageKind kind;
+    private UsageKind kind;
 
     public static enum UsageKind {
         declarations,
@@ -30,9 +30,8 @@ public class LSPUsagePsiElement extends LSPPsiElement {
         implementations;
     }
 
-    public LSPUsagePsiElement(@NotNull PsiFile file, @NotNull TextRange textRange, @NotNull UsageKind kind) {
+    public LSPUsagePsiElement(@NotNull PsiFile file, @NotNull TextRange textRange) {
         super(file, textRange);
-        this.kind = kind;
     }
 
     /**
@@ -42,5 +41,9 @@ public class LSPUsagePsiElement extends LSPPsiElement {
      */
     public UsageKind getKind() {
         return kind;
+    }
+
+    public void setKind(UsageKind kind) {
+        this.kind = kind;
     }
 }


### PR DESCRIPTION
fix: jump to proper location when no Psi element

![GoToDefinitionFix](https://github.com/redhat-developer/lsp4ij/assets/1932211/bd3cf91e-c8cd-479c-8dec-9f9db6608669)

This PR fixes the position but not the underlined.
