### PR TITLE
test: Add tests for LSPIJUtils#toPosition

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -292,12 +292,17 @@ public class LSPIJUtils {
         return Math.min(offset, lineEndOffset);
     }
 
-    public static Position toPosition(int offset, Document document) {
+    /**
+     * Returns the LSP position from the given offset in teh given document.
+     * @param offset the offset.
+     * @param document the document.
+     * @return the LSP position from the given offset in teh given document.
+     */
+    @NotNull
+    public static Position toPosition(int offset, @NotNull Document document) {
         int line = document.getLineNumber(offset);
-        int lineStart = document.getLineStartOffset(line);
-        String lineTextBeforeOffset = document.getText(new TextRange(lineStart, offset));
-        int column = lineTextBeforeOffset.length();
-        return new Position(line, column);
+        int character = offset - document.getLineStartOffset(line);
+        return new Position(line, character);
     }
 
     @NotNull

--- a/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_getTokenRangeTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_getTokenRangeTest.java
@@ -73,12 +73,12 @@ public class LSPIJUtils_getTokenRangeTest extends BasePlatformTestCase {
     }
 
     private static void assertTokenRange(final String contentWithOffset, String expected) {
-        int offset = contentWithOffset.indexOf('|');
-        String content = contentWithOffset.substring(0, offset) + contentWithOffset.substring(offset + 1);
+        TextAndOffset textAndOffset = new TextAndOffset(contentWithOffset);
+        String content = textAndOffset.getContent();
         Document document = new DocumentImpl(content);
-        TextRange textRange = LSPIJUtils.getTokenRange(document, offset);
+        TextRange textRange = LSPIJUtils.getTokenRange(document, textAndOffset.getOffset());
         if (expected == null) {
-            assertNull("TextRange should be null",textRange);
+            assertNull("TextRange should be null", textRange);
             return;
         }
 

--- a/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_toPositionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_toPositionTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.impl.DocumentImpl;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.eclipse.lsp4j.Position;
+
+/**
+ * Tests for {@link LSPIJUtils#toPosition(int, Document)}.
+ */
+public class LSPIJUtils_toPositionTest extends BasePlatformTestCase {
+
+    public void testSingleLine() {
+        assertPosition("|foo", 0, 0);
+        assertPosition("f|oo", 0, 1);
+        assertPosition("fo|o", 0, 2);
+        assertPosition("foo|", 0, 3);
+    }
+
+    public void testMultiLine() {
+        assertPosition("bar\n|foo", 1, 0);
+        assertPosition("bar\nf|oo", 1, 1);
+        assertPosition("bar\nfo|o", 1, 2);
+        assertPosition("bar\nfoo|", 1, 3);
+    }
+
+    public static void assertPosition(String contentWithOffset, int expectedLine, int expectedCharacter) {
+        TextAndOffset textAndOffset = new TextAndOffset(contentWithOffset);
+        assertPosition(textAndOffset.getContent(), textAndOffset.getOffset(), expectedLine, expectedCharacter);
+    }
+
+    public static void assertPosition(String content, int offset, int expectedLine, int expectedCharacter) {
+        Document document = new DocumentImpl(content);
+        Position expectedPosition = new Position(expectedLine, expectedCharacter);
+        Position actualPosition = LSPIJUtils.toPosition(offset, document);
+        assertEquals(expectedPosition, actualPosition);
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/TextAndOffset.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/TextAndOffset.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+/**
+ * Parse content/offset which uses '|' to mark an offset.
+ */
+public class TextAndOffset {
+
+    private final int offset;
+    private final String content;
+
+    public TextAndOffset(String contentWithOffset) {
+        this.offset = contentWithOffset.indexOf('|');
+        this.content = contentWithOffset.substring(0, offset) + contentWithOffset.substring(offset + 1);
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}


### PR DESCRIPTION
This PR simplify the LSPIJUtils#toPosition by avoiding computing a text range and add tests.
