### PR TITLE
fix: Ensure didOpen is called before other features than documentLink, codelens, etc

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -588,8 +588,10 @@ public class LanguageServerWrapper implements Disposable {
     private CompletableFuture<LanguageServer> connect(@NotNull URI fileUri) throws IOException {
         removeStopTimer(false);
 
-        if (this.connectedDocuments.containsKey(fileUri)) {
-            return CompletableFuture.completedFuture(languageServer);
+        var existingData = connectedDocuments.get(fileUri);
+        if (existingData != null) {
+            return existingData.getSynchronizer().didOpenFuture
+                    .thenApplyAsync(theVoid -> languageServer);
         }
         start();
         if (this.initializeFuture == null) {
@@ -975,7 +977,7 @@ public class LanguageServerWrapper implements Disposable {
             return NullLanguageServerLifecycleManager.INSTANCE;
         }
         var manager = LanguageServerLifecycleManager.getInstance(project);
-        return manager == null? NullLanguageServerLifecycleManager.INSTANCE : manager;
+        return manager == null ? NullLanguageServerLifecycleManager.INSTANCE : manager;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
@@ -30,6 +30,7 @@ import com.redhat.devtools.lsp4ij.commands.CommandExecutor;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import kotlin.Pair;
 import org.eclipse.lsp4j.CodeLens;
+import org.eclipse.lsp4j.CodeLensParams;
 import org.eclipse.lsp4j.Command;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -221,13 +222,14 @@ public class LSPCodeLensProvider implements CodeVisionProvider<Void> {
 
     private static CompletableFuture<List<CodeLensData>> getCodeLenses(@NotNull PsiFile psiFile) {
         LSPCodeLensSupport codeLensSupport = LSPFileSupport.getSupport(psiFile).getCodeLensSupport();
+        var params = new CodeLensParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()));
         CompletableFuture<List<CodeLensData>> future;
         try {
-            future = codeLensSupport.getCodeLenses();
+            future = codeLensSupport.getCodeLenses(params);
         } catch (CancellationException e) {
             // In some case, the PsiFile is modified and the cancellation support throws a CancellationException
             // get it again...
-            future = codeLensSupport.getCodeLenses();
+            future = codeLensSupport.getCodeLenses(params);
         }
         return future;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
@@ -13,13 +13,12 @@ package com.redhat.devtools.lsp4ij.features.codeLens;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
-import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
-import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensParams;
 import org.jetbrains.annotations.NotNull;
@@ -41,14 +40,12 @@ import static com.redhat.devtools.lsp4ij.features.codeLens.LSPCodeLensProvider.g
  * </ul>
  */
 public class LSPCodeLensSupport extends AbstractLSPFeatureSupport<CodeLensParams, List<CodeLensData>> {
-    private final CodeLensParams params;
 
     public LSPCodeLensSupport(@NotNull PsiFile file) {
         super(file);
-        this.params = new CodeLensParams(LSPIJUtils.toTextDocumentIdentifier(file.getVirtualFile()));
     }
 
-    public CompletableFuture<List<CodeLensData>> getCodeLenses() {
+    public CompletableFuture<List<CodeLensData>> getCodeLenses(CodeLensParams params) {
         return super.getFeatureData(params);
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
@@ -23,6 +23,7 @@ import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPInlayHintsProvider;
 import org.eclipse.lsp4j.Color;
+import org.eclipse.lsp4j.DocumentColorParams;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -47,7 +48,8 @@ public class LSPColorProvider extends AbstractLSPInlayHintsProvider {
                              @NotNull List<CompletableFuture> pendingFutures) throws InterruptedException {
         // Get LSP color information from cache or create them
         LSPColorSupport colorSupport = LSPFileSupport.getSupport(psiFile).getColorSupport();
-        CompletableFuture<List<ColorData>> future = colorSupport.getColors();
+        var params = new DocumentColorParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()));
+        CompletableFuture<List<ColorData>> future = colorSupport.getColors(params);
 
         try {
             List<Pair<Integer, ColorData>> codeLenses = createColorInformation(editor.getDocument(), future);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorSupport.java
@@ -13,13 +13,12 @@ package com.redhat.devtools.lsp4ij.features.color;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
-import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
-import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.DocumentColorParams;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,14 +35,12 @@ import java.util.concurrent.CompletableFuture;
  * </ul>
  */
 public class LSPColorSupport extends AbstractLSPFeatureSupport<DocumentColorParams, List<ColorData>> {
-    private final DocumentColorParams params;
 
     public LSPColorSupport(@NotNull PsiFile file) {
         super(file);
-        this.params = new DocumentColorParams(LSPIJUtils.toTextDocumentIdentifier(file.getVirtualFile()));
     }
 
-    public CompletableFuture<List<ColorData>> getColors() {
+    public CompletableFuture<List<ColorData>> getColors(DocumentColorParams params) {
         return super.getFeatureData(params);
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
@@ -31,6 +31,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import org.eclipse.lsp4j.DocumentLink;
+import org.eclipse.lsp4j.DocumentLinkParams;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +67,8 @@ public class LSPDocumentLinkGotoDeclarationHandler implements GotoDeclarationHan
         }
 
         LSPDocumentLinkSupport documentLinkSupport = LSPFileSupport.getSupport(psiFile).getDocumentLinkSupport();
-        CompletableFuture<List<DocumentLinkData>> documentLinkFuture = documentLinkSupport.getDocumentLinks();
+        var params = new DocumentLinkParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()));
+        CompletableFuture<List<DocumentLinkData>> documentLinkFuture = documentLinkSupport.getDocumentLinks(params);
         try {
             waitUntilDone(documentLinkFuture, psiFile);
         } catch (ProcessCanceledException | CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkSupport.java
@@ -13,13 +13,12 @@ package com.redhat.devtools.lsp4ij.features.documentLink;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
-import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
-import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,14 +35,12 @@ import java.util.concurrent.CompletableFuture;
  * </ul>
  */
 public class LSPDocumentLinkSupport extends AbstractLSPFeatureSupport<DocumentLinkParams, List<DocumentLinkData>> {
-    private final DocumentLinkParams params;
 
     public LSPDocumentLinkSupport(@NotNull PsiFile file) {
         super(file);
-        this.params = new DocumentLinkParams(LSPIJUtils.toTextDocumentIdentifier(file.getVirtualFile()));
     }
 
-    public CompletableFuture<List<DocumentLinkData>> getDocumentLinks() {
+    public CompletableFuture<List<DocumentLinkData>> getDocumentLinks(DocumentLinkParams params) {
         return super.getFeatureData(params);
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
@@ -21,6 +21,7 @@ import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.FoldingRangeRequestParams;
 import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -56,7 +57,8 @@ public class LSPFoldingRangeBuilder extends CustomFoldingBuilder {
 
         // Consume LSP 'textDocument/foldingRanges' request
         LSPFoldingRangeSupport foldingRangeSupport = LSPFileSupport.getSupport(file).getFoldingRangeSupport();
-        CompletableFuture<List<FoldingRange>> foldingRangesFuture = foldingRangeSupport.getFoldingRanges();
+        var params = new FoldingRangeRequestParams(LSPIJUtils.toTextDocumentIdentifier(file.getVirtualFile()));
+        CompletableFuture<List<FoldingRange>> foldingRangesFuture = foldingRangeSupport.getFoldingRanges(params);
         try {
             waitUntilDone(foldingRangesFuture, file);
         } catch (ProcessCanceledException | CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeSupport.java
@@ -13,13 +13,12 @@ package com.redhat.devtools.lsp4ij.features.foldingRange;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
-import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
-import com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport;
-import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeRequestParams;
 import org.jetbrains.annotations.NotNull;
@@ -37,14 +36,12 @@ import java.util.concurrent.CompletableFuture;
  * </ul>
  */
 public class LSPFoldingRangeSupport extends AbstractLSPFeatureSupport<FoldingRangeRequestParams, List<FoldingRange>> {
-    private final FoldingRangeRequestParams params;
 
     public LSPFoldingRangeSupport(@NotNull PsiFile file) {
         super(file);
-        this.params = new FoldingRangeRequestParams(LSPIJUtils.toTextDocumentIdentifier(file.getVirtualFile()));
     }
 
-    public CompletableFuture<List<FoldingRange>> getFoldingRanges() {
+    public CompletableFuture<List<FoldingRange>> getFoldingRanges(FoldingRangeRequestParams params) {
         return super.getFeatureData(params);
     }
 

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
@@ -41,16 +41,15 @@ public abstract class LSPFormattingFixtureTestCase extends LSPCodeInsightFixture
     /**
      * Test LSP completion.
      *
-     * @param fileName           the file name used to match registered language servers.
-     * @param editorContentText  the editor content text.
-     * @param jsonFormatting the LSP CompletionList as JSON string.
-     * @param formattedtext      the expected IJ lookupItem string.
+     * @param fileName       the file name used to match registered language servers.
+     * @param text           the editor content text.
+     * @param formattingTextEdits the formatting TextEdit result of language server.
+     * @param formattedText  the expected formatted text.
      */
     protected void assertFormatting(@NotNull String fileName,
                                     @NotNull String text,
-
                                     @NotNull List<TextEdit> formattingTextEdits,
-    @NotNull String formattedText) {
+                                    @NotNull String formattedText) {
         MockLanguageServer.INSTANCE.setTimeToProceedQueries(1000);
         MockLanguageServer.INSTANCE.setFormattingTextEdits(formattingTextEdits);
         // Open editor for a given file name and content
@@ -60,7 +59,7 @@ public abstract class LSPFormattingFixtureTestCase extends LSPCodeInsightFixture
         try {
             LanguageServiceAccessor.getInstance(file.getProject())
                     .getLanguageServers(file.getVirtualFile(), null)
-                            .get(5000, TimeUnit.MILLISECONDS);
+                    .get(5000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
fix: Ensure didOpen is called before other features than documentLink, codelens, etc

Fixes #173

This PR should fix the original issue. The main idea is when we try to connect a file to a language server we return the didOpenFuture and each LSP features futures wait for this didOpenFuture.

But it is not enough since didOpen is a notification and could take some times, we wait for 500ms after the didOpen notification is sent.

It seems it is working, the only problem that I have seen is when your start IJ there are some compute of indexes, ls wait for dumb is finished to start it and sometimes teh codelens are not displayed when editor was opened when IJ starts.

When IJ is started and you stop ls and you retry it, codelens are displayed correctly.