### PR TITLE
fix: compute range from 1st non-whitespace word, if start==end

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/diagnostics/LSPDiagnosticAnnotator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/diagnostics/LSPDiagnosticAnnotator.java
@@ -88,7 +88,7 @@ public class LSPDiagnosticAnnotator extends ExternalAnnotator<Boolean, Boolean> 
     }
 
     private static void createAnnotation(Diagnostic diagnostic, Document document, LSPDiagnosticsForServer diagnosticsForServer, AnnotationHolder holder) {
-        // Get the text range from teh given LSP diagnostic range.
+        // Get the text range from the given LSP diagnostic range.
         // Since IJ cannot highlight an error when the start/end range offset are the same
         // the method LSPIJUtils.toTextRange is called with adjust, in other words when start/end range offset are the same:
         // - when the offset is at the end of the line, the method returns a text range with the same  offset,

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTargetProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTargetProvider.java
@@ -24,6 +24,8 @@ import com.redhat.devtools.lsp4ij.internal.SimpleLanguageUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static com.redhat.devtools.lsp4ij.LSPIJUtils.getTokenRange;
+
 /**
  * LSP Usage target provider.
  */
@@ -43,39 +45,13 @@ public class LSPUsageTargetProvider implements UsageTargetProvider {
         LSPUsageTriggeredPsiElement triggeredElement = new LSPUsageTriggeredPsiElement(file, new TextRange(offset > 0 ? offset - 1 : offset, offset));
         // Try to compute a proper name for the target
         Document document = editor.getDocument();
-        if (offset > 0 && offset >= document.getTextLength()) {
-            offset = document.getTextLength() - 1;
-        }
-        int start = getLeftOffsetOfPart(document, offset);
-        int end = getRightOffsetOfPart(document, offset);
-        if (start < end) {
-            String name = document.getText(new TextRange(start, end));
+        TextRange tokenRange = getTokenRange(document, offset);
+        if (tokenRange != null) {
+            String name = document.getText(tokenRange);
             triggeredElement.setName(name);
         }
         UsageTarget target = new PsiElement2UsageTargetAdapter(triggeredElement, true);
         return new UsageTarget[]{target};
-    }
-
-    private static int getLeftOffsetOfPart(Document document, int offset) {
-        int i = offset;
-        for (; i > 0; i--) {
-            char c = document.getCharsSequence().charAt(i);
-            if (!Character.isJavaIdentifierPart(c)) {
-                return i == offset ? offset : i + 1;
-            }
-        }
-        return i;
-    }
-
-    private static int getRightOffsetOfPart(Document document, int offset) {
-        int i = offset;
-        for (; i < document.getTextLength(); i++) {
-            char c = document.getCharsSequence().charAt(i);
-            if (!Character.isJavaIdentifierPart(c)) {
-                return i == offset ? offset : i;
-            }
-        }
-        return i;
     }
 
     @Override


### PR DESCRIPTION
Something fishy with intermediate diagnostics being computed on stale lines
![Feb-20-2024 12-16-06](https://github.com/redhat-developer/lsp4ij/assets/148698/8294375f-9cf2-4754-8530-752dce73891d)

Fixes #125