### PR TITLE
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'file' of com/intellij/openapi/vfs/VfsUtilCore.virtualToIoFile must not be null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationProvider.java
@@ -108,7 +108,7 @@ public class LSPDocumentationProvider extends DocumentationProviderEx implements
                 }
                 editor = LSPIJUtils.editorForElement(originalElement);
                 int targetOffset = getTargetOffset(originalElement);
-                LSPHoverSupport hoverSupport = LSPFileSupport.getSupport(element.getContainingFile()).getHoverSupport();
+                LSPHoverSupport hoverSupport = LSPFileSupport.getSupport(psiFile).getHoverSupport();
                 CompletableFuture<List<MarkupContent>> hoverFuture = hoverSupport.getHover(targetOffset, document);
 
                 try {


### PR DESCRIPTION
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'file' of com/intellij/openapi/vfs/VfsUtilCore.virtualToIoFile must not be null

I have never seen this bug, but the fork from IBM of LSP4IJ has encountered this problem https://github.com/OpenLiberty/liberty-tools-intellij/issues/711

The fix is correct because we need to work with original element.