### PR TITLE
fix: Completion errors using certain keys

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -439,6 +438,23 @@ public class LSPIJUtils {
         return offset == document.getLineEndOffset(line);
     }
 
+    public static TextRange getWordRange(PsiElement element, Document document, int offset) {
+        if (canUsePsiElementAsWord(element)) {
+            return element.getTextRange();
+        }
+        return LSPIJUtils.getTokenRange(document, offset);
+    }
+
+    private static boolean canUsePsiElementAsWord(PsiElement element) {
+        if (element == null || element instanceof PsiFile) {
+            return false;
+        }
+        if (element.getTextRange().equals(element.getContainingFile().getTextRange())) {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * Returns the token range from the document at given offset and null otherwise.
      *
@@ -456,7 +472,7 @@ public class LSPIJUtils {
      */
     @Nullable
     public static TextRange getTokenRange(Document document, int offset) {
-        if (offset > 0 && offset >= document.getTextLength()) {
+        if (offset > document.getTextLength()) {
             offset = document.getTextLength() - 1;
         }
         int start = getLeftOffsetOfPart(document, offset);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionPrefix.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionPrefix.java
@@ -14,6 +14,8 @@
 package com.redhat.devtools.lsp4ij.features.completion;
 
 import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.CompletionItem;
@@ -35,13 +37,18 @@ public class CompletionPrefix {
     private final int completionOffset;
     private final Position completionPos;
     private final Document document;
-
+    private final PsiElement triggeredPsiElement;
     private final Map<Range, String /* prefix */> prefixCache;
+    private Range wordRange;
 
-    public CompletionPrefix(int completionOffset, Document document) {
+    public CompletionPrefix(int completionOffset,
+                            @NotNull Position completionPos,
+                            @NotNull Document document,
+                            @NotNull PsiElement triggeredPsiElement) {
         this.completionOffset = completionOffset;
+        this.completionPos = completionPos;
         this.document = document;
-        this.completionPos = LSPIJUtils.toPosition(completionOffset, document);
+        this.triggeredPsiElement = triggeredPsiElement;
         this.prefixCache = new HashMap<>();
     }
 
@@ -115,4 +122,14 @@ public class CompletionPrefix {
         return filterText;
     }
 
+    public Range getWordRange() {
+        if (wordRange != null) {
+            return wordRange;
+        }
+        TextRange wordTextRange = LSPIJUtils.getWordRange(triggeredPsiElement, document, completionOffset);
+        if (wordTextRange != null) {
+            this.wordRange = LSPIJUtils.toRange(wordTextRange, document);
+        }
+        return wordRange;
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
@@ -62,13 +62,16 @@ public class LSPCompletionProposal extends LookupElement {
     private final Boolean supportResolveCompletion;
     private final boolean supportSignatureHelp;
     private final LSPCompletionContributor completionContributor;
-    private int currentOffset;
     private int bestOffset;
     private final Editor editor;
     private final LanguageServerItem languageServer;
     private CompletableFuture<CompletionItem> resolvedCompletionItemFuture;
 
-    public LSPCompletionProposal(PsiFile file, Editor editor, int offset, CompletionItem item, LanguageServerItem languageServer,
+    public LSPCompletionProposal(@NotNull PsiFile file,
+                                 @NotNull Editor editor,
+                                 int offset,
+                                 @NotNull CompletionItem item,
+                                 @NotNull LanguageServerItem languageServer,
                                  @NotNull LSPCompletionContributor completionContributor) {
         this.file = file;
         this.item = item;
@@ -76,7 +79,6 @@ public class LSPCompletionProposal extends LookupElement {
         this.languageServer = languageServer;
         this.completionContributor = completionContributor;
         this.initialOffset = offset;
-        this.currentOffset = offset;
         this.bestOffset = getPrefixCompletionStart(editor.getDocument(), offset);
         this.supportResolveCompletion = languageServer.isResolveCompletionSupported();
         this.supportSignatureHelp = languageServer.isSignatureHelpSupported();
@@ -136,7 +138,6 @@ public class LSPCompletionProposal extends LookupElement {
                 && (template.getSegmentsCount() > 0 // There are some tabstops, e.g. $0, $1
                 || !template.getVariables().isEmpty()); // There are some placeholders, e.g ${1:name}
     }
-
 
     /**
      * Update the insert text with the given new value <code>newText</code>.
@@ -259,7 +260,7 @@ public class LSPCompletionProposal extends LookupElement {
             return null;
         }
         // Here the IJ lookup item is selected.
-        if(needToResolveCompletionDetail()) {
+        if (needToResolveCompletionDetail()) {
             // The LSP completion item 'detail' is not filled, try to resolve it
             // inside getExpensiveRenderer() which should not impact performance.
             CompletionItem resolved = getResolvedCompletionItem();
@@ -305,6 +306,8 @@ public class LSPCompletionProposal extends LookupElement {
         }
         try {
             if (textEdit == null) {
+                // Completion item provides an insertText / label without a text edit:
+
                 // ex:
                 // {
                 //    "label": "let",

--- a/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_getTokenRangeTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_getTokenRangeTest.java
@@ -68,6 +68,18 @@ public class LSPIJUtils_getTokenRangeTest extends BasePlatformTestCase {
         assertTokenRange("\nfoo.bar|()\n", "\nfoo.[bar]()\n");
     }
 
+    public void testProperties() {
+        assertTokenRange("|foo=bar", "[foo]=bar");
+        assertTokenRange("f|oo=bar", "[foo]=bar");
+        assertTokenRange("fo|o=bar", "[foo]=bar");
+        assertTokenRange("foo|=bar", "[foo]=bar");
+
+        assertTokenRange("foo=|bar", "foo=[bar]");
+        assertTokenRange("foo=b|ar", "foo=[bar]");
+        assertTokenRange("foo=ba|r", "foo=[bar]");
+        assertTokenRange("foo=bar|", "foo=[bar]");
+    }
+
     public void testBracket() {
         assertTokenRange("foo.bar(|)", null);
     }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/BootstrapPropertiesCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/BootstrapPropertiesCompletionTest.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionFixtureTestCase;
+
+/**
+ * Completion tests by emulating LSP 'textDocument/completion' responses
+ * from the liberty-ls language server
+ * which returns completion items without text edit.
+ */
+public class BootstrapPropertiesCompletionTest extends LSPCompletionFixtureTestCase {
+
+    public BootstrapPropertiesCompletionTest() {
+        super("bootstrap.properties");
+    }
+
+    // ------------ Completion on property key
+
+    public void testCompletionOnPropertyKeyAtEnd() {
+        // 1. Test completion items result
+        assertCompletion("bootstrap.properties",
+                "com.ibm.ws.log<caret>", """                
+                        [
+                          {
+                              "label": "com.ibm.ws.logging.message.file.name",
+                              "kind": 10,
+                              "documentation": {
+                                "kind": "markdown",
+                                "value": "This setting specifies the name of the message log file. The message log file has a default name of `messages.log`. This file always exists, and contains INFO and other (AUDIT, WARNING, ERROR, FAILURE) messages in addition to the System.out and System.err streams. This log also contains time stamps and the issuing thread ID. If the log file is rolled over, the names of earlier log files have the format messages_timestamp.log."
+                              }
+                            },
+                            {
+                              "label": "com.ibm.ws.logging.max.files",
+                              "kind": 10,
+                              "documentation": {
+                                "kind": "markdown",
+                                "value": "This setting specifies how many of each of the logs files are kept. This setting also applies to the number of exception summary logs for FFDC. So if this number is 10, you might have 10 message logs, 10 trace logs, and 10 exception summaries in the ffdc directory. By default, the value is `2`. The console log does not roll so this setting does not apply to the console.log file."
+                              }
+                            },
+                            {
+                              "label": "com.ibm.ws.logging.max.file.size",
+                              "kind": 10,
+                              "documentation": {
+                                "kind": "markdown",
+                                "value": "This setting specifies the maximum size (in MB) that a log file can reach before it is rolled. Setting the value to `0` disables log rolling. The default value is `20`. The console.log does not roll so this setting does not apply."
+                              }
+                            }
+                          ]"""
+                ,
+                "com.ibm.ws.logging.message.file.name",
+                "com.ibm.ws.logging.max.files",
+                "com.ibm.ws.logging.max.file.size");
+        // 2. Test new editor content after applying the first completion item
+        assertApplyCompletionItem(0, "com.ibm.ws.com.ibm.ws.logging.max.file.size");
+    }
+
+    // ------------ Completion on property value
+
+    public void testCompletionOnPropertyValueWithEmptyValueAtEnd() {
+        // 1. Test completion items result
+        assertCompletion("bootstrap.properties",
+                "com.ibm.hpel.trace.bufferingEnabled=<caret>", """                
+                        [
+                            {
+                                 "label": "true",
+                                 "kind": 1,
+                                 "documentation": {
+                                     "kind": "markdown",
+                                     "value": "Specifies whether to allow a small delay in saving records to the disk for improved performance. When bufferingEnabled is set to true, records will be briefly held in memory before being written to disk."
+                                 },
+                                 "preselect": true
+                             },
+                             {
+                                 "label": "false",
+                                 "kind": 1,
+                                 "documentation": {
+                                     "kind": "markdown",
+                                     "value": "Specifies whether to allow a small delay in saving records to the disk for improved performance. When bufferingEnabled is set to true, records will be briefly held in memory before being written to disk."
+                                 }
+                             }
+                          ]"""
+                ,
+                "true",
+                "false");
+        // 2. Test new editor content after applying the first completion item
+        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false");
+    }
+
+    public void testCompletionOnPropertyValueWithValueAtEnd() {
+        // 1. Test completion items result
+        assertCompletion("bootstrap.properties",
+                "com.ibm.hpel.trace.bufferingEnabled=f<caret>", """                
+                        [
+                            {
+                                 "label": "true",
+                                 "kind": 1,
+                                 "documentation": {
+                                     "kind": "markdown",
+                                     "value": "Specifies whether to allow a small delay in saving records to the disk for improved performance. When bufferingEnabled is set to true, records will be briefly held in memory before being written to disk."
+                                 },
+                                 "preselect": true
+                             },
+                             {
+                                 "label": "false",
+                                 "kind": 1,
+                                 "documentation": {
+                                     "kind": "markdown",
+                                     "value": "Specifies whether to allow a small delay in saving records to the disk for improved performance. When bufferingEnabled is set to true, records will be briefly held in memory before being written to disk."
+                                 }
+                             }
+                          ]"""
+                , "false");
+        // 2. Test new editor content after applying the first completion item
+        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false");
+    }
+
+    public void testCompletionOnPropertyValueWithValueInsideValue() {
+        // 1. Test completion items result
+        assertCompletion("bootstrap.properties",
+                "com.ibm.hpel.trace.bufferingEnabled=fa<caret>ls", """                
+                        [
+                            {
+                                 "label": "true",
+                                 "kind": 1,
+                                 "documentation": {
+                                     "kind": "markdown",
+                                     "value": "Specifies whether to allow a small delay in saving records to the disk for improved performance. When bufferingEnabled is set to true, records will be briefly held in memory before being written to disk."
+                                 },
+                                 "preselect": true
+                             },
+                             {
+                                 "label": "false",
+                                 "kind": 1,
+                                 "documentation": {
+                                     "kind": "markdown",
+                                     "value": "Specifies whether to allow a small delay in saving records to the disk for improved performance. When bufferingEnabled is set to true, records will be briefly held in memory before being written to disk."
+                                 }
+                             }
+                          ]"""
+                , "false");
+        // 2. Test new editor content after applying the first completion item
+        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false");
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/ClojureCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/ClojureCompletionTest.java
@@ -14,14 +14,18 @@ import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionFixtureTestCase;
 
 /**
  * Completion tests by emulating LSP 'textDocument/completion' responses
- * from the clojure-lsp language server.
+ * from the clojure-lsp language server
+ * which returns completion items without text edit.
  */
 public class ClojureCompletionTest extends LSPCompletionFixtureTestCase {
 
+    public ClojureCompletionTest() {
+        super("*.clj");
+    }
+
     public void testCompletionWithoutTextEditAndEmptyContent() {
-        // clojure-lsp returns completion items without text edit.
         // 1. Test completion items result
-        assertCompletion("test.ts",
+        assertCompletion("test.clj",
                 "<caret>", """                
                         [
                             {
@@ -45,9 +49,8 @@ public class ClojureCompletionTest extends LSPCompletionFixtureTestCase {
     }
 
     public void testCompletionWithoutTextEdit() {
-        // clojure-lsp returns completion items without text edit.
         // 1. Test completion items result
-        assertCompletion("test.ts",
+        assertCompletion("test.clj",
                 "let<caret>", """                
                         [
                             {
@@ -71,9 +74,8 @@ public class ClojureCompletionTest extends LSPCompletionFixtureTestCase {
     }
 
     public void testCompletionWithoutTextEditAndCaretInsideToken() {
-        // clojure-lsp returns completion items without text edit.
         // 1. Test completion items result
-        assertCompletion("test.ts",
+        assertCompletion("test.clj",
                 "le<caret>t", """                
                         [
                             {

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionTest.java
@@ -18,6 +18,10 @@ import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionFixtureTestCase;
  */
 public class TypeScriptCompletionTest extends LSPCompletionFixtureTestCase {
 
+    public TypeScriptCompletionTest() {
+        super("*.ts");
+    }
+
     public void testCompletionWithTextEdit() {
         // 1. Test completion items result
         assertCompletion("test.ts",

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/ClojureFormattingTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/ClojureFormattingTest.java
@@ -18,9 +18,13 @@ import com.redhat.devtools.lsp4ij.fixtures.LSPFormattingFixtureTestCase;
  */
 public class ClojureFormattingTest extends LSPFormattingFixtureTestCase {
 
+    public ClojureFormattingTest() {
+        super("*.clj");
+    }
+
     public void testFormatting() {
         // Test with TextEdit end which is outside the document length (uses of 999999)
-        assertFormatting("test.ts",
+        assertFormatting("test.clj",
                 """                
                         (let
                                             [binding ""])""",

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptFormattingTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptFormattingTest.java
@@ -18,6 +18,10 @@ import com.redhat.devtools.lsp4ij.fixtures.LSPFormattingFixtureTestCase;
  */
 public class TypeScriptFormattingTest extends LSPFormattingFixtureTestCase {
 
+    public TypeScriptFormattingTest() {
+        super("*.ts");
+    }
+
     public void testFormatting() {
         // 1. Test completion items result
         assertFormatting("test.ts",

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCodeInsightFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCodeInsightFixtureTestCase.java
@@ -26,8 +26,13 @@ import java.util.List;
  */
 public abstract class LSPCodeInsightFixtureTestCase extends UsefulTestCase {
 
+    private final String[] fileNamePatterns;
     protected LSPCodeInsightTestFixture myFixture;
     private MockLanguageServerDefinition serverDefinition;
+
+    public LSPCodeInsightFixtureTestCase(String... fileNamePatterns) {
+        this.fileNamePatterns = fileNamePatterns;
+    }
 
     @Override
     protected void setUp() throws Exception {
@@ -54,7 +59,7 @@ public abstract class LSPCodeInsightFixtureTestCase extends UsefulTestCase {
 
     private void registerServer() {
         serverDefinition = new MockLanguageServerDefinition();
-        List<ServerMappingSettings> mappings = List.of(ServerMappingSettings.createFileNamePatternsMappingSettings(List.of("*.ts"), null));
+        List<ServerMappingSettings> mappings = List.of(ServerMappingSettings.createFileNamePatternsMappingSettings(List.of(fileNamePatterns), null));
         LanguageServersRegistry.getInstance().addServerDefinition(serverDefinition, mappings);
     }
 

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionFixtureTestCase.java
@@ -23,6 +23,10 @@ import java.util.stream.Stream;
  */
 public abstract class LSPCompletionFixtureTestCase extends LSPCodeInsightFixtureTestCase {
 
+    public LSPCompletionFixtureTestCase(String... fileNamePatterns) {
+        super(fileNamePatterns);
+    }
+
     /**
      * Test LSP completion.
      *
@@ -60,9 +64,9 @@ public abstract class LSPCompletionFixtureTestCase extends LSPCodeInsightFixture
         // Process completion
         myFixture.completeBasic();
         if (expectedItems == null || expectedItems.length == 0) {
-            assertNull(myFixture.getLookup());
+            assertNull("Completion should be null", myFixture.getLookup());
         } else {
-            assertNotNull(myFixture.getLookup());
+            assertNotNull("Completion should be not null", myFixture.getLookup());
             var actualItems = Stream.of(myFixture.getLookupElements())
                     .map(LookupElement::getLookupString)
                     .toList();

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
@@ -26,6 +26,10 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class LSPFormattingFixtureTestCase extends LSPCodeInsightFixtureTestCase {
 
+    public LSPFormattingFixtureTestCase(String... fileNamePatterns) {
+        super(fileNamePatterns);
+    }
+
     private class MyList {
         public List<TextEdit> edits;
     }

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServerDefinition.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServerDefinition.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class MockLanguageServerDefinition extends LanguageServerDefinition {
     public MockLanguageServerDefinition() {
-        super("id", "name", null, true, 5, true);
+        super("mock-server-id", "name", null, true, 5, true);
     }
 
     @Override


### PR DESCRIPTION
fix: Completion errors using certain keys

Fixes #270

It fixes the problem only for property value:

![BootstrapCompletion](https://github.com/redhat-developer/lsp4ij/assets/1932211/438f3ca0-b42e-437c-a4ef-b5cfa520a3ad)

I have written test for this usecase.

It doesn't fix the first problem with completionon key, but as your Liberty LS doesn't work on vscode for completion key, I cannot test, but I suspect that there is the same behavior with vscode.