### PR TITLE
fix: Infinite completionItem/resolve when documentation for completion returns nothing

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileSupport.java
@@ -16,6 +16,7 @@ import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.features.codeAction.intention.LSPIntentionCodeActionSupport;
 import com.redhat.devtools.lsp4ij.features.codeLens.LSPCodeLensSupport;
 import com.redhat.devtools.lsp4ij.features.color.LSPColorSupport;
+import com.redhat.devtools.lsp4ij.features.completion.LSPCompletionSupport;
 import com.redhat.devtools.lsp4ij.features.documentLink.LSPDocumentLinkSupport;
 import com.redhat.devtools.lsp4ij.features.documentation.LSPHoverSupport;
 import com.redhat.devtools.lsp4ij.features.foldingRange.LSPFoldingRangeSupport;
@@ -60,6 +61,8 @@ public class LSPFileSupport implements Disposable {
 
     private final LSPRenameSupport renameSupport;
 
+    private final LSPCompletionSupport completionSupport;
+
     private LSPFileSupport(@NotNull PsiFile file) {
         this.file = file;
         this.codeLensSupport = new LSPCodeLensSupport(file);
@@ -74,6 +77,7 @@ public class LSPFileSupport implements Disposable {
         this.intentionCodeActionSupport = new LSPIntentionCodeActionSupport(file);
         this.prepareRenameSupport = new LSPPrepareRenameSupport(file);
         this.renameSupport = new LSPRenameSupport(file);
+        this.completionSupport = new LSPCompletionSupport(file);
         file.putUserData(LSP_FILE_SUPPORT_KEY, this);
     }
 
@@ -93,6 +97,7 @@ public class LSPFileSupport implements Disposable {
         getIntentionCodeActionSupport().cancel();
         getPrepareRenameSupport().cancel();
         getRenameSupport().cancel();
+        getCompletionSupport().cancel();
     }
 
     /**
@@ -203,6 +208,14 @@ public class LSPFileSupport implements Disposable {
         return renameSupport;
     }
 
+    /**
+     * Returns the LSP completion support.
+     *
+     * @return the LSP completion support.
+     */
+    public LSPCompletionSupport getCompletionSupport() {
+        return completionSupport;
+    }
 
     /**
      * Return the existing LSP file support for the given Psi file, or create a new one if necessary.

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -623,14 +623,6 @@ public class LSPIJUtils {
         return EditorFactory.getInstance().getEditors(document, project);
     }
 
-    public static CompletionParams toCompletionParams(URI fileUri, int offset, Document document) {
-        Position start = toPosition(offset, document);
-        CompletionParams param = new CompletionParams();
-        param.setPosition(start);
-        param.setTextDocument(toTextDocumentIdentifier(fileUri));
-        return param;
-    }
-
     public static TextDocumentIdentifier toTextDocumentIdentifier(VirtualFile file) {
         return toTextDocumentIdentifier(toUri(file));
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPRequestConstants.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPRequestConstants.java
@@ -44,6 +44,7 @@ public class LSPRequestConstants {
     public static final String TEXT_DOCUMENT_SIGNATURE_HELP = "textDocument/signatureHelp";
     public static final String TEXT_DOCUMENT_PREPARE_RENAME = "textDocument/prepareRename";
     public static final String TEXT_DOCUMENT_RENAME = "textDocument/rename";
+    public static final String TEXT_DOCUMENT_DOCUMENT_COMPLETION = "textDocument/completion";
 
     private LSPRequestConstants() {
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionData.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionData.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * LSP completion data.
+ *
+ * @param completion               the LSP completion result
+ * @param languageServer         the language server which has created the completion result.
+ */
+record CompletionData(@NotNull Either<List<CompletionItem>, CompletionList> completion,
+                      @NotNull LanguageServerItem languageServer) {
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionPrefix.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionPrefix.java
@@ -60,7 +60,8 @@ public class CompletionPrefix {
      * @param item          the completion item.
      * @return the proper prefix from the given text range and label/filterText defined in the given completion item and null otherwise.
      */
-    public @Nullable String getPrefixFor(@NotNull Range textEditRange, CompletionItem item) {
+    public @Nullable String getPrefixFor(@NotNull Range textEditRange,
+                                         @NotNull CompletionItem item) {
         // Try to get the computed prefix from the cache
         String prefix = prefixCache.get(textEditRange);
         if (prefix == null && !prefixCache.containsKey(textEditRange)) {
@@ -101,7 +102,7 @@ public class CompletionPrefix {
         return prefix;
     }
 
-    private static String getAccurateFilterText(CompletionItem item) {
+    private static String getAccurateFilterText(@NotNull CompletionItem item) {
         String filterText = item.getFilterText();
         if (StringUtils.isBlank(filterText)) {
             return null;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionParams.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionParams.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+/**
+ * LSP completion parameters which hosts the offset where completion has been triggered.
+ */
+public class LSPCompletionParams extends CompletionParams {
+
+    // Use transient to avoid serializing the fields when GSON will be processed
+    private transient final int offset;
+
+    public LSPCompletionParams(TextDocumentIdentifier textDocument, Position position, int offset) {
+        super.setTextDocument(textDocument);
+        super.setPosition(position);
+        this.offset = offset;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionSupport.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
+import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
+import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
+import org.eclipse.lsp4j.CompletionParams;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * LSP Completion support which loads and caches Completion information by consuming:
+ *
+ * <ul>
+ *     <li>LSP 'textDocument/completion' requests</li>
+ * </ul>
+ */
+public class LSPCompletionSupport extends AbstractLSPFeatureSupport<LSPCompletionParams, List<CompletionData>> {
+
+    private Integer previousOffset;
+    public LSPCompletionSupport(@NotNull PsiFile file) {
+        super(file);
+    }
+
+    public CompletableFuture<List<CompletionData>> getCompletions(LSPCompletionParams params) {
+        int offset = params.getOffset();
+        if (previousOffset != null && !previousOffset.equals(offset)) {
+            super.cancel();
+        }
+        previousOffset = offset;
+        return super.getFeatureData(params);
+    }
+
+    @Override
+    protected CompletableFuture<List<CompletionData>> doLoad(@NotNull LSPCompletionParams params,
+                                                             @NotNull CancellationSupport cancellationSupport) {
+        PsiFile file = super.getFile();
+        return getCompletions(file.getVirtualFile(), file.getProject(), params, cancellationSupport);
+    }
+
+    private static @NotNull CompletableFuture<List<CompletionData>> getCompletions(@NotNull VirtualFile file,
+                                                                              @NotNull Project project,
+                                                                              @NotNull LSPCompletionParams params,
+                                                                              @NotNull CancellationSupport cancellationSupport) {
+
+        return LanguageServiceAccessor.getInstance(project)
+                .getLanguageServers(file, LanguageServerItem::isCompletionSupported)
+                .thenComposeAsync(languageServers -> {
+                    // Here languageServers is the list of language servers which matches the given file
+                    // and which have completion capability
+                    if (languageServers.isEmpty()) {
+                        return CompletableFuture.completedFuture(Collections.emptyList());
+                    }
+
+                    // Collect list of textDocument/completion future for each language servers
+                    List<CompletableFuture<List<CompletionData>>> completionPerServerFutures = languageServers
+                            .stream()
+                            .map(languageServer -> getCompletionsFor(params, languageServer, cancellationSupport))
+                            .toList();
+
+                    // Merge list of textDocument/completion future in one future which return the list of completion items
+                    return CompletableFutures.mergeInOneFuture(completionPerServerFutures, cancellationSupport);
+                });
+    }
+
+    private static CompletableFuture<List<CompletionData>> getCompletionsFor(@NotNull CompletionParams params,
+                                                                        @NotNull LanguageServerItem languageServer,
+                                                                        @NotNull CancellationSupport cancellationSupport) {
+        return cancellationSupport.execute(languageServer
+                        .getTextDocumentService()
+                        .completion(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DOCUMENT_COMPLETION)
+                .thenApplyAsync(result -> {
+                    if (result == null) {
+                        // textDocument/completion may return null
+                        return Collections.emptyList();
+                    }
+                    return List.of(new CompletionData(result, languageServer));
+                });
+    }
+
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/SupportedFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/SupportedFeatures.java
@@ -58,7 +58,11 @@ public class SupportedFeatures {
                 .setDocumentationFormat(List.of(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
         completionItemCapabilities.setInsertTextModeSupport(new CompletionItemInsertTextModeSupportCapabilities(List.of(InsertTextMode.AsIs, InsertTextMode.AdjustIndentation)));
 
-        completionItemCapabilities.setResolveSupport(new CompletionItemResolveSupportCapabilities(List.of("documentation" /*, "detail", "additionalTextEdits" */)));
+        completionItemCapabilities.setResolveSupport(new CompletionItemResolveSupportCapabilities(
+                List.of(
+                        "documentation" ,
+                        "detail",
+                        "additionalTextEdits" )));
         CompletionCapabilities completionCapabilities = new CompletionCapabilities(completionItemCapabilities);
         completionCapabilities.setCompletionList(new CompletionListCapabilities(List.of("editRange")));
         textDocumentClientCapabilities.setCompletion(completionCapabilities);


### PR DESCRIPTION
fix: Infinite completionItem/resolve when documentation for completion returns nothing

Fixes #182

This PR:

 * uses now LSPCompletionSupport pattern to cancel  the future when file is closed and cache the value if offset has not changed
 * fix the infinite loop
 * resolve 'detail' and 'additionaltextEdits'.

For resolving 'detail', you can see that in action with TypeScript LS:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/4f45ffa9-30d2-4164-998f-73c688ec5cbd)

The only annoying thing is that `completionItem/resolve` is called for all completion items. It should be called just for the selected completion item but I don't know how to do that in IJ.

It seems performance are good with TypeScript LS, we can keep that and improve it in the future if we see some performance problems. vscode does that, it display detail only for the selected item:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/d309e44c-660d-4458-9034-113859649ed7)

