### PR TITLE
fix: don't process prepare rename / rename in EDT to avoid freezing IJ

### DIFF
--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -130,6 +130,9 @@ lsp.refactor.rename.symbol.dialog.title=Rename ''{0}'' Symbol to:
 lsp.refactor.rename.symbol.handler.title=Rename LSP Symbol
 lsp.refactor.rename.language.server.not.ready=Rename... is not available during language servers starting.
 lsp.refactor.rename.cannot.be.renamed.error=The element can't be renamed.
+lsp.refactor.rename.prepare.progress.title=Prepare renaming for ''{0}'' file at {1} offset...
 lsp.refactor.rename.prepare.error=Error while preparing rename: {0}
+lsp.refactor.rename.progress.title=Renaming ''{0}'' file with ''{0}'' new name...
 lsp.refactor.rename.process.error=Error while renaming: {0}
+
 


### PR DESCRIPTION
fix: don't process prepare rename / rename in EDT to avoid freezing IJ