### PR TITLE
fix: avoid logging error from LSP4J when LSP response send an error.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/ExecutionAttemptLimitReachedException.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/ExecutionAttemptLimitReachedException.java
@@ -14,11 +14,16 @@
 package com.redhat.devtools.lsp4ij.client;
 
 
+import com.redhat.devtools.lsp4ij.internal.ResponseErrorExceptionWrapper;
+
 /**
  * Exception thrown when the restart of non blocking read action for a given service is reached.
  */
-public class ExecutionAttemptLimitReachedException extends RuntimeException {
+public class ExecutionAttemptLimitReachedException extends ResponseErrorExceptionWrapper {
+
     public ExecutionAttemptLimitReachedException(String executionName, int limit, Throwable ex) {
         super("Execution attempt limit (" + limit + ") reached to execute '" + executionName + ".", ex);
     }
+
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/CancellationSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/CancellationSupport.java
@@ -97,11 +97,11 @@ public class CancellationSupport implements CancelChecker {
     /**
      * Add the given future to the list of the futures to cancel (when CancellationSupport.cancel() is called)
      *
-     * @param future         the future to cancel when CancellationSupport.cancel() is called.
-     * @param languageServer the language server which have created the LSP future and null otherwise.
-     * @param featureName    the LSP feature name (ex: textDocument/completion) and null otherwise.
+     * @param future                    the future to cancel when CancellationSupport.cancel() is called.
+     * @param languageServer            the language server which have created the LSP future and null otherwise.
+     * @param featureName               the LSP feature name (ex: textDocument/completion) and null otherwise.
      * @param handleLanguageServerError true if the error coming from language server are caught and displayed as notification, log, ignore and false otherwise.
-     * @param <T>            the result type of the future.
+     * @param <T>                       the result type of the future.
      * @return the future to execute.
      */
     public <T> CompletableFuture<T> execute(@NotNull CompletableFuture<T> future,
@@ -138,8 +138,8 @@ public class CancellationSupport implements CancelChecker {
                     return null;
                 }
             }
-            if (handleLanguageServerError && error instanceof ResponseErrorException) {
-                handleLanguageServerError(languageServer, featureName, error);
+            if (handleLanguageServerError && error instanceof ResponseErrorException responseError) {
+                handleLanguageServerError(languageServer, featureName, responseError);
                 // return null as result instead of throwing the ResponseErrorException error
                 // to avoid breaking the LSP request result of another language server (when file is associated to several language servers)
                 return null;
@@ -158,7 +158,7 @@ public class CancellationSupport implements CancelChecker {
 
     private static void handleLanguageServerError(@NotNull LanguageServerWrapper languageServer,
                                                   @Nullable String featureName,
-                                                  @NotNull Throwable error) {
+                                                  @NotNull ResponseErrorException error) {
         ErrorReportingKind errorReportingKind = getReportErrorKind(languageServer);
         switch (errorReportingKind) {
             case as_notification -> // Show LSP error (ResponseErrorException) in an IJ notification
@@ -174,7 +174,7 @@ public class CancellationSupport implements CancelChecker {
         }
     }
 
-    private static void showNotificationError(@NotNull LanguageServerWrapper serverWrapper, @Nullable String featureName, Throwable error) {
+    private static void showNotificationError(@NotNull LanguageServerWrapper serverWrapper, @Nullable String featureName, ResponseErrorException error) {
         String languageServerName = serverWrapper.getServerDefinition().getDisplayName();
         String title = languageServerName + " (" + featureName + ")";
         String content = error.getMessage();
@@ -198,7 +198,7 @@ public class CancellationSupport implements CancelChecker {
         ErrorReportingKind errorReportingKind = null;
         Project project = languageServer.getProject();
         UserDefinedLanguageServerSettings.LanguageServerDefinitionSettings settings = UserDefinedLanguageServerSettings.getInstance(project)
-                        .getLanguageServerSettings(languageServerId);
+                .getLanguageServerSettings(languageServerId);
         if (settings != null) {
             errorReportingKind = settings.getErrorReportingKind();
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/PromiseToCompletableFuture.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/PromiseToCompletableFuture.java
@@ -97,7 +97,9 @@ public class PromiseToCompletableFuture<R> extends CompletableFuture<R> {
                 super.cancel(true);
             } else {
                 // Other case..., mark the completable future as error
-                this.completeExceptionally(ex);
+                // to avoid log from LSP4J https://github.com/eclipse-lsp4j/lsp4j/blob/d0757511e66be409ea9c27440e426616e53339e3/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java#L62
+                // the exception is wrapped to throw an LSP4J ResponseErrorException
+                this.completeExceptionally(new ResponseErrorExceptionWrapper(ex));
             }
         });
         // On success...

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/ResponseErrorExceptionWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/ResponseErrorExceptionWrapper.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal;
+
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+
+/**
+ * LSP4J Response error wrapper.
+ */
+public class ResponseErrorExceptionWrapper extends ResponseErrorException  {
+
+    public ResponseErrorExceptionWrapper(@NotNull Throwable throwable) {
+        super(toResponseError(throwable.getMessage(), throwable));
+    }
+
+    public ResponseErrorExceptionWrapper(@NotNull String message,
+                                         @NotNull Throwable throwable) {
+        super(toResponseError(message, throwable));
+    }
+
+    @NotNull
+    private static ResponseError toResponseError(@NotNull String message,
+                                                @NotNull Throwable throwable) {
+        ResponseError error = new ResponseError();
+        error.setMessage(message);
+        error.setCode(ResponseErrorCode.InternalError);
+        ByteArrayOutputStream stackTrace = new ByteArrayOutputStream();
+        PrintWriter stackTraceWriter = new PrintWriter(stackTrace);
+        throwable.printStackTrace(stackTraceWriter);
+        stackTraceWriter.flush();
+        error.setData(stackTrace.toString());
+        return error;
+    }
+}


### PR DESCRIPTION
fix: avoid logging error from LSP4J when LSP response send an error.

When PsiJavaFile is not ready it can throw a PrgressCancelException, see explanation at https://github.com/redhat-developer/lsp4ij/pull/267

We try 5 times to collect information from Java components (visit PsiJavaFile , use search) for some LSP features which requires Java like IJ Quarkus and after that ExecutionAttemptLimitReachedException is thrown.

This error is logged by LSP4J https://github.com/eclipse-lsp4j/lsp4j/blob/d0757511e66be409ea9c27440e426616e53339e3/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java#L62 which is very annoying because IJ logs that.

To avoid this log, the promise to completable future must throw exception which extends LSP4J ResponseErrorException.

This PR takes care of that.

To test this PR:

 * you need to have a problem with PsiJavaFile which throws a ProgressCancelException (in my case I start IJ with 3 projects which requires to compute JDK index and when PsiJavaFile requires to be visisted (ex : for Java diagnostics from MP L), it throws a ProgressCancelException 
 * update the private constate PromiseToCompletableFuture#MAX_ATTEMPT to 0.

You should see no logged error but you should see (by default) the error which is marked as language server error as notification. See https://github.com/redhat-developer/lsp4ij?tab=readme-ov-file#feedback
