### PR TITLE
feat: Promote save settings when updating LSP settings

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
@@ -332,6 +332,7 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
         ActionToolbar tb = ActionManager.getInstance().createActionToolbar("LSP Detail", myToolbarActions, false);
         tb.setTargetComponent(detailComponent);
         tb.getComponent().setBorder(JBUI.Borders.merge(tb.getComponent().getBorder(), JBUI.Borders.customLine(OnePixelDivider.BACKGROUND, 0, 0, 0, 1), true));
+        tb.getComponent().setName(ApplyLanguageServerSettingsAction.ACTION_TOOLBAR_COMPONENT_NAME);
         detailComponent.add(tb.getComponent(), BorderLayout.WEST);
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -73,7 +73,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
 
     private void showBalloon() {
         languageServerView.isSaveTipShown(true);
-        JBLabel jbPanel = new JBLabel("Press here to save the changes");
+        JBLabel jbPanel = new JBLabel(LanguageServerBundle.message("action.lsp.detail.apply.balloon"));
 
         BalloonBuilder builder = JBPopupFactory.getInstance()
                 .createBalloonBuilder(jbPanel)

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -17,12 +17,17 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.ui.popup.BalloonBuilder;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.HyperlinkLabel;
 import com.intellij.ui.awt.RelativePoint;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.settings.LanguageServerView;
 import com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings;
@@ -93,7 +98,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
 
         BalloonBuilder builder = JBPopupFactory.getInstance()
                 .createBalloonBuilder(jbPanel)
-                .setFadeoutTime(1600) // How many ms the balloon is shown for
+                .setFadeoutTime(10000) // How many ms the balloon is shown for
                 .setHideOnAction(false);
 
         // Have an instance reference to hide the balloon with the button
@@ -125,16 +130,16 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
     private @NotNull JBPanel<JBPanel> createBalloonPanel(Project project) {
         var jbPanel = new JBPanel<>();
         jbPanel.setLayout(new BoxLayout(jbPanel, BoxLayout.Y_AXIS));
-        JBLabel jbLabel = new JBLabel(LanguageServerBundle.message("action.lsp.detail.apply.balloon"));
-        JButton jButton = new JButton(LanguageServerBundle.message("action.lsp.detail.apply.balloon.disable"));
-
-        jButton.addActionListener(e -> {
+        // For some reason the HyperlinkLabel is indented by a single space
+        JBLabel jbLabel = new JBLabel(" " + LanguageServerBundle.message("action.lsp.detail.apply.balloon"));
+        HyperlinkLabel hyperlinkLabel = new HyperlinkLabel(LanguageServerBundle.message("action.lsp.detail.apply.balloon.disable"));
+        hyperlinkLabel.addHyperlinkListener(e -> {
             UserDefinedLanguageServerSettings.getInstance(project).showSaveTipOnConfigurationChange(false);
             this.saveTipBalloon.hide();
         });
 
         jbPanel.add(jbLabel);
-        jbPanel.add(jButton);
+        jbPanel.add(hyperlinkLabel);
         return jbPanel;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -77,7 +77,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
 
         BalloonBuilder builder = JBPopupFactory.getInstance()
                 .createBalloonBuilder(jbPanel)
-                .setFadeoutTime(800)
+                .setFadeoutTime(800) // How many ms the balloon is shown for
                 .setHideOnAction(false);
 
         Balloon balloon = builder.createBalloon();

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -41,6 +41,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
     public static final String ACTION_TOOLBAR_COMPONENT_NAME = "ActionToolbarComponent";
     private final LanguageServerView languageServerView;
     private Balloon saveTipBalloon;
+    private boolean hasSaveTipBalloonShown = false;
 
     public ApplyLanguageServerSettingsAction(LanguageServerView languageServerView) {
         this.languageServerView = languageServerView;
@@ -59,18 +60,18 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
     @Override
     public void update(@NotNull AnActionEvent e) {
         boolean modified = languageServerView.isModified();
-        boolean isShown = languageServerView.isSaveTipShown();
         var project = e.getProject();
 
         if (project != null) {
-            boolean isSaveTipBalloonDisabled = com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings.getInstance(project).isSaveTipBalloonDisabled();
+            boolean showSaveTipOnConfigurationChange = com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings.getInstance(project).showSaveTipOnConfigurationChange();
             // Only show the tooltip once per configuration change
-            if (modified && !isShown && !isSaveTipBalloonDisabled) {
+            if (modified && !hasSaveTipBalloonShown && showSaveTipOnConfigurationChange) {
+                hasSaveTipBalloonShown = true;
                 showBalloon(project);
             }
             // If configuration is returned to match the unmodified state, reset the tooltip to be shown again
             if (!modified) {
-                languageServerView.isSaveTipShown(false);
+                hasSaveTipBalloonShown = false;
             }
         }
 
@@ -88,7 +89,6 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
      * @param project passed on to the panel creation to create the button's action listener
      */
     private void showBalloon(@NotNull Project project) {
-        languageServerView.isSaveTipShown(true);
         var jbPanel = createBalloonPanel(project);
 
         BalloonBuilder builder = JBPopupFactory.getInstance()
@@ -129,7 +129,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
         JButton jButton = new JButton(LanguageServerBundle.message("action.lsp.detail.apply.balloon.disable"));
 
         jButton.addActionListener(e -> {
-            UserDefinedLanguageServerSettings.getInstance(project).isSaveTipBalloonDisabled(true);
+            UserDefinedLanguageServerSettings.getInstance(project).showSaveTipOnConfigurationChange(false);
             this.saveTipBalloon.hide();
         });
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.ui.popup.BalloonBuilder;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
@@ -24,7 +25,6 @@ import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.settings.LanguageServerView;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
 import java.awt.*;
 
 /**
@@ -100,6 +100,6 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
         RelativePoint displayPoint = new RelativePoint(applyComponent, point);
 
         // Use invokeLater to prevent the balloon from resizing when it is shown
-        SwingUtilities.invokeLater(() -> balloon.show(displayPoint, Balloon.Position.above));
+        ApplicationManager.getApplication().invokeLater(() -> balloon.show(displayPoint, Balloon.Position.above));
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -24,8 +24,11 @@ import com.intellij.ui.components.JBLabel;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.settings.LanguageServerView;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
+import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * Action to update the proper language server settings and language server definition
@@ -71,6 +74,10 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
         return ActionUpdateThread.BGT;
     }
 
+    /**
+     * Create and show a balloon to draw attention to the save button when modifying
+     * configurations in the LSP console
+     */
     private void showBalloon() {
         languageServerView.isSaveTipShown(true);
         JBLabel jbPanel = new JBLabel(LanguageServerBundle.message("action.lsp.detail.apply.balloon"));
@@ -82,18 +89,15 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
 
         Balloon balloon = builder.createBalloon();
 
-        ActionToolbarImpl actionToolbarComponent = null;
         var components = languageServerView.getComponent().getComponents();
-        for (Component component : components) {
-            if (ACTION_TOOLBAR_COMPONENT_NAME.equals(component.getName())) {
-                actionToolbarComponent = (ActionToolbarImpl) component;
-            }
-        }
+        Optional<Component> actionToolbarComponent = Arrays.stream(components)
+                .filter(c -> ACTION_TOOLBAR_COMPONENT_NAME.equals(c.getName()))
+                .findFirst();
 
-        if (actionToolbarComponent == null) {
+        if (actionToolbarComponent.isEmpty()) {
             return;
         }
-        Component applyComponent = actionToolbarComponent.getComponent(0);
+        Component applyComponent = ((ActionToolbarImpl) actionToolbarComponent.get()).getComponent(0);
 
         // Move the position by 1/2 of the component width, because the icon is not centered
         Point point = new Point(applyComponent.getWidth()/2 ,0);

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -82,7 +82,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
 
         Balloon balloon = builder.createBalloon();
 
-        // This is a bit nicer looking, but it would be nice not to rely on correct positions
+        // This is a bit nicer looking, but I think the current is better, because it does not rely on the positions
         // ActionToolbarImpl asd = (ActionToolbarImpl) languageServerView.getComponent().getComponent(1);
 
         ActionToolbarImpl actionToolbarComponent = null;
@@ -98,7 +98,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
         }
         Component applyComponent = actionToolbarComponent.getComponent(0);
 
-        // Move the position by 1/2 of the component width, the icon is not centered
+        // Move the position by 1/2 of the component width, because the icon is not centered
         Point point = new Point(applyComponent.getWidth()/2 ,0);
         RelativePoint displayPoint = new RelativePoint(applyComponent, point);
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -40,6 +40,8 @@ import java.util.Optional;
 public class ApplyLanguageServerSettingsAction extends AnAction {
     public static final String ACTION_TOOLBAR_COMPONENT_NAME = "ActionToolbarComponent";
     private final LanguageServerView languageServerView;
+    private Balloon saveTipBalloon;
+
     public ApplyLanguageServerSettingsAction(LanguageServerView languageServerView) {
         this.languageServerView = languageServerView;
         final String message = LanguageServerBundle.message("action.lsp.detail.apply.text");
@@ -91,10 +93,11 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
 
         BalloonBuilder builder = JBPopupFactory.getInstance()
                 .createBalloonBuilder(jbPanel)
-                .setFadeoutTime(1200) // How many ms the balloon is shown for
+                .setFadeoutTime(1600) // How many ms the balloon is shown for
                 .setHideOnAction(false);
 
-        Balloon balloon = builder.createBalloon();
+        // Have an instance reference to hide the balloon with the button
+        this.saveTipBalloon = builder.createBalloon();
 
         var components = languageServerView.getComponent().getComponents();
         Optional<Component> actionToolbarComponent = Arrays.stream(components)
@@ -111,7 +114,7 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
         RelativePoint displayPoint = new RelativePoint(applyComponent, point);
 
         // Use invokeLater to prevent the balloon from resizing when it is shown
-        ApplicationManager.getApplication().invokeLater(() -> balloon.show(displayPoint, Balloon.Position.above));
+        ApplicationManager.getApplication().invokeLater(() -> this.saveTipBalloon.show(displayPoint, Balloon.Position.above));
     }
 
     /**
@@ -119,13 +122,16 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
      * @param project necessary for updating the settings
      * @return the created JBPanel
      */
-    private static @NotNull JBPanel<JBPanel> createBalloonPanel(Project project) {
+    private @NotNull JBPanel<JBPanel> createBalloonPanel(Project project) {
         var jbPanel = new JBPanel<>();
         jbPanel.setLayout(new BoxLayout(jbPanel, BoxLayout.Y_AXIS));
         JBLabel jbLabel = new JBLabel(LanguageServerBundle.message("action.lsp.detail.apply.balloon"));
         JButton jButton = new JButton(LanguageServerBundle.message("action.lsp.detail.apply.balloon.disable"));
 
-        jButton.addActionListener(e -> UserDefinedLanguageServerSettings.getInstance(project).isSaveTipBalloonDisabled(true));
+        jButton.addActionListener(e -> {
+            UserDefinedLanguageServerSettings.getInstance(project).isSaveTipBalloonDisabled(true);
+            this.saveTipBalloon.hide();
+        });
 
         jbPanel.add(jbLabel);
         jbPanel.add(jButton);

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -82,9 +82,6 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
 
         Balloon balloon = builder.createBalloon();
 
-        // This is a bit nicer looking, but I think the current is better, because it does not rely on the positions
-        // ActionToolbarImpl asd = (ActionToolbarImpl) languageServerView.getComponent().getComponent(1);
-
         ActionToolbarImpl actionToolbarComponent = null;
         var components = languageServerView.getComponent().getComponents();
         for (Component component : components) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/actions/ApplyLanguageServerSettingsAction.java
@@ -23,11 +23,13 @@ import com.intellij.ui.awt.RelativePoint;
 import com.intellij.ui.components.JBLabel;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.settings.LanguageServerView;
+import com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -35,7 +37,6 @@ import java.util.Optional;
  * from the UI language server view fields.
  */
 public class ApplyLanguageServerSettingsAction extends AnAction {
-
     public static final String ACTION_TOOLBAR_COMPONENT_NAME = "ActionToolbarComponent";
     private final LanguageServerView languageServerView;
     public ApplyLanguageServerSettingsAction(LanguageServerView languageServerView) {
@@ -56,9 +57,9 @@ public class ApplyLanguageServerSettingsAction extends AnAction {
     public void update(@NotNull AnActionEvent e) {
         boolean modified = languageServerView.isModified();
         boolean isShown = languageServerView.isSaveTipShown();
-
+        boolean isSaveTipBalloonDisabled = com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings.getInstance(Objects.requireNonNull(e.getProject())).isSaveTipBalloonDisabled();
         // Only show the tooltip once per configuration change
-        if (modified && !isShown) {
+        if (modified && !isShown && !isSaveTipBalloonDisabled) {
             showBalloon();
         }
         // If configuration is returned to match the unmodified state, reset the tooltip to be shown again

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
@@ -60,6 +60,7 @@ public class LanguageServerView implements Disposable {
     private final JPanel myMainPanel;
     private final LanguageServerDefinition languageServerDefinition;
     private final Project project;
+    private boolean isSaveTipShown = false;
 
     private LanguageServerPanel languageServerPanel;
 
@@ -416,5 +417,13 @@ public class LanguageServerView implements Disposable {
      */
     public boolean isEditingCommand() {
         return languageServerPanel.getCommandLine() != null && languageServerPanel.getCommandLine().hasFocus();
+    }
+
+    public boolean isSaveTipShown() {
+        return isSaveTipShown;
+    }
+
+    public void isSaveTipShown(boolean isSaveTipShown) {
+        this.isSaveTipShown = isSaveTipShown;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
@@ -419,10 +419,20 @@ public class LanguageServerView implements Disposable {
         return languageServerPanel.getCommandLine() != null && languageServerPanel.getCommandLine().hasFocus();
     }
 
+    /**
+     * Tells whether the save tip balloon has been shown for this language server view
+     *
+     * @return true if save tip has been shown, else false
+     */
     public boolean isSaveTipShown() {
-        return isSaveTipShown;
+        return this.isSaveTipShown;
     }
 
+    /**
+     * Set the value of isSaveTipShown variable, enabling or preventing the save tip balloon from showing
+     *
+     * @param isSaveTipShown true if shown and false if it hasn't been shown
+     */
     public void isSaveTipShown(boolean isSaveTipShown) {
         this.isSaveTipShown = isSaveTipShown;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
@@ -60,7 +60,6 @@ public class LanguageServerView implements Disposable {
     private final JPanel myMainPanel;
     private final LanguageServerDefinition languageServerDefinition;
     private final Project project;
-    private boolean isSaveTipShown = false;
 
     private LanguageServerPanel languageServerPanel;
 
@@ -417,23 +416,5 @@ public class LanguageServerView implements Disposable {
      */
     public boolean isEditingCommand() {
         return languageServerPanel.getCommandLine() != null && languageServerPanel.getCommandLine().hasFocus();
-    }
-
-    /**
-     * Tells whether the save tip balloon has been shown for this language server view
-     *
-     * @return true if save tip has been shown, else false
-     */
-    public boolean isSaveTipShown() {
-        return this.isSaveTipShown;
-    }
-
-    /**
-     * Set the value of isSaveTipShown variable, enabling or preventing the save tip balloon from showing
-     *
-     * @param isSaveTipShown true if shown and false if it hasn't been shown
-     */
-    public void isSaveTipShown(boolean isSaveTipShown) {
-        this.isSaveTipShown = isSaveTipShown;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
@@ -172,10 +172,19 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
         }
     }
 
+    /**
+     * Tells whether the user has disabled the save tip balloon from showing
+     * @return true if the balloon is disabled and not shown, false otherwise
+     */
     public boolean isSaveTipBalloonDisabled() {
         return this.myState.isSaveTipBalloonDisabled;
     }
 
+    /**
+     * Sets the value if the save tip balloon should be shown
+     * There is no way to set this value to false at the moment, it can only be disabled
+     * @param value true if the balloon should be disabled and not shown, false if it should be shown
+     */
     public void isSaveTipBalloonDisabled(boolean value) {
         this.myState.isSaveTipBalloonDisabled = value;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
@@ -172,6 +172,14 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
         }
     }
 
+    public boolean isSaveTipBalloonDisabled() {
+        return this.myState.isSaveTipBalloonDisabled;
+    }
+
+    public void isSaveTipBalloonDisabled(boolean value) {
+        this.myState.isSaveTipBalloonDisabled = value;
+    }
+
     public static class LanguageServerDefinitionSettings {
 
         private String debugPort;
@@ -227,6 +235,7 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
         MyState() {
         }
 
+        private boolean isSaveTipBalloonDisabled = false;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
@@ -173,20 +173,20 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
     }
 
     /**
-     * Tells whether the user has disabled the save tip balloon from showing
-     * @return true if the balloon is disabled and not shown, false otherwise
+     * Tells whether the save tip balloon is shown when changing language server configuration
+     * @return true if the balloon should be shown, false otherwise
      */
-    public boolean isSaveTipBalloonDisabled() {
-        return this.myState.isSaveTipBalloonDisabled;
+    public boolean showSaveTipOnConfigurationChange() {
+        return this.myState.showSaveTipOnConfigurationChange;
     }
 
     /**
-     * Sets the value if the save tip balloon should be shown
-     * There is no way to set this value to false at the moment, it can only be disabled
-     * @param value true if the balloon should be disabled and not shown, false if it should be shown
+     * Sets the value if the save tip balloon should be shown on language server configuration change
+     * There is no way to set this value to true at the moment, it can only be disabled
+     * @param value true if the balloon should be shown, false otherwise
      */
-    public void isSaveTipBalloonDisabled(boolean value) {
-        this.myState.isSaveTipBalloonDisabled = value;
+    public void showSaveTipOnConfigurationChange(boolean value) {
+        this.myState.showSaveTipOnConfigurationChange = value;
     }
 
     public static class LanguageServerDefinitionSettings {
@@ -244,7 +244,7 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
         MyState() {
         }
 
-        private boolean isSaveTipBalloonDisabled = false;
+        private boolean showSaveTipOnConfigurationChange = true;
     }
 
     /**

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -86,6 +86,7 @@ action.lsp.console.new.language.server.description=Open dialog to create a new l
 action.lsp.detail.apply.text=Apply
 action.lsp.detail.apply.description=Apply changes for this language server settings
 action.lsp.detail.apply.balloon=Press here to save the settings
+action.lsp.detail.apply.balloon.disable=Got it
 action.lsp.detail.reset.text=Reset
 action.lsp.detail.reset.description=Rollback changes for this language server settings
 ## Dialog

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -85,6 +85,7 @@ action.lsp.console.new.language.server.text=New language server
 action.lsp.console.new.language.server.description=Open dialog to create a new language server
 action.lsp.detail.apply.text=Apply
 action.lsp.detail.apply.description=Apply changes for this language server settings
+action.lsp.detail.apply.balloon=Press here to save the settings
 action.lsp.detail.reset.text=Reset
 action.lsp.detail.reset.description=Rollback changes for this language server settings
 ## Dialog


### PR DESCRIPTION
Here a demo:

![ShowBalloon](https://github.com/redhat-developer/lsp4ij/assets/1932211/f9fae429-b19a-41a4-bf80-293947fecc72)


![image](https://github.com/redhat-developer/lsp4ij/assets/55958056/b345beff-4fde-40ed-b033-3dea480bff13)

To make the save button more clear to use, create a balloon when updating the settings pointing to the save button/icon. The balloon is shown once every time the settings are changed from an unmodified state.

I'm wondering if the naming/component fetching can be done better
- the applyComponent is still fetched using the index
- not sure if adding the ACTION_TOOLBAR_COMPONENT_NAME to ApplyLanguageServerSettingsAction is the cleanest option, but I think it is better than using `getComponent(n)`

Currently missing from this PR is the possibility to have the balloon not show up any more