### PR TITLE
fix: Details pane in consoles view is not removed after deleting the last LS

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
@@ -125,6 +125,18 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
     }
 
     /**
+     * Remove the detail, console panel of the given language server tree node.
+     *
+     * @param serverTreeNode the language server tree node.
+     */
+    public void removeConsolePanel(LanguageServerTreeNode serverTreeNode) {
+        if (consoles == null || isDisposed()) {
+            return;
+        }
+        consoles.dispose(serverTreeNode);
+    }
+
+    /**
      * A card-panel that displays panels for each language server instances.
      */
     private class ConsolesPanel extends CardLayoutPanel<DefaultMutableTreeNode, DefaultMutableTreeNode, ConsoleContentPanel> {
@@ -151,6 +163,25 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
         protected void dispose(DefaultMutableTreeNode key, ConsoleContentPanel value) {
             if (value != null) {
                 value.dispose();
+            }
+        }
+
+        /**
+         * Remove the detail, console panel of the given language server tree node.
+         *
+         * @param key the language server or process tree node.
+         */
+        public void dispose(@NotNull DefaultMutableTreeNode key) {
+            var value = super.getValue(key, false);
+            if (value != null) {
+                // Remove the detail panel of the language server
+                value.dispose();
+            }
+            // Remove the console panel of the language server (processes)
+            for (int i = 0; i <  key.getChildCount(); i++) {
+                if (key.getChildAt(i) instanceof DefaultMutableTreeNode treeNode) {
+                    dispose(treeNode);
+                }
             }
         }
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorer.java
@@ -75,7 +75,11 @@ public class LanguageServerExplorer extends SimpleToolWindowPanel implements Dis
             for (var serverDefinition : event.serverDefinitions) {
                 LanguageServerTreeNode node = findNodeForServer(serverDefinition, root);
                 if (node != null) {
+                    // Remove the language server definition from the tree
                     root.remove(node);
+                    // Remove the detail, console panel (on the right) of the language server
+                    removeConsolePanel(node);
+
                 }
             }
             treeModel.reload(root);
@@ -266,6 +270,15 @@ public class LanguageServerExplorer extends SimpleToolWindowPanel implements Dis
 
     public void showError(LanguageServerProcessTreeNode processTreeNode, Throwable exception) {
         panel.showError(processTreeNode, exception);
+    }
+
+    /**
+     * Remove the detail, console panel of the given language server tree node.
+     *
+     * @param serverTreeNode the language server tree node.
+     */
+    public void removeConsolePanel(LanguageServerTreeNode serverTreeNode) {
+        panel.removeConsolePanel(serverTreeNode);
     }
 
     public DefaultTreeModel getTreeModel() {


### PR DESCRIPTION
fix: Details pane in consoles view is not removed after deleting the last LS

Fixes #220