### PR TITLE
fix: Quarkus codeLens url are never shown

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/AbstractDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/AbstractDocumentMatcher.java
@@ -45,9 +45,6 @@ public abstract class AbstractDocumentMatcher implements DocumentMatcher {
         if (ApplicationManager.getApplication().isUnitTestMode()) {
             return false;
         }
-        if (!ApplicationManager.getApplication().isReadAccessAllowed()) {
-            return true;
-        }
         return DumbService.getInstance(project).isDumb();
     }
 }


### PR DESCRIPTION
The Quarkus URL codelens are never shown since it delegate the computation of CodeLens in a new Thread which visits the AST to return the position /url of the codelens.

Java file in Quarkus project uses a document matcher and in the codelens context, it is not in read action mode, it is executed in async mode but for a reason that I cannot explain it cancels the matcher which cancels the codelens future.

The fix is to resolve document matcher synchronously and don't cancel the codelens future when a ProgressCancelledException is thrown.