### PR TITLE
feat: Support for window/showDocument

### DIFF
--- a/docs/LSPSupport.md
+++ b/docs/LSPSupport.md
@@ -97,7 +97,7 @@ Current state of [Window Features]( https://microsoft.github.io/language-server-
  * ✅ [window/showMessage](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessage). (see [implementation details](#show-message))
  * ✅ [window/showMessageRequest](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest) (see [implementation details](#show-message-request))
  * ❌ [window/logMessage](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage).
- * ❌ [window/showDocument](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument).
+ * ✅ [window/showDocument](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument).
  * ❌ [telemetry/event](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#telemetry_event).
 
 ## Implementation details

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -72,7 +72,8 @@ public class LSPIJUtils {
      * @param project  the project.
      * @return true if the file was opened and false otherwise.
      */
-    public static boolean openInEditor(@Nullable Location location, @NotNull Project project) {
+    public static boolean openInEditor(@Nullable Location location,
+                                       @NotNull Project project) {
         if (location == null) {
             return false;
         }
@@ -87,9 +88,27 @@ public class LSPIJUtils {
      * @param project  the project.
      * @return true if the file was opened and false otherwise.
      */
-    public static boolean openInEditor(@NotNull String fileUri, @Nullable Position position, @NotNull Project project) {
+    public static boolean openInEditor(@NotNull String fileUri,
+                                       @Nullable Position position,
+                                       @NotNull Project project) {
+        return openInEditor(fileUri, position, true, project);
+    }
+
+    /**
+     * Open the given fileUri with the given position in an editor.
+     *
+     * @param fileUri     the file Uri.
+     * @param position    the position.
+     * @param focusEditor true if editor will take the focus and false otherwise.
+     * @param project     the project.
+     * @return true if the file was opened and false otherwise.
+     */
+    public static boolean openInEditor(@NotNull String fileUri,
+                                       @Nullable Position position,
+                                       boolean focusEditor,
+                                       @NotNull Project project) {
         VirtualFile file = findResourceFor(fileUri);
-        return openInEditor(file, position, project);
+        return openInEditor(file, position, focusEditor, project);
     }
 
     /**
@@ -100,7 +119,25 @@ public class LSPIJUtils {
      * @param project  the project.
      * @return true if the file was opened and false otherwise.
      */
-    public static boolean openInEditor(@Nullable VirtualFile file, @Nullable Position position, @NotNull Project project) {
+    public static boolean openInEditor(@Nullable VirtualFile file,
+                                       @Nullable Position position,
+                                       @NotNull Project project) {
+        return openInEditor(file, position, true, project);
+    }
+
+    /**
+     * Open the given file with the given position in an editor.
+     *
+     * @param file        the file.
+     * @param position    the position.
+     * @param focusEditor true if editor will take the focus and false otherwise.
+     * @param project     the project.
+     * @return true if the file was opened and false otherwise.
+     */
+    public static boolean openInEditor(@Nullable VirtualFile file,
+                                       @Nullable Position position,
+                                       boolean focusEditor,
+                                       @NotNull Project project) {
         if (file != null) {
             if (position == null) {
                 return FileEditorManager.getInstance(project).openFile(file, true).length > 0;
@@ -108,7 +145,7 @@ public class LSPIJUtils {
                 Document document = FileDocumentManager.getInstance().getDocument(file);
                 if (document != null) {
                     OpenFileDescriptor desc = new OpenFileDescriptor(project, file, LSPIJUtils.toOffset(position, document));
-                    return FileEditorManager.getInstance(project).openTextEditor(desc, true) != null;
+                    return FileEditorManager.getInstance(project).openTextEditor(desc, focusEditor) != null;
                 }
             }
         }
@@ -297,7 +334,8 @@ public class LSPIJUtils {
 
     /**
      * Returns the LSP position from the given offset in teh given document.
-     * @param offset the offset.
+     *
+     * @param offset   the offset.
      * @param document the document.
      * @return the LSP position from the given offset in teh given document.
      */

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -85,6 +85,11 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     }
 
     @Override
+    public CompletableFuture<ShowDocumentResult> showDocument(ShowDocumentParams params) {
+        return ServerMessageHandler.showDocument(params, getProject());
+    }
+
+    @Override
     public final void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
         this.diagnosticHandler.accept(diagnostics);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/SupportedFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/SupportedFeatures.java
@@ -203,13 +203,13 @@ public class SupportedFeatures {
 
     public static WindowClientCapabilities getWindowClientCapabilities() {
         final var windowClientCapabilities = new WindowClientCapabilities();
-        //windowClientCapabilities.setShowDocument(new ShowDocumentCapabilities(true));
+        windowClientCapabilities.setShowDocument(new ShowDocumentCapabilities(true));
         /**
          * LSP4IJ supports server initiated progress using the
          * `window/workDoneProgress/create` request.
          */
         windowClientCapabilities.setWorkDoneProgress(true);
-        //windowClientCapabilities.setShowMessage(new WindowShowMessageRequestCapabilities());
+        windowClientCapabilities.setShowMessage(new WindowShowMessageRequestCapabilities());
         return windowClientCapabilities;
     }
 


### PR DESCRIPTION
feat: Support for window/showDocument

Fixes #237

You can test this PR with Clojure LSP with `Create Test` code action:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/37c84915-1a6e-4ebe-860b-f0fa6065363d)

This code action generate the test file and after that `window/showDocument` is called to open the generated file:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/bf93d4da-1263-4b6e-a0df-19cb2632ae59)
