### PR TITLE
feat: Support pattern from FileSystemWatcher

### DIFF
--- a/docs/LSPSupport.md
+++ b/docs/LSPSupport.md
@@ -78,7 +78,7 @@ Current state of [Language Features]( https://microsoft.github.io/language-serve
 
 Current state of [Workspace Features]( https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFeatures) support:
 
- * 🟠 [workspace/didChangeWatchedFiles](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles) partially supported, missing pattern support.
+ * ✅ [workspace/didChangeWatchedFiles](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles).
  * ✅ [workspace/executeCommand](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand).
  * ✅ [workspace/applyEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_applyEdit).
  * ❌ [workspace/symbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol).

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.vfs.*;
+import com.redhat.devtools.lsp4ij.features.filewatchers.FileSystemWatcherManager;
+import org.eclipse.lsp4j.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * LSP file listener.
+ */
+class LSPFileListener implements FileEditorManagerListener, VirtualFileListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LSPFileListener.class);
+
+    private final LanguageServerWrapper languageServerWrapper;
+    private final FileSystemWatcherManager fileSystemWatcherManager;
+
+    public LSPFileListener(LanguageServerWrapper languageServerWrapper) {
+        this.languageServerWrapper = languageServerWrapper;
+        this.fileSystemWatcherManager = new FileSystemWatcherManager();
+    }
+
+    @Override
+    public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
+        if (languageServerWrapper.initialProject != null && !Objects.equals(source.getProject(), languageServerWrapper.initialProject)) {
+            // The file has been closed from another project,don't send textDocument/didClose
+            return;
+        }
+        // Manage textDocument/didClose
+        URI uri = LSPIJUtils.toUri(file);
+        if (uri != null) {
+            try {
+                // Disconnect the given file from the current language servers
+                languageServerWrapper.disconnect(uri, !languageServerWrapper.isDisposed());
+            } catch (Exception e) {
+                LOGGER.warn("Error while disconnecting the file '" + uri + "' from all language servers", e);
+            }
+        }
+    }
+
+    @Override
+    public void propertyChanged(@NotNull VirtualFilePropertyEvent event) {
+        if (event.getPropertyName().equals(VirtualFile.PROP_NAME) && event.getOldValue() instanceof String) {
+            // A file (Test1.java) has been renamed (to Test2.java) by using Refactor / Rename from IJ
+
+            // 1. Send a textDocument/didClose for the renamed file (Test1.java)
+            URI oldFileUri = didClose(event.getFile().getParent(), (String) event.getOldValue());
+
+            // 2. Send a workspace/didChangeWatchedFiles
+            VirtualFile newFile = event.getFile();
+            moveFile(oldFileUri, newFile);
+        }
+    }
+
+    private void moveFile(URI oldFileUri, VirtualFile newFile) {
+        if (hasFilePatterns()) {
+            List<FileEvent> changes = new ArrayList<>(2);
+            if (isMatchFilePatterns(oldFileUri, WatchKind.Delete)) {
+                changes.add(fe(oldFileUri, FileChangeType.Deleted));
+            }
+            URI newFileUri = LSPIJUtils.toUri(newFile);
+            if (isMatchFilePatterns(newFileUri, WatchKind.Create)) {
+                changes.add(fe(newFileUri, FileChangeType.Created));
+            }
+            if (!changes.isEmpty()) {
+                didChangeWatchedFiles(changes.toArray(new FileEvent[changes.size()]));
+            }
+        }
+    }
+
+    @Override
+    public void contentsChanged(@NotNull VirtualFileEvent event) {
+        VirtualFile file = event.getFile();
+        URI uri = LSPIJUtils.toUri(file);
+        if (uri != null) {
+            LSPVirtualFileData documentListener = languageServerWrapper.connectedDocuments.get(uri);
+            if (documentListener != null) {
+                // 1. Send a textDocument/didSave for the saved file
+                documentListener.getSynchronizer().documentSaved();
+            }
+            if (isMatchFilePatterns(uri, WatchKind.Change)) {
+                // 2. Send a workspace/didChangeWatchedFiles
+                didChangeWatchedFiles(fe(uri, FileChangeType.Changed));
+            }
+        }
+    }
+
+    @Override
+    public void fileCreated(@NotNull VirtualFileEvent event) {
+        VirtualFile file = event.getFile();
+        URI uri = LSPIJUtils.toUri(file);
+        if (isMatchFilePatterns(uri, WatchKind.Create)) {
+            // 2. Send a workspace/didChangeWatchedFiles with 'Created' file change type.
+            didChangeWatchedFiles(fe(uri, FileChangeType.Created));
+        }
+    }
+
+    @Override
+    public void fileDeleted(@NotNull VirtualFileEvent event) {
+        VirtualFile file = event.getFile();
+        URI uri = LSPIJUtils.toUri(file);
+        if (isMatchFilePatterns(uri, WatchKind.Delete)) {
+            // Send a workspace/didChangeWatchedFiles with 'Deleted' file change type.
+            didChangeWatchedFiles(fe(uri, FileChangeType.Deleted));
+        }
+    }
+
+    @Override
+    public void fileMoved(@NotNull VirtualFileMoveEvent event) {
+        // A file (foo.Test1.java) has been moved (to bar1.Test1.java)
+
+        // 1. Send a textDocument/didClose for the moved file (foo.Test1.java)
+        URI oldFileUri = didClose(event.getOldParent(), event.getFileName());
+        moveFile(oldFileUri, event.getFile());
+    }
+
+    private FileEvent fe(URI uri, FileChangeType type) {
+        return new FileEvent(uri.toASCIIString(), type);
+    }
+
+    private @NotNull URI didClose(VirtualFile virtualParentFile, String fileName) {
+        File parent = VfsUtilCore.virtualToIoFile(virtualParentFile);
+        URI uri = LSPIJUtils.toUri(new File(parent, fileName));
+        if (languageServerWrapper.isConnectedTo(uri)) {
+            languageServerWrapper.disconnect(uri, false);
+        }
+        return uri;
+    }
+
+    private void didChangeWatchedFiles(FileEvent... changes) {
+        languageServerWrapper.sendNotification(ls -> {
+            DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams(Arrays.asList(changes));
+            ls.getWorkspaceService()
+                    .didChangeWatchedFiles(params);
+        });
+    }
+
+    private boolean hasFilePatterns() {
+        return fileSystemWatcherManager.hasFilePatterns();
+    }
+
+    private boolean isMatchFilePatterns(@Nullable URI uri, int kind) {
+        if (uri == null || !hasFilePatterns()) {
+            return false;
+        }
+        return fileSystemWatcherManager.isMatchFilePattern(uri, kind);
+    }
+
+    public void setFileSystemWatchers(List<FileSystemWatcher> fileSystemWatchers) {
+        fileSystemWatcherManager.setFileSystemWatchers(fileSystemWatchers);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPNotificationConstants.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPNotificationConstants.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+/**
+ * LSP notification constants.
+ */
+public class LSPNotificationConstants {
+
+    // workspace/* LSP notifications
+    public static final String WORKSPACE_DID_CHANGE_WORKSPACE_FOLDERS = "workspace/didChangeWorkspaceFolders";
+
+    public static final String WORKSPACE_DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
+
+    private LSPNotificationConstants() {
+
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPRequestConstants.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPRequestConstants.java
@@ -8,18 +8,24 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package com.redhat.devtools.lsp4ij.features;
+package com.redhat.devtools.lsp4ij;
 
 /**
  * LSP request constants.
  */
 public class LSPRequestConstants {
 
+    // workspace/* LSP requests
+    public static final String WORKSPACE_EXECUTE_COMMAND = "workspace/executeCommand";
+
+    // textDocument/* LSP requests
+
     public static final String TEXT_DOCUMENT_DECLARATION = "textDocument/declaration";
     public static final String TEXT_DOCUMENT_DEFINITION = "textDocument/definition";
     public static final String TEXT_DOCUMENT_DOCUMENT_LINK = "textDocument/documentLink";
     public static final String TEXT_DOCUMENT_FOLDING_RANGE = "textDocument/foldingRange";
     public static final String TEXT_DOCUMENT_TYPE_DEFINITION = "textDocument/typeDefinition";
+    public static final String TEXT_DOCUMENT_CODE_ACTION = "textDocument/codeAction";
     public static final String TEXT_DOCUMENT_CODE_LENS = "textDocument/codeLens";
     public static final String TEXT_DOCUMENT_RESOLVE_CODE_LENS = "textDocument/resolveCodelens";
     public static final String TEXT_DOCUMENT_HOVER = "textDocument/hover";

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
@@ -31,7 +31,7 @@ public abstract class AbstractLSPFeatureSupport<Params, Result> {
     private long modificationStamp;
 
     // true if the future must be canceled when the Psi file is modified and false otherwise.
-    private boolean cancelWhenFileModified;
+    private final boolean cancelWhenFileModified;
 
     // The current LSP requests for all language servers applying to a given Psi file
     private @Nullable CompletableFuture<Result> future;
@@ -121,10 +121,11 @@ public abstract class AbstractLSPFeatureSupport<Params, Result> {
      * Cancel all LSP requests.
      */
     public void cancel() {
-        if (future != null && !future.isDone()) {
+        var future = this.future;
+        if (future != null && !future.isCancelled() && !future.isDone()) {
             future.cancel(true);
         }
-        future = null;
+        this.future = null;
         // Store the CancellationSupport in a local variable to prevent from NPE (very rare case)
         CancellationSupport cancellation = cancellationSupport;
         if (cancellation != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codelens/LSPCodeLensSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codelens/LSPCodeLensSupport.java
@@ -19,7 +19,7 @@ import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensParams;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorSupport.java
@@ -19,7 +19,7 @@ import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.DocumentColorParams;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
@@ -30,7 +30,7 @@ import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkSupport.java
@@ -19,7 +19,7 @@ import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPHoverSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPHoverSupport.java
@@ -19,7 +19,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/filewatchers/FileSystemWatcherManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/filewatchers/FileSystemWatcherManager.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.filewatchers;
+
+import org.eclipse.lsp4j.FileSystemWatcher;
+import org.eclipse.lsp4j.RelativePattern;
+import org.eclipse.lsp4j.WatchKind;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * LSP file system manager which matches a given URI by using LSP {@link FileSystemWatcher}.
+ */
+public class FileSystemWatcherManager {
+
+    private static final int WatchKindAny = 7;
+
+    private List<FileSystemWatcher> fileSystemWatchers;
+
+    private Map<Integer, List<PathPatternMatcher>> pathPatternMatchers;
+
+    /**
+     * Update the list of LSP file system watchers.
+     *
+     * @param fileSystemWatchers list of file system watcher.
+     */
+    public void setFileSystemWatchers(List<FileSystemWatcher> fileSystemWatchers) {
+        this.fileSystemWatchers = fileSystemWatchers;
+        pathPatternMatchers = null;
+    }
+
+    /**
+     * Returns the list of LSP file system watchers and null otherwise.
+     *
+     * @return the list of LSP file system watchers and null otherwise.
+     */
+    public List<FileSystemWatcher> getFileSystemWatchers() {
+        return fileSystemWatchers;
+    }
+
+    /**
+     * Returns true if there are some file system watchers and false otherwise.
+     *
+     * @return true if there are some file system watchers and false otherwise.
+     */
+    public boolean hasFilePatterns() {
+        return fileSystemWatchers != null && !fileSystemWatchers.isEmpty();
+    }
+
+    /**
+     * Returns true if the given uri matches a pattern for the given watch kind and false otherwise.
+     *
+     * @param uri  the uri to match.
+     * @param kind the watch kind ({@link WatchKind#Create}, {@link WatchKind#Change}, {@link WatchKind#Delete} or 7 (for any))
+     * @return true if the given uri matches a pattern for the given watch kind and false otherwise.
+     */
+    public boolean isMatchFilePattern(@Nullable URI uri, int kind) {
+        if (uri == null || !hasFilePatterns()) {
+            return false;
+        }
+        computePatternMatchersIfNeed();
+        return (match(uri, kind) || match(uri, WatchKindAny));
+    }
+
+    private void computePatternMatchersIfNeed() {
+        if (pathPatternMatchers == null) {
+            computePatternMatchers();
+        }
+    }
+
+    private synchronized void computePatternMatchers() {
+        if (pathPatternMatchers != null) {
+            return;
+        }
+        Map<Integer, List<PathPatternMatcher>> matchers = new HashMap<>();
+        for (var fileSystemMatcher : fileSystemWatchers) {
+            PathPatternMatcher matcher = getPathPatternMatcher(fileSystemMatcher);
+            if (matcher != null) {
+                Integer kind = getWatchKind(fileSystemMatcher);
+                List<PathPatternMatcher> matchersForKind = matchers.computeIfAbsent(kind, k -> new ArrayList<>());
+                matchersForKind.add(matcher);
+            }
+        }
+        pathPatternMatchers = matchers;
+    }
+
+    @Nullable
+    private static PathPatternMatcher getPathPatternMatcher(FileSystemWatcher fileSystemMatcher) {
+        Either<String, RelativePattern> globPattern = fileSystemMatcher.getGlobPattern();
+        if (globPattern != null) {
+            if (globPattern.isLeft()) {
+                String pattern = globPattern.getLeft();
+                return new PathPatternMatcher(pattern);
+            } else {
+                RelativePattern relativePattern = globPattern.getRight();
+                if (relativePattern != null) {
+                    // Implement relative pattern like glob string pattern
+                    // by waiting for finding a concrete use case.
+                    String pattern = relativePattern.getPattern();
+                    return new PathPatternMatcher(pattern);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Integer getWatchKind(FileSystemWatcher watcher) {
+        Integer kind = watcher.getKind();
+        if (kind != null && (kind == WatchKind.Create || kind == WatchKind.Change || kind == WatchKind.Delete)) {
+            return kind;
+        }
+        return WatchKindAny;
+    }
+
+    private boolean match(URI uri, int kind) {
+        List<PathPatternMatcher> matchers = pathPatternMatchers.get(kind);
+        if (matchers == null) {
+            return false;
+        }
+        for (var matcher : matchers) {
+            if (matcher.matches(uri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/filewatchers/PathPatternMatcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/filewatchers/PathPatternMatcher.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.filewatchers;
+
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Path pattern matcher.
+ */
+public class PathPatternMatcher {
+
+    record Parts(List<String> parts, List<Integer> cols) {}
+
+    private List<PathMatcher> pathMatchers;
+    private final String pattern;
+
+    public PathPatternMatcher(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public boolean matches(String uri) {
+        try {
+            return matches(new URI(uri));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public boolean matches(URI uri) {
+        if (pattern.isEmpty()) {
+            return false;
+        }
+        if (pathMatchers == null) {
+            createPathMatchers();
+        }
+        try {
+            Path path = Paths.get(uri);
+            for (PathMatcher pathMatcher : pathMatchers) {
+                try {
+                    if (pathMatcher.matches(path)) {
+                        return true;
+                    }
+                } catch (Exception e) {
+                    // Do nothing
+                }
+            }
+        } catch (Exception e) {
+            // Do nothing
+        }
+        return false;
+    }
+
+    private synchronized void createPathMatchers() {
+        if (pathMatchers != null) {
+            return;
+        }
+        String glob = pattern.replace("\\", "/");
+        // As Java NIO glob doesn't support **/, /** as optional
+        // we need to expand the pattern, ex: **/foo -> foo, **/foo.
+        List<String> expandedPatterns = expandPatterns(glob);
+        List<PathMatcher> pathMatchers = new ArrayList<>();
+        for (var expandedPattern : expandedPatterns) {
+            try {
+                PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + expandedPattern);
+                pathMatchers.add(pathMatcher);
+            } catch (Exception e) {
+                // Do nothing
+            }
+        }
+        this.pathMatchers = pathMatchers;
+    }
+
+    /**
+     * Expand the given pattern. ex: ** /foo -> foo, ** /foo.
+     *
+     * @param pattern the pattern
+     * @return the given pattern.
+     */
+    static List<String> expandPatterns(String pattern) {
+        Parts parts = getParts(pattern);
+        if (parts != null) {
+            // tokenize pattern ex : **/foo/** --> [**/, foo, /**]
+            List<String> expanded = new ArrayList<>();
+            // generate combinations array with 0,1 according to the number of **/, /**
+            // ex: **/foo/** (number=2) --> [[0, 0], [0, 1], [1, 0], [1, 1]
+            List<int[]> combinations = generateCombinations(parts.cols().size());
+            for (int[] combination : combinations) {
+                // Clone tokenized pattern (ex : [**/, foo, /**])
+                List<String> expand = new ArrayList<>(parts.parts());
+                for (int i = 0; i < combination.length; i++) {
+                    // Loop for current combination (ex : [0, 1])
+                    if (combination[i] == 0) {
+                        // When 0,  replace **/, /** with ""
+                        // ex : [**/, foo, /**] --> ["", foo, "/**"]
+                        int col = parts.cols().get(i);
+                        expand.set(col, "");
+                    }
+                }
+                // ["", foo, "/**"] --> foo/**
+                expanded.add(String.join("", expand));
+            }
+            return expanded;
+        }
+        return Collections.singletonList(pattern);
+    }
+
+
+    private static Parts getParts(String pattern) {
+        int from = 0;
+        int index = getNextIndex(pattern, from);
+        if (index != -1) {
+            List<Integer> cols = new ArrayList<>();
+            List<String> parts = new ArrayList<>();
+            while (index != -1) {
+                String s = pattern.substring(from, index);
+                if (!s.isEmpty()) {
+                    parts.add(s);
+                }
+                cols.add(parts.size());
+                from = index + 3;
+                parts.add(pattern.substring(index, from));
+                index += 3;
+                index = getNextIndex(pattern, index);
+            }
+            parts.add(pattern.substring(from));
+            return new Parts(parts, cols);
+        }
+        return null;
+    }
+
+    private static int getNextIndex(String pattern, int fromIndex) {
+        int startSlashIndex = pattern.indexOf("**/", fromIndex);
+        int endSlashIndex = pattern.indexOf("/**", fromIndex);
+        if (startSlashIndex != -1 || endSlashIndex != -1) {
+            if (startSlashIndex == -1) {
+                return endSlashIndex;
+            }
+            if (endSlashIndex == -1) {
+                return startSlashIndex;
+            }
+            return Math.min(startSlashIndex, endSlashIndex);
+        }
+        return -1;
+    }
+
+    public static List<int[]> generateCombinations(int N) {
+        List<int[]> combinations = new ArrayList<>();
+        generateCombinationsHelper(N, new int[N], 0, combinations);
+        return combinations;
+    }
+
+    private static void generateCombinationsHelper(int N, int[] combination, int index, List<int[]> combinations) {
+        if (index == N) {
+            combinations.add(combination.clone());
+        } else {
+            combination[index] = 0;
+            generateCombinationsHelper(N, combination, index + 1, combinations);
+            combination[index] = 1;
+            generateCombinationsHelper(N, combination, index + 1, combinations);
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj instanceof PathPatternMatcher other) {
+            if (!Objects.deepEquals(pathMatchers, other.pathMatchers)) {
+                return false;
+            }
+            return Objects.equals(pattern, other.getPattern());
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeSupport.java
@@ -19,7 +19,7 @@ import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeRequestParams;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
@@ -23,7 +23,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightSupport.java
@@ -17,7 +17,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsSupport.java
@@ -18,7 +18,7 @@ import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintParams;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPSignatureHelpSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPSignatureHelpSupport.java
@@ -17,7 +17,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SignatureHelpParams;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSupport.java
@@ -19,7 +19,7 @@ import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.features.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTargetProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTargetProvider.java
@@ -54,7 +54,12 @@ public class LSPUsageTargetProvider implements UsageTargetProvider {
         }
         LSPUsageTriggeredPsiElement triggeredElement = new LSPUsageTriggeredPsiElement(file, tokenRange);
         // force to compute of the name by using token range
-        triggeredElement.getName();
+        try {
+            triggeredElement.getName();
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
         UsageTarget target = new PsiElement2UsageTargetAdapter(triggeredElement, true);
         return new UsageTarget[]{target};
     }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/filewatchers/FileSystemWatcherManagerTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/filewatchers/FileSystemWatcherManagerTest.java
@@ -1,0 +1,652 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.filewatchers;
+
+import com.intellij.openapi.util.SystemInfo;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test glob pattern with {@link FileSystemWatcherManager}.
+ *
+ * The glob pattern to watch relative to the base path. Glob patterns can have
+ * the following syntax:
+ * - `*` to match one or more characters in a path segment
+ * - `?` to match on one character in a path segment
+ * - `**` to match any number of path segments, including none
+ * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript
+ *   and JavaScript files)
+ * - `[]` to declare a range of characters to match in a path segment
+ *   (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+ * - `[!...]` to negate a range of characters to match in a path segment
+ *   (e.g., `example.[!0-9]` to match on `example.a`, `example.b`,
+ *   but not `example.0`)
+ *
+ * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#pattern">LSP Pattern</a>
+ */
+public class FileSystemWatcherManagerTest {
+
+    private FileSystemWatcherManager manager = new FileSystemWatcherManager();
+
+    @Test
+    public void jdt_ls() {
+        // On Windows OS, we generate a base dir with lower case because JDT LS generate this base dir.
+        String baseDir = SystemInfo.isWindows ? getBaseDir().toLowerCase() : getBaseDir();
+        registerWatchers("""
+                {"watchers": [
+                          {
+                            "globPattern": "**/*.java"
+                          },
+                          {
+                            "globPattern": "**/.project"
+                          },
+                          {
+                            "globPattern": "**/.classpath"
+                          },
+                          {
+                            "globPattern": "**/.settings/*.prefs"
+                          },
+                          {
+                            "globPattern": "**/src/**"
+                          },
+                          {
+                            "globPattern": "**/*.gradle"
+                          },
+                          {
+                            "globPattern": "**/*.gradle.kts"
+                          },
+                          {
+                            "globPattern": "**/gradle.properties"
+                          },
+                          {
+                            "globPattern": "**/pom.xml"
+                          },
+                          {
+                            "globPattern": "%sUsers/X/foo/lib/**"
+                          },
+                          {
+                            "globPattern": "**/.settings"
+                          }
+                        ]
+                      }
+                """.formatted(baseDir));
+
+        // Match "**/*.java"
+        assertMatchFile(getBaseUri() + "foo.java"); // file:///C:/foo.java
+        assertMatchFile(getBaseUri().toLowerCase() + "foo.java"); // file:///c:/foo.java
+
+        // Match "**/src/**"
+        assertNoMatchFile(getBaseUri() + "foo.ts"); // file:///C:/foo.ts
+        assertMatchFile(getBaseUri() + "src/foo.ts"); // "file:///C:/src/foo.ts"
+
+        // Match c:/Users/X/foo/lib/**
+        assertNoMatchFile(getBaseUri() + "Users/X/lib/bar.jar"); // file:///C:/Users/X/lib/bar.jar
+        assertMatchFile(getBaseUri() + "Users/X/foo/lib/bar.jar"); // file:///C:/Users/X/foo/lib/bar.jar
+
+        // Match "**/.settings
+        assertNoMatchFile(getBaseUri() + "foo.ts"); // file:///C:/foo.ts
+        assertMatchFile(getBaseUri() + ".settings"); // file:///C:/.settings
+
+        // Match **/.settings/*.prefs
+        assertNoMatchFile(getBaseUri() + ".settings/foo.pref"); // file:///C:/.settings/foo.pref
+        assertNoMatchFile(getBaseUri() + ".settings/bar/foo.prefs"); // file:///C:/.settings/bar/foo.prefs
+        assertMatchFile(getBaseUri() + ".settings/foo.prefs"); // file:///C:/.settings/foo.prefs
+
+    }
+
+    @Test
+    public void vscode_simple() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L77
+        String p = "node_modules";
+
+        assertGlobMatch(p, "node_modules");
+        assertNoGlobMatch(p, "node_module");
+        // assertNoGlobMatch(p, baseUri + "/node_modules");
+        assertNoGlobMatch(p, "test/node_modules");
+
+        p = "test.txt";
+        assertGlobMatch(p, "test.txt");
+        assertNoGlobMatch(p, "test?txt");
+        assertNoGlobMatch(p, "/text.txt");
+        assertNoGlobMatch(p, "test/test.txt");
+
+        p = "test(.txt";
+        assertGlobMatch(p, "test(.txt");
+        assertNoGlobMatch(p, "test?txt");
+
+        p = "qunit";
+
+        assertGlobMatch(p, "qunit");
+        assertNoGlobMatch(p, "qunit.css");
+        assertNoGlobMatch(p, "test/qunit");
+
+        // Absolute
+        p = "DNXConsoleApp/**/*.cs";
+        assertGlobMatch(p, "/DNXConsoleApp/Program.cs");
+        assertGlobMatch(p, "/DNXConsoleApp/foo/Program.cs");
+
+        p = "*";
+        // FIXME: the glob  from Java IO doesn't support optional *
+        // assertGlobMatch(p, "");
+
+        assertGlobMatch(p, "a");
+        assertGlobMatch(p, "ab");
+    }
+
+    @Test
+    public void vscode_dot_hidden() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L116C3-L157C45
+        String p = ".*";
+
+        assertGlobMatch(p, ".git");
+        assertGlobMatch(p, ".hidden.txt");
+        assertNoGlobMatch(p, "git");
+        assertNoGlobMatch(p, "hidden.txt");
+        assertNoGlobMatch(p, "path/.git");
+        assertNoGlobMatch(p, "path/.hidden.txt");
+
+        p = "**/.*";
+        assertGlobMatch(p, ".git");
+        assertGlobMatch(p, "/.git");
+        assertGlobMatch(p, ".hidden.txt");
+        assertNoGlobMatch(p, "git");
+        assertNoGlobMatch(p, "hidden.txt");
+
+        assertGlobMatch(p, "path/.git");
+        assertGlobMatch(p, "path/.hidden.txt");
+        assertGlobMatch(p, "/path/.git");
+        assertGlobMatch(p, "/path/.hidden.txt");
+        assertNoGlobMatch(p, "path/git");
+        assertNoGlobMatch(p, "pat.h/hidden.txt");
+
+        p = "._*";
+
+        assertGlobMatch(p, "._git");
+        assertGlobMatch(p, "._hidden.txt");
+        assertNoGlobMatch(p, "git");
+        assertNoGlobMatch(p, "hidden.txt");
+        assertNoGlobMatch(p, "path/._git");
+        assertNoGlobMatch(p, "path/._hidden.txt");
+
+        p = "**/._*";
+        assertGlobMatch(p, "._git");
+        assertGlobMatch(p, "._hidden.txt");
+        assertNoGlobMatch(p, "git");
+        assertNoGlobMatch(p, "hidden._txt");
+
+        assertGlobMatch(p, "path/._git");
+        assertGlobMatch(p, "path/._hidden.txt");
+        assertGlobMatch(p, "/path/._git");
+        assertGlobMatch(p, "/path/._hidden.txt");
+        assertNoGlobMatch(p, "path/git");
+        assertNoGlobMatch(p, "pat.h/hidden._txt");
+    }
+
+    @Test
+    public void vscode_file_pattern() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L161
+        String p = "*.js";
+
+        assertGlobMatch(p, "foo.js");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertNoGlobMatch(p, "/node_modules/foo.js");
+        assertNoGlobMatch(p, "foo.jss");
+        assertNoGlobMatch(p, "some.js/test");
+
+        p = "html.*";
+        assertGlobMatch(p, "html.js");
+        assertGlobMatch(p, "html.txt");
+        assertNoGlobMatch(p, "htm.txt");
+
+        p = "*.*";
+        assertGlobMatch(p, "html.js");
+        assertGlobMatch(p, "html.txt");
+        assertGlobMatch(p, "htm.txt");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertNoGlobMatch(p, "/node_modules/foo.js");
+
+        p = "node_modules/test/*.js";
+        assertGlobMatch(p, "node_modules/test/foo.js");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertNoGlobMatch(p, "/node_module/test/foo.js");
+        assertNoGlobMatch(p, "foo.jss");
+        assertNoGlobMatch(p, "some.js/test");
+    }
+
+    @Test
+    public void vscode_star() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L190C3-L203C48
+        String p = "node*modules";
+
+        assertGlobMatch(p, "node_modules");
+        assertGlobMatch(p, "node_super_modules");
+        assertNoGlobMatch(p, "node_module");
+        //assertNoGlobMatch(p, "/node_modules");
+        assertNoGlobMatch(p, "test/node_modules");
+
+        p = "*";
+        assertGlobMatch(p, "html.js");
+        assertGlobMatch(p, "html.txt");
+        assertGlobMatch(p, "htm.txt");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertNoGlobMatch(p, "/node_modules/foo.js");
+    }
+
+    @Test
+    public void vscode_file_folder_match() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L207C3-L221C51
+        String p = "**/node_modules/**";
+
+        assertGlobMatch(p, "node_modules");
+        assertGlobMatch(p, "node_modules/");
+        assertGlobMatch(p, "a/node_modules");
+        assertGlobMatch(p, "a/node_modules/");
+        assertGlobMatch(p, "node_modules/foo");
+        assertGlobMatch(p, "foo/node_modules/foo/bar");
+
+        assertGlobMatch(p, "/node_modules");
+        assertGlobMatch(p, "/node_modules/");
+        assertGlobMatch(p, "/a/node_modules");
+        assertGlobMatch(p, "/a/node_modules/");
+        assertGlobMatch(p, "/node_modules/foo");
+        assertGlobMatch(p, "/foo/node_modules/foo/bar");
+    }
+
+    @Test
+    public void vscode_questionmark() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L225C3-L238C48
+        String p = "node?modules";
+
+        assertGlobMatch(p, "node_modules");
+        assertNoGlobMatch(p, "node_super_modules");
+        assertNoGlobMatch(p, "node_module");
+        //assertNoGlobMatch(p, "/node_modules");
+        //assertNoGlobMatch(p, "test/node_modules");
+
+        p = "?";
+        assertGlobMatch(p, "h");
+        assertNoGlobMatch(p, "html.txt");
+        assertNoGlobMatch(p, "htm.txt");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertNoGlobMatch(p, "/node_modules/foo.js");
+    }
+
+    @Test
+    public void vscode_globstar() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L242C3-L352C42
+        String p = "**/*.js";
+
+        assertGlobMatch(p, "foo.js");
+        assertGlobMatch(p, "/foo.js");
+        assertGlobMatch(p, "folder/foo.js");
+        assertGlobMatch(p, "/node_modules/foo.js");
+        assertNoGlobMatch(p, "foo.jss");
+        assertNoGlobMatch(p, "some.js/test");
+        assertNoGlobMatch(p, "/some.js/test");
+        //assertNoGlobMatch(p, "\\some.js\\test"); // invalid file uri
+
+        p = "**/project.json";
+
+        assertGlobMatch(p, "project.json");
+        assertGlobMatch(p, "/project.json");
+        assertGlobMatch(p, "some/folder/project.json");
+        assertGlobMatch(p, "/some/folder/project.json");
+        assertNoGlobMatch(p, "some/folder/file_project.json");
+        assertNoGlobMatch(p, "some/folder/fileproject.json");
+        assertNoGlobMatch(p, "some/rrproject.json");
+        //assertNoGlobMatch(p, "some\\rrproject.json"); // invaid file uri
+
+        p = "test/**";
+        assertGlobMatch(p, "test");
+        assertGlobMatch(p, "test/foo");
+        assertGlobMatch(p, "test/foo/");
+        assertGlobMatch(p, "test/foo.js");
+        assertGlobMatch(p, "test/other/foo.js");
+        assertNoGlobMatch(p, "est/other/foo.js");
+
+        p = "**";
+        assertGlobMatch(p, "/");
+        assertGlobMatch(p, "foo.js");
+        assertGlobMatch(p, "folder/foo.js");
+        assertGlobMatch(p, "folder/foo/");
+        assertGlobMatch(p, "/node_modules/foo.js");
+        assertGlobMatch(p, "foo.jss");
+        assertGlobMatch(p, "some.js/test");
+
+        p = "test/**/*.js";
+        assertGlobMatch(p, "test/foo.js");
+        assertGlobMatch(p, "test/other/foo.js");
+        assertGlobMatch(p, "test/other/more/foo.js");
+        assertNoGlobMatch(p, "test/foo.ts");
+        assertNoGlobMatch(p, "test/other/foo.ts");
+        assertNoGlobMatch(p, "test/other/more/foo.ts");
+
+        p = "**/**/*.js";
+
+        assertGlobMatch(p, "foo.js");
+        assertGlobMatch(p, "folder/foo.js");
+        assertGlobMatch(p, "/node_modules/foo.js");
+        assertNoGlobMatch(p, "foo.jss");
+        assertNoGlobMatch(p, "some.js/test");
+
+        p = "**/node_modules/**/*.js";
+
+        assertNoGlobMatch(p, "foo.js");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertGlobMatch(p, "node_modules/foo.js");
+        assertGlobMatch(p, "/node_modules/foo.js");
+        assertGlobMatch(p, "node_modules/some/folder/foo.js");
+        assertGlobMatch(p, "/node_modules/some/folder/foo.js");
+        assertNoGlobMatch(p, "node_modules/some/folder/foo.ts");
+        assertNoGlobMatch(p, "foo.jss");
+        assertNoGlobMatch(p, "some.js/test");
+
+        p = "{**/node_modules/**,**/.git/**,**/bower_components/**}";
+
+        assertGlobMatch(p, "node_modules");
+        assertGlobMatch(p, "/node_modules");
+        assertGlobMatch(p, "/node_modules/more");
+        assertGlobMatch(p, "some/test/node_modules");
+        //assertGlobMatch(p, "some\\test\\node_modules"); // invalid file uri
+        assertGlobMatch(p, "/some/test/node_modules");
+        //assertGlobMatch(p, "\\some\\test\\node_modules"); // invalid file uri
+        //assertGlobMatch(p, "C:\\\\some\\test\\node_modules"); // invalid file uri
+        //assertGlobMatch(p, "C:\\\\some\\test\\node_modules\\more"); // invalid file uri
+
+        assertGlobMatch(p, "bower_components");
+        assertGlobMatch(p, "bower_components/more");
+        assertGlobMatch(p, "/bower_components");
+        assertGlobMatch(p, "some/test/bower_components");
+        //assertGlobMatch(p, "some\\test\\bower_components"); // invalid file uri
+        assertGlobMatch(p, "/some/test/bower_components");
+        //assertGlobMatch(p, "\\some\\test\\bower_components"); // invalid file uri
+        //assertGlobMatch(p, "C:\\\\some\\test\\bower_components"); // invalid file uri
+        //assertGlobMatch(p, "C:\\\\some\\test\\bower_components\\more"); // invalid file uri
+
+        assertGlobMatch(p, ".git");
+        assertGlobMatch(p, "/.git");
+        assertGlobMatch(p, "some/test/.git");
+        //assertGlobMatch(p, "some\\test\\.git"); // invalid file uri
+        assertGlobMatch(p, "/some/test/.git");
+        //assertGlobMatch(p, "\\some\\test\\.git"); // invalid file uri
+        //assertGlobMatch(p, "C:\\\\some\\test\\.git"); // invalid file uri
+
+        assertNoGlobMatch(p, "tempting");
+        assertNoGlobMatch(p, "/tempting");
+        assertNoGlobMatch(p, "some/test/tempting");
+        //assertNoGlobMatch(p, "some\\test\\tempting"); // invalid file uri
+        assertNoGlobMatch(p, "/some/test/tempting");
+        //assertNoGlobMatch(p, "\\some\\test\\tempting"); // invalid file uri
+        //assertNoGlobMatch(p, "C:\\\\some\\test\\tempting"); // invalid file uri
+
+        p = "{**/package.json,**/project.json}";
+        assertGlobMatch(p, "package.json");
+        assertGlobMatch(p, "/package.json");
+        assertGlobMatch(p, "src/package.json");
+        assertNoGlobMatch(p, "xpackage.json");
+        assertNoGlobMatch(p, "/xpackage.json");
+    }
+
+    @Test
+    public void vscode_issue_41724() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L356
+        String p = "some/**/*.js";
+
+        assertGlobMatch(p, "some/foo.js");
+        assertGlobMatch(p, "some/folder/foo.js");
+        assertNoGlobMatch(p, "something/foo.js");
+        assertNoGlobMatch(p, "something/folder/foo.js");
+
+        p = "some/**/*";
+
+        assertGlobMatch(p, "some/foo.js");
+        assertGlobMatch(p, "some/folder/foo.js");
+        assertNoGlobMatch(p, "something/foo.js");
+        assertNoGlobMatch(p, "something/folder/foo.js");
+    }
+    @Test
+    public void vscode_brace_expansion() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L372C3-L469C39
+        String p = "*.{html,js}";
+
+        assertGlobMatch(p, "foo.js");
+        assertGlobMatch(p, "foo.html");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertNoGlobMatch(p, "/node_modules/foo.js");
+        assertNoGlobMatch(p, "foo.jss");
+        assertNoGlobMatch(p, "some.js/test");
+
+        p = "*.{html}";
+
+        assertGlobMatch(p, "foo.html");
+        assertNoGlobMatch(p, "foo.js");
+        assertNoGlobMatch(p, "folder/foo.js");
+        assertNoGlobMatch(p, "/node_modules/foo.js");
+        assertNoGlobMatch(p, "foo.jss");
+        assertNoGlobMatch(p, "some.js/test");
+
+        p = "{node_modules,testing}";
+        assertGlobMatch(p, "node_modules");
+        assertGlobMatch(p, "testing");
+        assertNoGlobMatch(p, "node_module");
+        assertNoGlobMatch(p, "dtesting");
+
+        p = "**/{foo,bar}";
+        assertGlobMatch(p, "foo");
+        assertGlobMatch(p, "bar");
+        assertGlobMatch(p, "test/foo");
+        assertGlobMatch(p, "test/bar");
+        assertGlobMatch(p, "other/more/foo");
+        assertGlobMatch(p, "other/more/bar");
+        assertGlobMatch(p, "/foo");
+        assertGlobMatch(p, "/bar");
+        assertGlobMatch(p, "/test/foo");
+        assertGlobMatch(p, "/test/bar");
+        assertGlobMatch(p, "/other/more/foo");
+        assertGlobMatch(p, "/other/more/bar");
+
+        p = "{foo,bar}/**";
+        assertGlobMatch(p, "foo");
+        assertGlobMatch(p, "bar");
+        assertGlobMatch(p, "bar/");
+        assertGlobMatch(p, "foo/test");
+        assertGlobMatch(p, "bar/test");
+        assertGlobMatch(p, "bar/test/");
+        assertGlobMatch(p, "foo/other/more");
+        assertGlobMatch(p, "bar/other/more");
+        assertGlobMatch(p, "bar/other/more/");
+
+        p = "{**/*.d.ts,**/*.js}";
+
+        assertGlobMatch(p, "foo.js");
+        assertGlobMatch(p, "testing/foo.js");
+        //assertGlobMatch(p, "testing\\foo.js"); // invalid file uri
+        assertGlobMatch(p, "/testing/foo.js");
+        //assertGlobMatch(p, "\\testing\\foo.js"); // invalid file uri
+        //assertGlobMatch(p, "C:\\testing\\foo.js"); // invalid file uri
+
+        assertGlobMatch(p, "foo.d.ts");
+        assertGlobMatch(p, "testing/foo.d.ts");
+        //assertGlobMatch(p, "testing\\foo.d.ts"); // invalid file uri
+        assertGlobMatch(p, "/testing/foo.d.ts");
+        //assertGlobMatch(p, "\\testing\\foo.d.ts"); // invalid file uri
+        //assertGlobMatch(p, "C:\\testing\\foo.d.ts"); // invalid file uri
+
+        assertNoGlobMatch(p, "foo.d");
+        assertNoGlobMatch(p, "testing/foo.d");
+        //assertNoGlobMatch(p, "testing\\foo.d"); // invalid file uri
+        assertNoGlobMatch(p, "/testing/foo.d");
+        //assertNoGlobMatch(p, "\\testing\\foo.d"); // invalid file uri
+        //assertNoGlobMatch(p, "C:\\testing\\foo.d"); // invalid file uri
+
+        p = "{**/*.d.ts,**/*.js,path/simple.jgs}";
+
+        //assertGlobMatch(p, "foo.js"); // invalid file uri
+        assertGlobMatch(p, "testing/foo.js");
+        //assertGlobMatch(p, "testing\\foo.js"); // invalid file uri
+        assertGlobMatch(p, "/testing/foo.js");
+        assertGlobMatch(p, "path/simple.jgs");
+        //assertNoGlobMatch(p, "/path/simple.jgs"); // invalid file uri
+        //assertGlobMatch(p, "\\testing\\foo.js"); // invalid file uri
+        //assertGlobMatch(p, "C:\\testing\\foo.js"); // invalid file uri
+
+        p = "{**/*.d.ts,**/*.js,foo.[0-9]}";
+
+        assertGlobMatch(p, "foo.5");
+        assertGlobMatch(p, "foo.8");
+        assertNoGlobMatch(p, "bar.5");
+        assertNoGlobMatch(p, "foo.f");
+        assertGlobMatch(p, "foo.js");
+
+        p = "prefix/{**/*.d.ts,**/*.js,foo.[0-9]}";
+
+        assertGlobMatch(p, "prefix/foo.5");
+        assertGlobMatch(p, "prefix/foo.8");
+        assertNoGlobMatch(p, "prefix/bar.5");
+        assertNoGlobMatch(p, "prefix/foo.f");
+        assertGlobMatch(p, "prefix/foo.js");
+    }
+    
+    @Test
+    public void vscode_bracket() {
+        // See https://github.com/microsoft/vscode/blob/e49b522e12d1a55dfe2950af355767c9d5b824aa/src/vs/base/test/common/glob.test.ts#L528C3-L580C31
+        String p = "foo.[0-9]";
+
+        assertGlobMatch(p, "foo.5");
+        assertGlobMatch(p, "foo.8");
+        assertNoGlobMatch(p, "bar.5");
+        assertNoGlobMatch(p, "foo.f");
+
+        // Seems ^ not supported by Java NIO
+        p = "foo.[^0-9]";
+
+        //assertNoGlobMatch(p, "foo.5");
+        //assertNoGlobMatch(p, "foo.8");
+        //assertNoGlobMatch(p, "bar.5");
+        //assertGlobMatch(p, "foo.f");
+
+        p = "foo.[!0-9]";
+
+        assertNoGlobMatch(p, "foo.5");
+        assertNoGlobMatch(p, "foo.8");
+        assertNoGlobMatch(p, "bar.5");
+        assertGlobMatch(p, "foo.f");
+
+        p = "foo.[0!^*?]";
+
+        assertNoGlobMatch(p, "foo.5");
+        assertNoGlobMatch(p, "foo.8");
+        assertGlobMatch(p, "foo.0");
+        assertGlobMatch(p, "foo.!");
+        //assertGlobMatch(p, "foo.^"); // not a valid file uri
+        //assertGlobMatch(p, "foo.*"); // not a valid file uri
+        //assertGlobMatch(p, "foo.?"); // not a valid file uri
+
+        // Seems [/] not supported by Java NIO (fails with java.util.regex.PatternSyntaxException: Explicit 'name separator' in class near index 19
+        //C:/Users/azerr/foo[/]bar)
+        p = "foo[/]bar";
+
+        //assertNoGlobMatch(p, "foo/bar");
+
+        p = "foo.[[]";
+
+        //assertGlobMatch(p, "foo.["); // not a valid file uri
+
+        p = "foo.[]]";
+
+        // assertGlobMatch(p, "foo.]"); // not a valid file uri
+
+        p = "foo.[][!]";
+
+        //assertGlobMatch(p, "foo.]"); // not a valid file uri
+        //assertGlobMatch(p, "foo.["); // not a valid file uri
+
+        // java.util.regex.PatternSyntaxException: Unclosed character class near index 47
+//^C:\\Users\\azerr\\foo\.[[^\\]&&[]][[^\\]&&[^]]$
+        // assertGlobMatch(p, "foo.!");
+
+        p = "foo.[]-]";
+
+        //assertGlobMatch(p, "foo.]"); // not a valid file uri
+        //assertGlobMatch(p, "foo.-");
+    }
+
+    private void assertGlobMatch(String pattern, String uri) {
+        assertGlobMatch(pattern, uri, true);
+    }
+
+    private void assertNoGlobMatch(String pattern, String uri) {
+        assertGlobMatch(pattern, uri, false);
+    }
+
+    private void assertGlobMatch(String pattern, String uri, boolean expected) {
+
+        // Tests must be adapted to use file uri
+
+        String baseDir = getBaseDir();
+        pattern = baseDir + pattern;
+
+        String baseUri = getBaseUri();
+        uri = baseUri + uri;
+
+        registerWatchers("""
+                {"watchers": [
+                          {
+                            "globPattern": "%s"
+                          }
+                          ]}
+                          """.formatted(pattern));
+        if (expected) {
+            assertMatchFile(uri);
+        } else {
+            assertNoMatchFile(uri);
+        }
+    }
+
+
+    private void assertMatchFile(String fileUri) {
+        URI uri = URI.create(fileUri);
+        boolean matched = manager.isMatchFilePattern(uri, -1);
+        String watchers = JSONUtils.getLsp4jGson().toJson(manager.getFileSystemWatchers());
+        assertTrue(watchers + " should match " + fileUri, matched);
+    }
+
+    private void assertNoMatchFile(String fileUri) {
+        URI uri = URI.create(fileUri);
+        boolean matched = manager.isMatchFilePattern(uri, -1);
+        String watchers = JSONUtils.getLsp4jGson().toJson(manager.getFileSystemWatchers());
+        assertFalse(watchers + " should not match " + fileUri, matched);
+    }
+
+    private void registerWatchers(String watchers) {
+        var options = JSONUtils.getLsp4jGson().fromJson(watchers, DidChangeWatchedFilesRegistrationOptions.class);
+        manager.setFileSystemWatchers(options.getWatchers());
+    }
+
+    private static String getBaseUri() {
+        return (SystemInfo.isWindows ? "file:///" : "file://") + getBaseDir();
+    }
+
+    private static String getBaseDir() {
+        String baseDir = System.getProperty("user.home")
+                .replace('\\', '/');
+        if (!baseDir.endsWith("/")) {
+            return baseDir + "/";
+        }
+        return baseDir;
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/filewatchers/PathPatternMatcherTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/filewatchers/PathPatternMatcherTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.filewatchers;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Test with pattern expansion.
+**/
+public class PathPatternMatcherTest {
+
+    @Test
+    public void noExpansion() {
+        assertExpandPatterns("foo", "foo");
+    }
+
+    @Test
+    public void oneExpansion() {
+        assertExpandPatterns("**/foo", "foo", "**/foo");
+    }
+
+    @Test
+    public void twoExpansion() {
+        assertExpandPatterns("**/foo/**", "foo", "**/foo", "foo/**", "**/foo/**");
+    }
+
+    @Test
+    public void sixExpansion() {
+        assertExpandPatterns("{**/node_modules/**,**/.git/**,**/bower_components/**}",
+                "{node_modules,.git,bower_components}",
+                "{node_modules,.git,bower_components/**}",
+                "{node_modules,.git,**/bower_components}",
+                "{node_modules,.git,**/bower_components/**}",
+                "{node_modules,.git/**,bower_components}",
+                "{node_modules,.git/**,bower_components/**}",
+                "{node_modules,.git/**,**/bower_components}",
+                "{node_modules,.git/**,**/bower_components/**}",
+                "{node_modules,**/.git,bower_components}",
+                "{node_modules,**/.git,bower_components/**}",
+                "{node_modules,**/.git,**/bower_components}",
+                "{node_modules,**/.git,**/bower_components/**}",
+                "{node_modules,**/.git/**,bower_components}",
+                "{node_modules,**/.git/**,bower_components/**}",
+                "{node_modules,**/.git/**,**/bower_components}",
+                "{node_modules,**/.git/**,**/bower_components/**}",
+                "{node_modules/**,.git,bower_components}",
+                "{node_modules/**,.git,bower_components/**}",
+                "{node_modules/**,.git,**/bower_components}",
+                "{node_modules/**,.git,**/bower_components/**}",
+                "{node_modules/**,.git/**,bower_components}",
+                "{node_modules/**,.git/**,bower_components/**}",
+                "{node_modules/**,.git/**,**/bower_components}",
+                "{node_modules/**,.git/**,**/bower_components/**}",
+                "{node_modules/**,**/.git,bower_components}",
+                "{node_modules/**,**/.git,bower_components/**}",
+                "{node_modules/**,**/.git,**/bower_components}",
+                "{node_modules/**,**/.git,**/bower_components/**}",
+                "{node_modules/**,**/.git/**,bower_components}",
+                "{node_modules/**,**/.git/**,bower_components/**}",
+                "{node_modules/**,**/.git/**,**/bower_components}",
+                "{node_modules/**,**/.git/**,**/bower_components/**}",
+                "{**/node_modules,.git,bower_components}",
+                "{**/node_modules,.git,bower_components/**}",
+                "{**/node_modules,.git,**/bower_components}",
+                "{**/node_modules,.git,**/bower_components/**}",
+                "{**/node_modules,.git/**,bower_components}",
+                "{**/node_modules,.git/**,bower_components/**}",
+                "{**/node_modules,.git/**,**/bower_components}",
+                "{**/node_modules,.git/**,**/bower_components/**}",
+                "{**/node_modules,**/.git,bower_components}",
+                "{**/node_modules,**/.git,bower_components/**}",
+                "{**/node_modules,**/.git,**/bower_components}",
+                "{**/node_modules,**/.git,**/bower_components/**}",
+                "{**/node_modules,**/.git/**,bower_components}",
+                "{**/node_modules,**/.git/**,bower_components/**}",
+                "{**/node_modules,**/.git/**,**/bower_components}",
+                "{**/node_modules,**/.git/**,**/bower_components/**}",
+                "{**/node_modules/**,.git,bower_components}",
+                "{**/node_modules/**,.git,bower_components/**}",
+                "{**/node_modules/**,.git,**/bower_components}",
+                "{**/node_modules/**,.git,**/bower_components/**}",
+                "{**/node_modules/**,.git/**,bower_components}",
+                "{**/node_modules/**,.git/**,bower_components/**}",
+                "{**/node_modules/**,.git/**,**/bower_components}",
+                "{**/node_modules/**,.git/**,**/bower_components/**}",
+                "{**/node_modules/**,**/.git,bower_components}",
+                "{**/node_modules/**,**/.git,bower_components/**}",
+                "{**/node_modules/**,**/.git,**/bower_components}",
+                "{**/node_modules/**,**/.git,**/bower_components/**}",
+                "{**/node_modules/**,**/.git/**,bower_components}",
+                "{**/node_modules/**,**/.git/**,bower_components/**}",
+                "{**/node_modules/**,**/.git/**,**/bower_components}",
+                "{**/node_modules/**,**/.git/**,**/bower_components/**}");
+    }
+
+    private static void assertExpandPatterns(String pattern, String... expectedPatterns) {
+        List<String> actual = PathPatternMatcher.expandPatterns(pattern);
+        Collections.sort(actual);
+        List<String> expected = Arrays.asList(expectedPatterns);
+        Collections.sort(expected);
+        assertArrayEquals("'" + pattern + "' pattern expansion should match [\"" + String.join("\",\"", actual) + "\"]",
+                actual.toArray(new String[0]), expected.toArray(new String[0]));
+    }
+}


### PR DESCRIPTION
feat: Support pattern from FileSystemWatcher

Fixes #11

This PR support now pattern and I have integrated the same test than vscode. However there is some limitations:

 * using `**/` (managed with Java NIO glob) is not optional. So if you have the following pattern `C:/foo/**/*.ts`, the `C:/foo/bar.ts` is not valid altough it is valid in vscode. Since I have seen a lot of usecases about that, I implemented this support **It is now supported.**
 * using `*`, same thing it is not optional. No see usecases for that.

I have written tests for glob pattern but not for the implementation of workspace/didChangeWatchedFiles when a file is created, deleted, moved. It should be nice to write those test in a separate PR.