### PR TITLE
fix: inject env variables to LS process builder, run in shell

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -952,12 +952,13 @@ public class LanguageServerWrapper implements Disposable {
         return serverDefinition.isSingleton();
     }
 
-    private LanguageServerLifecycleManager getLanguageServerLifecycleManager() {
+    private @NotNull LanguageServerLifecycleManager getLanguageServerLifecycleManager() {
         Project project = initialProject;
         if (project.isDisposed()) {
             return NullLanguageServerLifecycleManager.INSTANCE;
         }
-        return LanguageServerLifecycleManager.getInstance(project);
+        var manager = LanguageServerLifecycleManager.getInstance(project);
+        return manager == null? NullLanguageServerLifecycleManager.INSTANCE : manager;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/ProcessStreamConnectionProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/ProcessStreamConnectionProvider.java
@@ -10,12 +10,10 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.server;
 
+import com.intellij.util.EnvironmentUtil;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.List;
 import java.util.Objects;
 
@@ -48,8 +46,7 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
         }
         ProcessBuilder builder = createProcessBuilder();
         try {
-            Process p = builder.start();
-            this.process = p;
+            this.process = builder.start();
         } catch (IOException e) {
             throw new CannotStartProcessException(e);
         }
@@ -57,7 +54,7 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
 
     @Override
     public boolean isAlive() {
-        return process != null ? process.isAlive() : false;
+        return process != null && process.isAlive();
     }
 
     @Override
@@ -77,6 +74,7 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
 
     protected ProcessBuilder createProcessBuilder() {
         ProcessBuilder builder = new ProcessBuilder(getCommands());
+        builder.environment().putAll(EnvironmentUtil.getEnvironmentMap());
         if (getWorkingDirectory() != null) {
             builder.directory(new File(getWorkingDirectory()));
         }
@@ -142,10 +140,9 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
         if (obj == null) {
             return false;
         }
-        if (!(obj instanceof ProcessStreamConnectionProvider)) {
+        if (!(obj instanceof ProcessStreamConnectionProvider other)) {
             return false;
         }
-        ProcessStreamConnectionProvider other = (ProcessStreamConnectionProvider) obj;
         return Objects.equals(this.getCommands(), other.getCommands())
                 && Objects.equals(this.getWorkingDirectory(), other.getWorkingDirectory());
     }

--- a/src/main/resources/templates/template-ls.json
+++ b/src/main/resources/templates/template-ls.json
@@ -37,7 +37,8 @@
       "id": "gopls",
       "name": "Go Language Server",
       "programArgs": {
-        "default": "gopls -mode=stdio"
+        "default": "sh -c gopls -mode=stdio",
+        "windows": "gopls -mode=stdio"
       },
       "fileTypeMappings": [
         {
@@ -256,7 +257,8 @@
       "name": "Rust Language Server",
       "dev": true,
       "programArgs": {
-        "default": "rust-analyzer"
+        "default": "sh -c rust-analyzer",
+        "windows": "rust-analyzer"
       },
       "fileTypeMappings": [
         {


### PR DESCRIPTION
When running user defined LS, if the IDE has not been started from a terminal, the proper environment variables are missing, leading to programs usually found in PATH to be missing.
<img width="1155" alt="Screenshot 2024-04-19 at 18 30 30" src="https://github.com/redhat-developer/lsp4ij/assets/148698/de5ce152-c267-4cfb-a554-310dde28c5b0">

The patch injects them into the ProcessBuilder of the LS command.

Signed-off-by: Fred Bricon <fbricon@gmail.com>
