### PR TITLE
fix: Formatting fails when position end is out of range of the document

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractLSPFormattingService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractLSPFormattingService.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.lsp4ij.features.formatting;
 import com.intellij.formatting.service.AsyncDocumentFormattingService;
 import com.intellij.formatting.service.AsyncFormattingRequest;
 import com.intellij.lang.LanguageFormatting;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
@@ -33,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Abstract class for LSP {@link AsyncDocumentFormattingService} implementation.
  */
-public  abstract class AbstractLSPFormattingService extends AsyncDocumentFormattingService {
+public abstract class AbstractLSPFormattingService extends AsyncDocumentFormattingService {
 
     @Nullable
     @Override
@@ -76,7 +77,9 @@ public  abstract class AbstractLSPFormattingService extends AsyncDocumentFormatt
             formattingSupport = LSPFileSupport.getSupport(psiFile).getFormattingSupport();
             formattingSupport.cancel();
             Editor[] editors = LSPIJUtils.editorsForFile(psiFile.getVirtualFile(), psiFile.getProject());
-            formattingSupport.format(editors.length > 0 ? editors[0] : null, formattingRange, formattingRequest);
+            Editor editor = editors.length > 0 ? editors[0] : null;
+            Document document = editor != null ? editor.getDocument() : LSPIJUtils.getDocument(psiFile.getVirtualFile());
+            formattingSupport.format(document, editor, formattingRange, formattingRequest);
         }
 
         @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingParams.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingParams.java
@@ -10,16 +10,18 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.features.formatting;
 
-import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.util.TextRange;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * LSP formatting parameters.
  *
- * @param editor    the editor
+ * @param tabSize    the tab size and null otherwise.
+ * @param insertSpaces the insert spaces and null otherwise.
  * @param textRange the text range and null otherwise.
+ * @param document the document.
  */
-public record LSPFormattingParams(@Nullable Editor editor, @Nullable TextRange textRange) {
+public record LSPFormattingParams(@Nullable Integer tabSize, @Nullable Boolean insertSpaces, @Nullable TextRange textRange, @Nullable Document document) {
 
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_toOffsetTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_toOffsetTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.impl.DocumentImpl;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.eclipse.lsp4j.Position;
+
+/**
+ * Tests for {@link LSPIJUtils#toOffset(Position, Document)}.
+ */
+public class LSPIJUtils_toOffsetTest extends BasePlatformTestCase {
+
+    public void testValidPositionWithOneLine() {
+        assertOffset("foo", 0, 0, 0, 'f');
+        assertOffset("foo", 0, 1, 1, 'o');
+        assertOffset("foo", 0, 2, 2, 'o');
+        assertOffset("foo", 0, 3, 3, null);
+    }
+
+    public void testValidPositionWithTwoLines() {
+        assertOffset("foo\nbar", 0, 0, 0, 'f');
+        assertOffset("foo\nbar", 0, 1, 1, 'o');
+        assertOffset("foo\nbar", 0, 2, 2, 'o');
+        assertOffset("foo\nbar", 0, 3, 3, null);
+
+        assertOffset("foo\nbar", 1, 0, 4, 'b');
+        assertOffset("foo\nbar", 1, 1, 5, 'a');
+        assertOffset("foo\nbar", 1, 2, 6, 'r');
+        assertOffset("foo\nbar", 1, 3, 7, null);
+    }
+
+    public void testInvalidLineWithOneLine() {
+        assertOffset("foo", 999999, 0, 0, 'f');
+        assertOffset("foo", 999999, 1, 1, 'o');
+        assertOffset("foo", 999999, 2, 2, 'o');
+        assertOffset("foo", 999999, 3, 3, null);
+    }
+
+    public void testInvalidLineWithTwoLines() {
+        assertOffset("foo\nbar", 999999, 0, 4, 'b');
+        assertOffset("foo\nbar", 999999, 1, 5, 'a');
+        assertOffset("foo\nbar", 999999, 2, 6, 'r');
+        assertOffset("foo\nbar", 999999, 3, 7, null);
+    }
+
+    public void testInvalidCharacterWithOneLine() {
+        assertOffset("foo", 0, 999999, 3, null);
+    }
+
+    public void testInvalidCharacterWithTwoLines() {
+        assertOffset("foo\nbar", 0, 999999, 3, null);
+        assertOffset("foo\nbar", 1, 999999, 7, null);
+    }
+
+    public void testInvalidPositionWithOneLine() {
+        assertOffset("foo", 999999, 999999, 3, null);
+    }
+
+    public void testInvalidPositionWithTwoLine() {
+        assertOffset("foo\nbar", 999999, 999999, 7, null);
+    }
+
+    public void assertOffset(String content, int line, int character, int expectedOffset, Character expectedChar) {
+        assertOffset(content, new Position(line, character), expectedOffset, expectedChar);
+    }
+
+    public void assertOffset(String content, Position position, int expectedOffset, Character expectedChar) {
+        Document document = new DocumentImpl(content);
+        int actualOffset = LSPIJUtils.toOffset(position, document);
+        assertEquals(expectedOffset, actualOffset);
+        if (expectedChar == null) {
+            assertTrue(expectedOffset == content.length()  /* offset is at the end of the file */
+                    || content.charAt(expectedOffset) == '\n' /* or offset is at the end of line */);
+        } else {
+            // get the character from the given offset
+            Character actualChar = document.getCharsSequence().charAt(expectedOffset);
+            assertEquals(expectedChar, actualChar);
+        }
+    }
+
+
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionTest.java
@@ -13,11 +13,12 @@ package com.redhat.devtools.lsp4ij.features.completion;
 import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionFixtureTestCase;
 
 /**
- * Completion test by emulating LSP textDocument/completion response from the typescript-language-server.
+ * Completion tests by emulating LSP 'textDocument/completion' responses
+ * from the typescript-language-server.
  */
 public class TypeScriptCompletionTest extends LSPCompletionFixtureTestCase {
 
-    public void testCompletionWithNewText() {
+    public void testCompletionWithTextEdit() {
         // 1. Test completion items result
         assertCompletion("test.ts",
                 "''.<caret>", """                

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/ClojureFormattingTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/ClojureFormattingTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.formatting;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPFormattingFixtureTestCase;
+
+/**
+ * Formatting tests by emulating LSP 'textDocument/formatting', 'textDocument/rangeFormatting'
+ * responses from the clojure-lsp language server.
+ */
+public class ClojureFormattingTest extends LSPFormattingFixtureTestCase {
+
+    public void testFormatting() {
+        // Test with TextEdit end which is outside the document length (uses of 999999)
+        assertFormatting("test.ts",
+                """                
+                        (let
+                                            [binding ""])""",
+                """
+                          [
+                          {
+                               "range": {
+                                 "start": {
+                                   "line": 0,
+                                   "character": 0
+                                 },
+                                 "end": {
+                                   "line": 999999,
+                                   "character": 999999
+                                 }
+                               },
+                               "newText": "(let\\n [binding \\"\\"])"
+                             }
+                        ]
+                                        """,
+                """                
+                        (let
+                         [binding ""])""");
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptFormattingTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptFormattingTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.formatting;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPFormattingFixtureTestCase;
+
+/**
+ * Formatting tests by emulating LSP 'textDocument/formatting', 'textDocument/rangeFormatting'
+ * responses from the typescript-language-server.
+ */
+public class TypeScriptFormattingTest extends LSPFormattingFixtureTestCase {
+
+    public void testFormatting() {
+        // 1. Test completion items result
+        assertFormatting("test.ts",
+                """                
+                           function foo() {
+                        const s = ''
+                        }""",
+                """
+                          [
+                          {
+                            "range": {
+                              "start": {
+                                "line": 0,
+                                "character": 0
+                              },
+                              "end": {
+                                "line": 0,
+                                "character": 4
+                              }
+                            },
+                            "newText": ""
+                          },
+                          {
+                            "range": {
+                              "start": {
+                                "line": 1,
+                                "character": 0
+                              },
+                              "end": {
+                                "line": 1,
+                                "character": 0
+                              }
+                            },
+                            "newText": "    "
+                          }
+                        ]
+                                        """,
+                """                
+                        function foo() {
+                            const s = ''
+                        }""");
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.fixtures;
+
+import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+import org.eclipse.lsp4j.TextEdit;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Base class test case to test LSP 'textDocument/formatting', 'textDocument/rangeFormatting' features.
+ */
+public abstract class LSPFormattingFixtureTestCase extends LSPCodeInsightFixtureTestCase {
+
+    private class MyList {
+        public List<TextEdit> edits;
+    }
+
+    protected void assertFormatting(@NotNull String fileName,
+                                    @NotNull String text,
+                                    @NotNull String jsonFormatting,
+                                    @NotNull String formattedText) {
+        MyList myList = JSONUtils.getLsp4jGson().fromJson("{\"edits\":" + jsonFormatting + "}", MyList.class);
+        assertFormatting(fileName, text, myList.edits, formattedText);
+    }
+
+    /**
+     * Test LSP completion.
+     *
+     * @param fileName           the file name used to match registered language servers.
+     * @param editorContentText  the editor content text.
+     * @param jsonFormatting the LSP CompletionList as JSON string.
+     * @param formattedtext      the expected IJ lookupItem string.
+     */
+    protected void assertFormatting(@NotNull String fileName,
+                                    @NotNull String text,
+
+                                    @NotNull List<TextEdit> formattingTextEdits,
+    @NotNull String formattedText) {
+        MockLanguageServer.INSTANCE.setTimeToProceedQueries(1000);
+        MockLanguageServer.INSTANCE.setFormattingTextEdits(formattingTextEdits);
+        // Open editor for a given file name and content
+        PsiFile file = myFixture.configureByText(fileName, text);
+        // As LSPFormattingService is done in async mode, force the connection of the language server
+        // to avoid having some block when ReadAction#compute is required (ex: call of LSP4IJUtils#getDocument).
+        try {
+            LanguageServiceAccessor.getInstance(file.getProject())
+                    .getLanguageServers(file.getVirtualFile(), null)
+                            .get(5000, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        myFixture.type('1');
+        myFixture.performEditorAction(IdeActions.ACTION_EDITOR_REFORMAT);
+        assertEquals(formattedText, myFixture.getEditor().getDocument().getText());
+    }
+
+}


### PR DESCRIPTION
fix: Formatting fails when position end is out of range of the document

Fixes #183