### PR TITLE
fix: prevent IJ from reporting an error in LSPIJUtils.getPsiFile if the file has been deleted

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -256,9 +256,20 @@ public class LSPIJUtils {
      */
     public static @Nullable PsiFile getPsiFile(@NotNull VirtualFile file, @NotNull Project project) {
         if (ApplicationManager.getApplication().isReadAccessAllowed()) {
-            return PsiManager.getInstance(project).findFile(file);
+            return doGetPsiFile(file, project);
         }
-        return ReadAction.compute(() -> PsiManager.getInstance(project).findFile(file));
+        return ReadAction.compute(() -> doGetPsiFile(file, project));
+    }
+
+    /**
+     * Returns the Psi file corresponding to the virtual file in the given project. Must be called in a Read Action.
+     * @param file    the virtual file.
+     * @param project the project.
+     * @return the Psi file corresponding to the virtual file in the given project.
+     */
+    private static @Nullable PsiFile doGetPsiFile(@NotNull VirtualFile file, @NotNull Project project) {
+        // Prevent PsiManager.findFile from logging a nasty error if file is not valid.
+        return (file.isValid())? PsiManager.getInstance(project).findFile(file) : null;
     }
 
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
@@ -117,7 +117,7 @@ public class LSPDocumentLinkGotoDeclarationHandler implements GotoDeclarationHan
                                 // If user accepts to create the file, the open is done after the creation of teh file.
                                 return PsiElement.EMPTY_ARRAY;
                             }
-                            return new PsiElement[]{PsiManager.getInstance(project).findFile(targetFile)};
+                            return new PsiElement[]{ LSPIJUtils.getPsiFile(targetFile, project)};
                         }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Fred Bricon <fbricon@gmail.com>
