### PR TITLE
perf: dont send empty didChange notification

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
@@ -147,6 +147,10 @@ public class DocumentContentSynchronizer implements DocumentListener {
     private void sendDidChangeEvents() {
         List<TextDocumentContentChangeEvent> events;
         synchronized (changeEvents) {
+            if (changeEvents.isEmpty()) {
+                // Don't send didChange notification with empty contentChanges.
+                return;
+            }
             events = new ArrayList<>(changeEvents);
             changeEvents.clear();
         }


### PR DESCRIPTION
perf: dont send empty didChange notification

To reproduce the problem, select a code block, press on TAB, you should see several didChange which are empty (tested with TypeScript LS)