### PR TITLE
feat: When rename does nothing, notify it with a message

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPPrepareRenameSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPPrepareRenameSupport.java
@@ -106,7 +106,8 @@ public class LSPPrepareRenameSupport extends AbstractLSPFeatureSupport<LSPPrepar
                                                                                          @NotNull CancellationSupport cancellationSupport) {
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
-                        .prepareRename(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_PREPARE_RENAME)
+                        .prepareRename(params), languageServer.getServerWrapper(), LSPRequestConstants.TEXT_DOCUMENT_PREPARE_RENAME,
+                        false /* if prepare name throws an error, the error must not be displayed as notification but as hint in the editor  */)
                 .thenApplyAsync(prepareRename -> {
                     PrepareRenameResultData result = getPrepareRenameResultData(defaultPrepareRenameResultProvider, languageServer, prepareRename);
                     return result!= null ? List.of(result) : Collections.emptyList();

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -128,4 +128,8 @@ lsp.intention.code.action.kind.empty=Empty
 # LSP Rename
 lsp.refactor.rename.symbol.dialog.title=Rename ''{0}'' Symbol to:
 lsp.refactor.rename.symbol.handler.title=Rename LSP Symbol
+lsp.refactor.rename.language.server.not.ready=Rename... is not available during language servers starting.
 lsp.refactor.rename.cannot.be.renamed.error=The element can't be renamed.
+lsp.refactor.rename.prepare.error=Error while preparing rename: {0}
+lsp.refactor.rename.process.error=Error while renaming: {0}
+


### PR DESCRIPTION
feat: When rename does nothing, notify it with a message

Fixes #217

This PR show errors when 

 * language server is starting, as we wait for 200ms to get the rename capability, there is a TimeOutException which is thrown (the server is not ready). In this case we display the hint error:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/8b330bf8-5241-4356-a593-2de8d8501512)

 * prepare rename fails (ex: Clojure LS) 

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/4041df55-f4d3-4899-ad3a-13f937c7154e)

 * or after a rename process done with a dialog

In this case:

 * when language server throws an error when rename is consumes, the error is not display as hint (try to rename import with go ls), you can see no identifier found as error which comes from the go ls:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/b810f33d-6bc2-4452-909c-6a6fe240a99e)

another error with go ls:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/2b2e0290-6ff9-40c7-9079-48ea7b6c491c)

 * when language server returns an empty workspaceedit instead of throwing error, there is thisgeneric message (ex : with TypeScript LS):

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/38744127-3602-4b92-a58f-c44578d305fb)
