### PR TITLE
fix: NPE when LSP DocumentHighlightKind is null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileSupport.java
@@ -17,6 +17,7 @@ import com.redhat.devtools.lsp4ij.operations.codelens.LSPCodeLensSupport;
 import com.redhat.devtools.lsp4ij.operations.color.LSPColorSupport;
 import com.redhat.devtools.lsp4ij.operations.foldingRange.LSPFoldingRangeSupport;
 import com.redhat.devtools.lsp4ij.operations.formatting.LSPFormattingSupport;
+import com.redhat.devtools.lsp4ij.operations.highlight.LSPHighlightSupport;
 import com.redhat.devtools.lsp4ij.operations.inlayhint.LSPInlayHintsSupport;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,6 +40,8 @@ public class LSPFileSupport implements Disposable {
 
     private final LSPFormattingSupport formattingSupport;
 
+    private final LSPHighlightSupport highlightSupport;
+
     private LSPFileSupport(@NotNull PsiFile file) {
         this.file = file;
         this.codeLensSupport = new LSPCodeLensSupport(file);
@@ -46,6 +49,7 @@ public class LSPFileSupport implements Disposable {
         this.colorSupport = new LSPColorSupport(file);
         this.foldingRangeSupport = new LSPFoldingRangeSupport(file);
         this.formattingSupport = new LSPFormattingSupport(file);
+        this.highlightSupport = new LSPHighlightSupport(file);
         file.putUserData(LSP_FILE_SUPPORT_KEY, this);
     }
 
@@ -58,6 +62,7 @@ public class LSPFileSupport implements Disposable {
         getColorSupport().cancel();
         getFoldingRangeSupport().cancel();
         getFormattingSupport().cancel();
+        getHighlightSupport().cancel();
     }
 
     /**
@@ -103,6 +108,15 @@ public class LSPFileSupport implements Disposable {
      */
     public LSPFormattingSupport getFormattingSupport() {
         return formattingSupport;
+    }
+
+    /**
+     * Returns the LSP highlight support.
+     *
+     * @return the LSP highlight support.
+     */
+    public LSPHighlightSupport getHighlightSupport() {
+        return highlightSupport;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
@@ -101,12 +101,14 @@ public class CompletableFutures {
             try {
                 // wait for 25 ms
                 future.get(25, TimeUnit.MILLISECONDS);
-                // check progress canceled
-                ProgressManager.checkCanceled();
-                // No ProcessCanceledException thrown, wait again for 25ms....
             } catch (TimeoutException ignore) {
             } catch (InterruptedException e) {
                 Thread.interrupted();
+            }
+            finally {
+                // check progress canceled
+                ProgressManager.checkCanceled();
+                // No ProcessCanceledException thrown, wait again for 25ms....
             }
         }
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/highlight/LSPHighlightSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/highlight/LSPHighlightSupport.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.operations.highlight;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
+import com.redhat.devtools.lsp4ij.operations.AbstractLSPFeatureSupport;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightParams;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * LSP highlight support which loads and caches highlight by consuming
+ * <ul>
+ *     <li>LSP requests textDocument/highlight</li>
+ * </ul>
+ */
+public class LSPHighlightSupport extends AbstractLSPFeatureSupport<DocumentHighlightParams, List<DocumentHighlight>> {
+
+    public LSPHighlightSupport(@NotNull PsiFile file) {
+        super(file);
+    }
+
+    public CompletableFuture<List<DocumentHighlight>> getHighlights(DocumentHighlightParams params) {
+        return super.getFeatureData(params);
+    }
+
+    @Override
+    protected CompletableFuture<List<DocumentHighlight>> doLoad(DocumentHighlightParams params, CancellationSupport cancellationSupport) {
+        PsiFile file = super.getFile();
+        return getHighlights(file.getVirtualFile(), file.getProject(), params, cancellationSupport);
+    }
+
+    private static @NotNull CompletableFuture<List<DocumentHighlight>> getHighlights(@NotNull VirtualFile file,
+                                                                                     @NotNull Project project,
+                                                                                     @NotNull DocumentHighlightParams params,
+                                                                                     @NotNull CancellationSupport cancellationSupport) {
+
+        return LanguageServiceAccessor.getInstance(project)
+                .getLanguageServers(file, LanguageServerItem::isDocumentHighlightSupported)
+                .thenComposeAsync(languageServers -> {
+                    // Here languageServers is the list of language servers which matches the given file
+                    // and which have documentHighlights capability
+                    if (languageServers.isEmpty()) {
+                        return CompletableFuture.completedStage(Collections.emptyList());
+                    }
+
+                    // Collect list of textDocument/highlights future for each language servers
+                    List<CompletableFuture<List<? extends org.eclipse.lsp4j.DocumentHighlight>>> highlightsPerServerFutures = languageServers
+                            .stream()
+                            .map(languageServer -> getHighlightsFor(params, languageServer, cancellationSupport))
+                            .toList();
+
+                    // Merge list of textDocument/highlights future in one future which return the list of highlights
+                    return mergeInOneFuture(highlightsPerServerFutures, cancellationSupport);
+                });
+    }
+
+    private static CompletableFuture<List<? extends org.eclipse.lsp4j.DocumentHighlight>> getHighlightsFor(@NotNull DocumentHighlightParams params,
+                                                                                                           @NotNull LanguageServerItem languageServer,
+                                                                                                           @NotNull CancellationSupport cancellationSupport) {
+        return cancellationSupport.execute(languageServer.getTextDocumentService().documentHighlight(params))
+                .thenApplyAsync(highlights -> {
+                    if (highlights == null) {
+                        // textDocument/highlight may return null
+                        return Collections.emptyList();
+                    }
+                    return highlights.stream()
+                            .filter(Objects::nonNull)
+                            .toList();
+                });
+    }
+
+    /**
+     * Merge the given futures List<CompletableFuture<List<DocumentHighlight>>> in one future CompletableFuture<List<DocumentHighlight>.
+     *
+     * @param futures             the list of futures which return a List<DocumentHighlight>.
+     * @param cancellationSupport the cancellation support.
+     * @return
+     */
+    private static @NotNull CompletableFuture<List<DocumentHighlight>> mergeInOneFuture(List<CompletableFuture<List<? extends DocumentHighlight>>> futures,
+                                                                                        @NotNull CancellationSupport cancellationSupport) {
+        CompletableFuture<Void> allFutures = cancellationSupport
+                .execute(CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])));
+        return allFutures.thenApply(Void -> {
+            List<DocumentHighlight> mergedDataList = new ArrayList<>(futures.size());
+            for (CompletableFuture<List<? extends DocumentHighlight>> dataListFuture : futures) {
+                List<? extends DocumentHighlight> data = dataListFuture.join();
+                if (data != null) {
+                    mergedDataList.addAll(data);
+                }
+            }
+            return mergedDataList;
+        });
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/operations/highlight/LSPHighlightUsagesHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/operations/highlight/LSPHighlightUsagesHandler.java
@@ -42,7 +42,7 @@ public class LSPHighlightUsagesHandler extends HighlightUsagesHandlerBase<LSPHig
     public void computeUsages(@NotNull List<? extends LSPHighlightPsiElement> targets) {
         targets.forEach(target ->
         {
-            if (target.getKind() == DocumentHighlightKind.Read) {
+            if (target.getKind() == DocumentHighlightKind.Read || target.getKind() == DocumentHighlightKind.Text) {
                 myReadUsages.add(target.getTextRange());
             } else {
                 myWriteUsages.add(target.getTextRange());


### PR DESCRIPTION
fix: NPE when LSP DocumentHighlightKind is null

This PR:
 * Fixes #160
 * Use an LSP highlight support (to be standard with other features like foldingRange, etc) and provide teh capability to cancel the LSP requests highlight when file is closed
 * Improve folding ranges to avoid using Timeout

