### PR TITLE
test: Add tests for rename

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameRefactoringDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameRefactoringDialog.java
@@ -140,9 +140,9 @@ class LSPRenameRefactoringDialog extends RefactoringDialog {
      * @param renameParams the rename parameters.
      * @param psiFile      the Psi file.
      */
-    private static void doRename(@NotNull LSPRenameParams renameParams,
-                                 @NotNull PsiFile psiFile,
-                                 @NotNull Editor editor) {
+    static void doRename(@NotNull LSPRenameParams renameParams,
+                         @NotNull PsiFile psiFile,
+                         @NotNull Editor editor) {
 
         CompletableFuture<List<WorkspaceEditData>> future = LSPFileSupport.getSupport(psiFile)
                 .getRenameSupport()
@@ -152,7 +152,8 @@ class LSPRenameRefactoringDialog extends RefactoringDialog {
         // The 'rename' is stopped:
         // - if user change the editor content
         // - if it cancels the Task
-        waitUntilDoneAsync(future, LanguageServerBundle.message("lsp.refactor.rename.progress.title", psiFile.getVirtualFile().getName(),renameParams.getNewName()), psiFile);
+        String title = LanguageServerBundle.message("lsp.refactor.rename.progress.title", psiFile.getVirtualFile().getName(), renameParams.getNewName());
+        waitUntilDoneAsync(future, title, psiFile);
 
         future.handle((workspaceEdits, error) -> {
             if (error != null) {
@@ -165,7 +166,7 @@ class LSPRenameRefactoringDialog extends RefactoringDialog {
                     error = error.getCause();
                 }
                 // The language server throws an error, display it as hint in the editor
-                LSPRenameHandler.showErrorHint(editor, LanguageServerBundle.message("lsp.refactor.rename.process.error", error.getMessage()));
+                LSPRenameHandler.showErrorHint(editor, error.getMessage());
                 return null;
             }
             if (workspaceEdits == null || workspaceEdits.isEmpty()) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameUnitTestMode.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameUnitTestMode.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.rename;
+
+import org.eclipse.lsp4j.RenameParams;
+
+/**
+ * LSP rename handler used in Junit test mode to emulate
+ *
+ * <ul>
+ *     <li>showErrorHint : when there is an error while renaming</li>
+ *     <li>showRenameRefactoringDialog : when rename dialog is opened with rename parameters
+ *     initialized with the prepare rename result</li>
+ * </ul>
+ */
+public class LSPRenameUnitTestMode {
+
+    public static interface LSPRenameUnitTestModeHandler {
+
+        /**
+         * Show error hint when there is an error while renaming.
+         *
+         * @param errorHintText the error hint text.
+         */
+        void showErrorHint(String errorHintText);
+
+        /**
+         * Show the rename dialog with the rename parameters initialized with the prepare rename result.
+         *
+         * @param renameParams the rename parameters.
+         */
+        void showRenameRefactoringDialog(RenameParams renameParams);
+
+    }
+
+    private static final ThreadLocal<LSPRenameUnitTestModeHandler> threadLocalHandler = new ThreadLocal<>();
+
+    public static void set(LSPRenameUnitTestModeHandler handler) {
+        threadLocalHandler.set(handler);
+    }
+
+    public static LSPRenameUnitTestModeHandler get() {
+        return threadLocalHandler.get();
+    }
+}

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -133,8 +133,5 @@ lsp.refactor.rename.symbol.handler.title=Rename LSP Symbol
 lsp.refactor.rename.language.server.not.ready=Rename... is not available during language servers starting.
 lsp.refactor.rename.cannot.be.renamed.error=The element can't be renamed.
 lsp.refactor.rename.prepare.progress.title=Prepare renaming for ''{0}'' file at {1} offset...
-lsp.refactor.rename.prepare.error=Error while preparing rename: {0}
-lsp.refactor.rename.progress.title=Renaming ''{0}'' file with ''{0}'' new name...
-lsp.refactor.rename.process.error=Error while renaming: {0}
-
+lsp.refactor.rename.progress.title=Renaming ''{0}'' file with ''{1}'' new name...
 

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/rename/GoRenameTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/rename/GoRenameTest.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.rename;
+
+import com.redhat.devtools.lsp4ij.LanguageServerBundle;
+import com.redhat.devtools.lsp4ij.fixtures.LSPRenameFixtureTestCase;
+
+/**
+ * Rename tests by emulating LSP 'textDocument/prepareRename' and 'textDocument/rename'
+ * responses from the Go language server.
+ */
+public class GoRenameTest extends LSPRenameFixtureTestCase {
+
+    public GoRenameTest() {
+        super("*.go");
+    }
+
+    public void testRenameWithPrepareRenameResult() {
+        // Go LS uses prepare rename result (range + placeholder)
+        assertRename("test.go",
+                """                
+                        package src
+                         
+                        func m<caret>ain() {
+                        }""",
+                """ 
+                        {
+                          "range": {
+                            "start": {
+                              "line": 2,
+                              "character": 5
+                            },
+                            "end": {
+                              "line": 2,
+                              "character": 9
+                            }
+                          },
+                          "placeholder": "main"
+                        }
+                        """, // Prepare rename managed by Go LS
+                "main", // expected placeholder returned by prepare rename
+                """                
+                        {
+                              "changes": {},
+                              "documentChanges": [
+                                {
+                                  "textDocument": {
+                                    "version": 5,
+                                    "uri": "%s"
+                                  },
+                                  "edits": [
+                                    {
+                                      "range": {
+                                        "start": {
+                                          "line": 2,
+                                          "character": 5
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "character": 9
+                                        }
+                                      },
+                                      "newText": "foo"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }""",
+                """                
+                        package src
+                         
+                        func foo() {
+                        }""");
+    }
+
+    public void testRenameWithPrepareRenameDefaultBehavior() {
+        // Go LS uses prepare rename default behavior which delegates
+        // prepare rename to the LSP client (word range at)
+        assertRename("test.go",
+                """                
+                        package src
+                         
+                        func m<caret>ain() {
+                        }""",
+                """ 
+                        {
+                          "defaultBehavior": true
+                        }
+                        """, // Prepare rename managed by LSP4IJ (client side)
+                "main", // expected placeholder returned by prepare rename
+                """                
+                        {
+                              "changes": {},
+                              "documentChanges": [
+                                {
+                                  "textDocument": {
+                                    "version": 5,
+                                    "uri": "%s"
+                                  },
+                                  "edits": [
+                                    {
+                                      "range": {
+                                        "start": {
+                                          "line": 2,
+                                          "character": 5
+                                        },
+                                        "end": {
+                                          "line": 2,
+                                          "character": 9
+                                        }
+                                      },
+                                      "newText": "foo"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }""",
+                """                
+                        package src
+                         
+                        func foo() {
+                        }""");
+    }
+
+    public void testElementCannotBeRenamed() {
+        // As Go LS supports prepare rename, we use it,
+        // and it returns a null prepare rename when
+        // user tries to rename keyword like 'func'
+        assertRenameWithError("test.go",
+                """                
+                        package src
+                         
+                        f<caret>unc main() {
+                        }""",
+                PREPARE_RENAME_NO_RESULT,
+                null,
+                null,
+                LanguageServerBundle.message("lsp.refactor.rename.cannot.be.renamed.error")); // "The element can't be renamed."
+    }
+
+    public void testRenameError() {
+        // Emulate that Go LS doesn't support prepare rename and throws an exception
+        // when element to rename cannot be renamed.
+        assertRenameWithError("test.go",
+                """                
+                        package src
+                         
+                        f<caret>unc main() {
+                        }""",
+                null,
+                "func",
+                """ 
+                        {
+                           "code": -32602,
+                           "message": "no identifier found"
+                        }
+                        """, // Go throws an error when user tries to rename 'func' keyword,
+                "no identifier found");
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/rename/QuteRenameTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/rename/QuteRenameTest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.rename;
+
+import com.redhat.devtools.lsp4ij.LanguageServerBundle;
+import com.redhat.devtools.lsp4ij.fixtures.LSPRenameFixtureTestCase;
+
+/**
+ * Rename tests by emulating LSP 'textDocument/rename'
+ * responses from the Qute language server.
+ * The Qute Language Server doesn't support prepare rename.
+ */
+public class QuteRenameTest extends LSPRenameFixtureTestCase {
+
+    public QuteRenameTest() {
+        super("*.html");
+    }
+
+    public void testRenameWithoutPrepareRename() {
+        // Qute LS don't support prepare rename
+        assertRename("test.html",
+                """                
+                        {#for i<caret>tem in items}
+                            {item}
+                        {/for}""",
+                null, // Qute doesn't support prepare rename
+                "item", // expected placeholder computed from the caret
+                """                
+                        {
+                            "changes": {
+                              "%s": [
+                                {
+                                  "range": {
+                                    "start": {
+                                      "line": 0,
+                                      "character": 6
+                                    },
+                                    "end": {
+                                      "line": 0,
+                                      "character": 10
+                                    }
+                                  },
+                                  "newText": "foo"
+                                },
+                                {
+                                  "range": {
+                                    "start": {
+                                      "line": 1,
+                                      "character": 5
+                                    },
+                                    "end": {
+                                      "line": 1,
+                                      "character": 9
+                                    }
+                                  },
+                                  "newText": "foo"
+                                }
+                              ]
+                            }
+                          }""",
+                """                
+                        {#for foo in items}
+                            {foo}
+                        {/for}""");
+    }
+
+    public void testLanguageServerNotReady() {
+        assertRenameWithError("test.html",
+                """                
+                        {<caret>#for item in items}
+                            {item}
+                        {/for}""",
+                null,
+                null,
+                null,
+                LanguageServerBundle.message("lsp.refactor.rename.language.server.not.ready"), // "Rename... is not available during language servers starting."
+                false);
+    }
+
+    public void testElementCannotBeRenamed() {
+        // As Qute LS doesn't support prepare rename
+        // LSP4IJ uses the client word range at strategy to get the prepare rename.
+        assertRenameWithError("test.html",
+                """                
+                        {<caret>#for item in items}
+                            {item}
+                        {/for}""",
+                null,
+                null,
+                null,
+                LanguageServerBundle.message("lsp.refactor.rename.cannot.be.renamed.error")); // "The element can't be renamed."
+    }
+
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/rename/RustRenameTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/rename/RustRenameTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.rename;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPRenameFixtureTestCase;
+
+/**
+ * Rename tests by emulating LSP 'textDocument/prepareRename' and 'textDocument/rename'
+ * responses from the Rust language server.
+ */
+public class RustRenameTest extends LSPRenameFixtureTestCase {
+
+    public RustRenameTest() {
+        super("*.rs");
+    }
+
+    public void testRenameWithPrepareNameRange() {
+        // Rust LS uses range as prepare rename result
+        assertRename("test.rs",
+                """                
+                        fn m<caret>ain() {
+                              
+                        }""",
+                """ 
+                        {
+                          "start": {
+                            "line": 0,
+                            "character": 3
+                          },
+                          "end": {
+                            "line": 0,
+                            "character": 7
+                          }
+                        }
+                        """, // Prepare rename managed by Rust LS
+                "main", // expected placeholder returned by prepare rename
+                """                
+                        {
+                             "changes": {},
+                             "documentChanges": [
+                               {
+                                 "textDocument": {
+                                   "version": 1,
+                                   "uri": "%s"
+                                 },
+                                 "edits": [
+                                   {
+                                     "range": {
+                                       "start": {
+                                         "line": 0,
+                                         "character": 3
+                                       },
+                                       "end": {
+                                         "line": 0,
+                                         "character": 7
+                                       }
+                                     },
+                                     "newText": "foo"
+                                   }
+                                 ]
+                               }
+                             ]
+                           }""",
+                """                
+                        fn foo() {
+                              
+                        }""");
+    }
+
+    public void testErrorWhilePrepareRenaming() {
+        // Rust LS throws a ResponseError exception when prepare rename is not valid.
+        assertRenameWithError("test.rs",
+                """                
+                        f|n main() {
+                              
+                        }""",
+                """ 
+                        {
+                           "code": -32602,
+                           "message": "No references found at position"
+                        }
+                        """, // Rust throws an error when user tries to rename 'fn' keyword
+                null,
+                null,
+                "No references found at position");
+    }
+
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
@@ -43,7 +43,7 @@ public abstract class LSPFormattingFixtureTestCase extends LSPCodeInsightFixture
     }
 
     /**
-     * Test LSP completion.
+     * Test LSP formatting.
      *
      * @param fileName       the file name used to match registered language servers.
      * @param text           the editor content text.

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPRenameFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPRenameFixtureTestCase.java
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.fixtures;
+
+import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.rename.LSPRenameUnitTestMode;
+import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Either3;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Base class test case to test LSP 'textDocument/prepareRename', 'textDocument/rename' features.
+ */
+public abstract class LSPRenameFixtureTestCase extends LSPCodeInsightFixtureTestCase {
+
+    protected static final String PREPARE_RENAME_NO_RESULT = "{}";
+
+    public LSPRenameFixtureTestCase(String... fileNamePatterns) {
+        super(fileNamePatterns);
+    }
+
+    /**
+     * Test LSP rename.
+     *
+     * @param fileName                  the file name used to match registered language servers.
+     * @param text                      the editor content text.
+     * @param jsonPrepareRenameResponse the emulated JSON prepare rename response and null otherwise.
+     * @param expectedPlaceholder       the expected placeholder and null otherwise.
+     * @param jsonRenameResponse        the emulated rename JSON rename response WorkspaceEdit and null otherwise.
+     * @param expectedRenamedText       the expected renamed text.
+     */
+    protected void assertRename(@NotNull String fileName,
+                                @NotNull String text,
+                                @Nullable String jsonPrepareRenameResponse,
+                                @NotNull String expectedPlaceholder,
+                                @NotNull String jsonRenameResponse,
+                                @NotNull String expectedRenamedText) {
+        assertRename(fileName,
+                text,
+                jsonPrepareRenameResponse,
+                expectedPlaceholder,
+                jsonRenameResponse,
+                expectedRenamedText,
+                null,
+                true);
+    }
+
+    /**
+     * Test LSP rename with error by waiting for starting language server.
+     *
+     * @param fileName                  the file name used to match registered language servers.
+     * @param text                      the editor content text.
+     * @param jsonPrepareRenameResponse the emulated JSON prepare rename response and null otherwise.
+     * @param expectedPlaceholder       the expected placeholder.
+     * @param jsonRenameResponse        the emulated rename JSON rename response WorkspaceEdit and null otherwise.
+     * @param expectedError             the expected error.
+     */
+    protected void assertRenameWithError(@NotNull String fileName,
+                                         @NotNull String text,
+                                         @Nullable String jsonPrepareRenameResponse,
+                                         @Nullable String expectedPlaceholder,
+                                         @Nullable String jsonRenameResponse,
+                                         @NotNull String expectedError) {
+        assertRenameWithError(fileName,
+                text,
+                jsonPrepareRenameResponse,
+                expectedPlaceholder,
+                jsonRenameResponse,
+                expectedError,
+                true);
+    }
+
+    /**
+     * Test LSP rename with error.
+     *
+     * @param fileName                  the file name used to match registered language servers.
+     * @param text                      the editor content text.
+     * @param jsonPrepareRenameResponse the emulated JSON prepare rename response and null otherwise.
+     * @param expectedPlaceholder       the expected placeholder.
+     * @param jsonRenameResponse        the emulated rename JSON rename response WorkspaceEdit and null otherwise.
+     * @param expectedError             the expected error.
+     * @param waitFor                   wait for some ms to take some times to start the language server.
+     */
+    protected void assertRenameWithError(@NotNull String fileName,
+                                         @NotNull String text,
+                                         @Nullable String jsonPrepareRenameResponse,
+                                         @Nullable String expectedPlaceholder,
+                                         @Nullable String jsonRenameResponse,
+                                         @NotNull String expectedError,
+                                         boolean waitFor) {
+        assertRename(fileName,
+                text,
+                jsonPrepareRenameResponse,
+                expectedPlaceholder,
+                jsonRenameResponse,
+                null,
+                expectedError,
+                waitFor);
+    }
+
+    /**
+     * Test LSP rename.
+     *
+     * @param fileName                  the file name used to match registered language servers.
+     * @param text                      the editor content text.
+     * @param jsonPrepareRenameResponse the emulated JSON prepare rename response and null otherwise.
+     * @param expectedPlaceholder       the expected placeholder and null otherwise.
+     * @param jsonRenameResponse        the emulated rename JSON rename response WorkspaceEdit and null otherwise.
+     * @param expectedRenamedText       the expected renamed text and null otherwise.
+     * @param expectedError             the expected error and null otherwise.
+     * @param waitFor                   wait for some ms to take some times to start the language server.
+     */
+    private void assertRename(@NotNull String fileName,
+                              @NotNull String text,
+                              @Nullable String jsonPrepareRenameResponse,
+                              @Nullable String expectedPlaceholder,
+                              @Nullable String jsonRenameResponse,
+                              @Nullable String expectedRenamedText,
+                              @Nullable String expectedError,
+                              boolean waitFor) {
+        updateRenameCapabilities(jsonPrepareRenameResponse);
+
+        MockLanguageServer.INSTANCE.setTimeToProceedQueries(1000);
+        PsiFile file = myFixture.configureByText(fileName, text);
+
+        // Prepare rename response
+        if (jsonPrepareRenameResponse != null) {
+            if (jsonPrepareRenameResponse == PREPARE_RENAME_NO_RESULT) {
+                // Prepare rename should return null.
+                MockLanguageServer.INSTANCE.setPrepareRenameProcessor(params -> null);
+            } else if (jsonPrepareRenameResponse.contains("code")) {
+                // prepare rename with error
+                // {
+                //  "code": -32602,
+                //  "message": "no identifier found"
+                // }
+                ResponseError error = JSONUtils.getLsp4jGson().fromJson(jsonPrepareRenameResponse, ResponseError.class);
+                MockLanguageServer.INSTANCE.setPrepareRenameProcessor(params -> {
+                    throw new ResponseErrorException(error);
+                });
+            } else {
+                // Prepare rename result
+                Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> prepareRenameResponse = getPrepareRenameResponse(jsonPrepareRenameResponse);
+                MockLanguageServer.INSTANCE.setPrepareRenameProcessor(params -> prepareRenameResponse);
+            }
+        }
+
+        // Rename response
+        if (jsonRenameResponse != null) {
+            if (jsonRenameResponse.contains("code")) {
+                // rename with error
+                // {
+                //  "code": -32602,
+                //  "message": "no identifier found"
+                // }
+                ResponseError error = JSONUtils.getLsp4jGson().fromJson(jsonRenameResponse, ResponseError.class);
+                MockLanguageServer.INSTANCE.setRenameProcessor(params -> {
+                    throw new ResponseErrorException(error);
+                });
+            } else {
+                // WorkspaceEdit
+                jsonRenameResponse = jsonRenameResponse.formatted(LSPIJUtils.toUri(file));
+                WorkspaceEdit workspaceEdit = JSONUtils.getLsp4jGson().fromJson(jsonRenameResponse, WorkspaceEdit.class);
+                MockLanguageServer.INSTANCE.setRenameProcessor(params -> workspaceEdit);
+            }
+        }
+
+        if (waitFor) {
+            // As rename support works only when language server is started
+            // to avoid having the error "Rename... is not available during language servers starting."
+            // we wait for some ms.
+            try {
+                LanguageServiceAccessor.getInstance(file.getProject())
+                        .getLanguageServers(file.getVirtualFile(), null)
+                        .get(5000, TimeUnit.MILLISECONDS);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        final AtomicReference<String> actualError = new AtomicReference<>();
+
+        var handler = new LSPRenameUnitTestMode.LSPRenameUnitTestModeHandler() {
+
+            @Override
+            public void showErrorHint(String errorHintText) {
+                if (expectedError == null) {
+                    Assert.assertNull("Should not have error while renaming", errorHintText);
+                }
+                actualError.set(errorHintText);
+            }
+
+            @Override
+            public void showRenameRefactoringDialog(RenameParams renameParams) {
+                Assert.assertEquals("Placeholder should be equals", expectedPlaceholder, renameParams.getNewName());
+            }
+        };
+        LSPRenameUnitTestMode.set(handler);
+
+        // Do Rename...
+        myFixture.performEditorAction(IdeActions.ACTION_RENAME);
+
+        if (expectedError != null) {
+            assertEquals(expectedError, actualError.get());
+        } else {
+            assertEquals(expectedRenamedText, myFixture.getEditor().getDocument().getText());
+        }
+    }
+
+    @NotNull
+    private static Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> getPrepareRenameResponse(@NotNull String jsonPrepareRenameResult) {
+        Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> prepareRenameResponse = null;
+        if (jsonPrepareRenameResult.contains("range")) {
+            prepareRenameResponse = Either3.forSecond(JSONUtils.getLsp4jGson().fromJson(jsonPrepareRenameResult, PrepareRenameResult.class));
+        } else if (jsonPrepareRenameResult.contains("start")) {
+            prepareRenameResponse = Either3.forFirst(JSONUtils.getLsp4jGson().fromJson(jsonPrepareRenameResult, Range.class));
+        } else {
+            prepareRenameResponse = Either3.forThird(JSONUtils.getLsp4jGson().fromJson(jsonPrepareRenameResult, PrepareRenameDefaultBehavior.class));
+        }
+        return prepareRenameResponse;
+    }
+
+    private static void updateRenameCapabilities(@Nullable String jsonPrepareRenameResult) {
+        Either<Boolean, RenameOptions> renameProvider = null;
+        if (jsonPrepareRenameResult != null) {
+            RenameOptions prepareRenameProvider = new RenameOptions();
+            prepareRenameProvider.setPrepareProvider(true);
+            renameProvider = Either.forRight(prepareRenameProvider);
+        } else {
+            renameProvider = Either.forLeft(Boolean.TRUE);
+        }
+        ServerCapabilities serverCapabilities = MockLanguageServer.defaultServerCapabilities();
+        serverCapabilities.setRenameProvider(renameProvider);
+        MockLanguageServer.reset(() -> serverCapabilities);
+    }
+
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
@@ -19,6 +19,7 @@ package com.redhat.devtools.lsp4ij.mock;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Either3;
 import org.eclipse.lsp4j.launch.LSPLauncher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -26,6 +27,7 @@ import org.eclipse.lsp4j.services.NotebookDocumentService;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -129,10 +131,6 @@ public final class MockLanguageServer implements LanguageServer {
 		capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 		capabilities
 				.setExecuteCommandProvider(new ExecuteCommandOptions(Collections.singletonList(SUPPORTED_COMMAND_ID)));
-		RenameOptions prepareRenameProvider = new RenameOptions();
-		prepareRenameProvider.setPrepareProvider(true);
-		Either<Boolean, RenameOptions> renameEither = Either.forRight(prepareRenameProvider);
-		capabilities.setRenameProvider(renameEither);
 		capabilities.setColorProvider(Boolean.TRUE);
 		capabilities.setDocumentSymbolProvider(Boolean.TRUE);
 		capabilities.setLinkedEditingRangeProvider(new LinkedEditingRangeRegistrationOptions());
@@ -224,6 +222,14 @@ public final class MockLanguageServer implements LanguageServer {
 		initializeResult.getCapabilities().setTextDocumentSync(textDocumentSyncOptions);
 
 		this.textDocumentService.setWillSaveWaitUntilCallback(edits);
+	}
+
+	public void setPrepareRenameProcessor(Function<PrepareRenameParams, Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> prepareRenameProcessor) {
+		this.textDocumentService.setPrepareRenameProcessor(prepareRenameProcessor);
+	}
+
+	public void setRenameProcessor(Function<RenameParams, WorkspaceEdit> renameProcessor) {
+		this.textDocumentService.setRenameProcessor(renameProcessor);
 	}
 
 	public InitializeResult getInitializeResult() {

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
@@ -34,182 +34,180 @@ import java.util.function.Function;
  */
 public class MockTextDocumentService implements TextDocumentService {
 
-	private CompletionList mockCompletionList;
-	private Hover mockHover;
-	private List<? extends Location> mockDefinitionLocations;
-	private List<? extends LocationLink> mockTypeDefinitions;
-	private List<? extends TextEdit> mockFormattingTextEdits;
-	private SignatureHelp mockSignatureHelp;
-	private List<CodeLens> mockCodeLenses;
-	private List<DocumentLink> mockDocumentLinks;
-	private Map<Position, List<? extends DocumentHighlight>> mockDocumentHighlights;
-	private LinkedEditingRanges mockLinkedEditingRanges;
+    private CompletionList mockCompletionList;
+    private Hover mockHover;
+    private List<? extends Location> mockDefinitionLocations;
+    private List<? extends LocationLink> mockTypeDefinitions;
+    private List<? extends TextEdit> mockFormattingTextEdits;
+    private SignatureHelp mockSignatureHelp;
+    private List<CodeLens> mockCodeLenses;
+    private List<DocumentLink> mockDocumentLinks;
+    private Map<Position, List<? extends DocumentHighlight>> mockDocumentHighlights;
+    private LinkedEditingRanges mockLinkedEditingRanges;
 
-	private CompletableFuture<DidOpenTextDocumentParams> didOpenCallback;
-	private CompletableFuture<DidSaveTextDocumentParams> didSaveCallback;
-	private CompletableFuture<DidCloseTextDocumentParams> didCloseCallback;
-	private List<TextEdit> mockWillSaveWaitUntilTextEdits;
-	private ConcurrentLinkedQueue<DidChangeTextDocumentParams> didChangeEvents = new ConcurrentLinkedQueue<>();
+    private CompletableFuture<DidOpenTextDocumentParams> didOpenCallback;
+    private CompletableFuture<DidSaveTextDocumentParams> didSaveCallback;
+    private CompletableFuture<DidCloseTextDocumentParams> didCloseCallback;
+    private List<TextEdit> mockWillSaveWaitUntilTextEdits;
+    private ConcurrentLinkedQueue<DidChangeTextDocumentParams> didChangeEvents = new ConcurrentLinkedQueue<>();
 
-	private Function<?, ? extends CompletableFuture<?>> _futureFactory;
-	private List<LanguageClient> remoteProxies;
-	private Location[] mockReferences = new Location[0];
-	private List<Diagnostic> diagnostics;
-	private List<Either<Command, CodeAction>> mockCodeActions;
-	private List<ColorInformation> mockDocumentColors;
-	private WorkspaceEdit mockRenameEdit;
-	private Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> mockPrepareRenameResult;
-	private List<DocumentSymbol> documentSymbols;
-	private SemanticTokens mockSemanticTokens;
-	private List<FoldingRange> foldingRanges;
-	public int codeActionRequests = 0;
+    private Function<?, ? extends CompletableFuture<?>> _futureFactory;
+    private List<LanguageClient> remoteProxies;
+    private Location[] mockReferences = new Location[0];
+    private List<Diagnostic> diagnostics;
+    private List<Either<Command, CodeAction>> mockCodeActions;
+    private List<ColorInformation> mockDocumentColors;
+    private Function<PrepareRenameParams, Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> prepareRenameProcessor;
+    private Function<RenameParams, WorkspaceEdit> renameProcessor;
+    private List<DocumentSymbol> documentSymbols;
+    private SemanticTokens mockSemanticTokens;
+    private List<FoldingRange> foldingRanges;
+    public int codeActionRequests = 0;
 
-	public <U> MockTextDocumentService(Function<U, CompletableFuture<U>> futureFactory) {
-		this._futureFactory = futureFactory;
-		// Some default values for mocks, can be overriden
-		CompletionItem item = new CompletionItem();
-		item.setLabel("Mock completion item");
-		mockCompletionList = new CompletionList(false, Collections.singletonList(item));
-		mockHover = new Hover(Collections.singletonList(Either.forLeft("Mock hover")), null);
-		mockPrepareRenameResult = Either3
-				.forSecond(new PrepareRenameResult(new Range(new Position(0, 0), new Position(0, 0)), "placeholder"));
-		this.remoteProxies = new ArrayList<>();
-		this.documentSymbols = Collections.emptyList();
-		this.codeActionRequests = 0;
-	}
+    public <U> MockTextDocumentService(Function<U, CompletableFuture<U>> futureFactory) {
+        this._futureFactory = futureFactory;
+        // Some default values for mocks, can be overriden
+        CompletionItem item = new CompletionItem();
+        item.setLabel("Mock completion item");
+        mockCompletionList = new CompletionList(false, Collections.singletonList(item));
+        mockHover = new Hover(Collections.singletonList(Either.forLeft("Mock hover")), null);
+        this.remoteProxies = new ArrayList<>();
+        this.documentSymbols = Collections.emptyList();
+        this.codeActionRequests = 0;
+    }
 
-	private <U> CompletableFuture<U> futureFactory(U value) {
-		return ((Function<U, CompletableFuture<U>>) this._futureFactory).apply(value);
-	}
+    private <U> CompletableFuture<U> futureFactory(U value) {
+        return ((Function<U, CompletableFuture<U>>) this._futureFactory).apply(value);
+    }
 
-	@Override
-	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
-		return futureFactory(Either.forRight(mockCompletionList));
-	}
+    @Override
+    public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
+        return futureFactory(Either.forRight(mockCompletionList));
+    }
 
-	@Override
-	public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
-		return CompletableFuture.completedFuture(null);
-	}
+    @Override
+    public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
+        return CompletableFuture.completedFuture(null);
+    }
 
-	@Override
-	public CompletableFuture<Hover> hover(HoverParams position) {
-		return CompletableFuture.completedFuture(mockHover);
-	}
+    @Override
+    public CompletableFuture<Hover> hover(HoverParams position) {
+        return CompletableFuture.completedFuture(mockHover);
+    }
 
-	@Override
-	public CompletableFuture<SignatureHelp> signatureHelp(SignatureHelpParams position) {
-		return CompletableFuture.completedFuture(mockSignatureHelp);
-	}
+    @Override
+    public CompletableFuture<SignatureHelp> signatureHelp(SignatureHelpParams position) {
+        return CompletableFuture.completedFuture(mockSignatureHelp);
+    }
 
-	@Override
-	public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> definition(
-			DefinitionParams position) {
-		return CompletableFuture.completedFuture(Either.forLeft(mockDefinitionLocations));
-	}
+    @Override
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> definition(
+            DefinitionParams position) {
+        return CompletableFuture.completedFuture(Either.forLeft(mockDefinitionLocations));
+    }
 
-	@Override
-	public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
-		return futureFactory(Arrays.asList(this.mockReferences));
-	}
+    @Override
+    public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
+        return futureFactory(Arrays.asList(this.mockReferences));
+    }
 
-	@Override
-	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams params) {
-		return CompletableFuture.completedFuture((mockDocumentHighlights != null) //
-				? mockDocumentHighlights.getOrDefault(params.getPosition(), Collections.emptyList())
-				: null);
-	}
+    @Override
+    public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams params) {
+        return CompletableFuture.completedFuture((mockDocumentHighlights != null) //
+                ? mockDocumentHighlights.getOrDefault(params.getPosition(), Collections.emptyList())
+                : null);
+    }
 
-	@Override
-	public CompletableFuture<LinkedEditingRanges> linkedEditingRange(LinkedEditingRangeParams position) {
-		return CompletableFuture.completedFuture(mockLinkedEditingRanges);
-	}
+    @Override
+    public CompletableFuture<LinkedEditingRanges> linkedEditingRange(LinkedEditingRangeParams position) {
+        return CompletableFuture.completedFuture(mockLinkedEditingRanges);
+    }
 
-	@Override
-	public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(
-			DocumentSymbolParams params) {
-		return CompletableFuture.completedFuture(documentSymbols.stream()
-				.map(symbol -> {
-					Either<SymbolInformation, DocumentSymbol> res = Either.forRight(symbol);
-					return res;
-				}).toList());
-	}
+    @Override
+    public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(
+            DocumentSymbolParams params) {
+        return CompletableFuture.completedFuture(documentSymbols.stream()
+                .map(symbol -> {
+                    Either<SymbolInformation, DocumentSymbol> res = Either.forRight(symbol);
+                    return res;
+                }).toList());
+    }
 
-	@Override
-	public CompletableFuture<List<DocumentLink>> documentLink(DocumentLinkParams params) {
-		return CompletableFuture.completedFuture(mockDocumentLinks);
-	}
+    @Override
+    public CompletableFuture<List<DocumentLink>> documentLink(DocumentLinkParams params) {
+        return CompletableFuture.completedFuture(mockDocumentLinks);
+    }
 
-	@Override
-	public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
-		codeActionRequests++;
-		return futureFactory(this.mockCodeActions);
-	}
+    @Override
+    public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
+        codeActionRequests++;
+        return futureFactory(this.mockCodeActions);
+    }
 
-	@Override
-	public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
-		if (mockCodeLenses != null) {
-			return CompletableFuture.completedFuture(mockCodeLenses);
-		}
-		File file = new File(URI.create(params.getTextDocument().getUri()));
-		if (file.exists() && file.length() > 100) {
-			return CompletableFuture.completedFuture(Collections.singletonList(new CodeLens(
-					new Range(new Position(1, 0), new Position(1, 1)), new Command("Hi, I'm a CodeLens", null), null)));
-		}
-		return CompletableFuture.completedFuture(Collections.emptyList());
-	}
+    @Override
+    public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
+        if (mockCodeLenses != null) {
+            return CompletableFuture.completedFuture(mockCodeLenses);
+        }
+        File file = new File(URI.create(params.getTextDocument().getUri()));
+        if (file.exists() && file.length() > 100) {
+            return CompletableFuture.completedFuture(Collections.singletonList(new CodeLens(
+                    new Range(new Position(1, 0), new Position(1, 1)), new Command("Hi, I'm a CodeLens", null), null)));
+        }
+        return CompletableFuture.completedFuture(Collections.emptyList());
+    }
 
-	@Override
-	public CompletableFuture<CodeLens> resolveCodeLens(CodeLens unresolved) {
-		return CompletableFuture.completedFuture(null);
-	}
+    @Override
+    public CompletableFuture<CodeLens> resolveCodeLens(CodeLens unresolved) {
+        return CompletableFuture.completedFuture(null);
+    }
 
-	@Override
-	public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
-		return CompletableFuture.completedFuture(mockFormattingTextEdits);
-	}
+    @Override
+    public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
+        return CompletableFuture.completedFuture(mockFormattingTextEdits);
+    }
 
-	@Override
-	public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
-		return CompletableFuture.completedFuture(null);
-	}
+    @Override
+    public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
+        return CompletableFuture.completedFuture(null);
+    }
 
-	@Override
-	public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(DocumentOnTypeFormattingParams params) {
-		return CompletableFuture.completedFuture(null);
-	}
+    @Override
+    public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(DocumentOnTypeFormattingParams params) {
+        return CompletableFuture.completedFuture(null);
+    }
 
-	@Override
-	public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
-		return CompletableFuture.completedFuture(mockRenameEdit);
-	}
+    @Override
+    public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
+        return CompletableFuture.supplyAsync(() -> renameProcessor.apply(params));
+    }
 
-	@Override
-	public CompletableFuture<Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> prepareRename(
-			PrepareRenameParams params) {
-		return CompletableFuture.completedFuture(this.mockPrepareRenameResult);
-	}
+    @Override
+    public CompletableFuture<Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> prepareRename(
+            PrepareRenameParams params) {
+        return CompletableFuture.supplyAsync(() -> this.prepareRenameProcessor.apply(params));
+    }
 
-	@Override
-	public void didOpen(DidOpenTextDocumentParams params) {
-		if (didOpenCallback != null) {
-			didOpenCallback.complete(params);
-			didOpenCallback = null;
-		}
+    @Override
+    public void didOpen(DidOpenTextDocumentParams params) {
+        if (didOpenCallback != null) {
+            didOpenCallback.complete(params);
+            didOpenCallback = null;
+        }
 
-		if (this.diagnostics != null && !this.diagnostics.isEmpty()) {
-			// we're not sure which remote proxy to use, but we know we should only use one
-			// per didOpen
-			// for proper LS interaction; so a strategy is to use the first one and rotate
-			// the others
-			// for further executions
-			synchronized (this.remoteProxies) {
-				// and we synchronize to avoid concurrent read/write on the list
-				this.remoteProxies.get(0).publishDiagnostics(
-						new PublishDiagnosticsParams(params.getTextDocument().getUri(), this.diagnostics));
-				Collections.rotate(this.remoteProxies, 1);
-			}
-		}
+        if (this.diagnostics != null && !this.diagnostics.isEmpty()) {
+            // we're not sure which remote proxy to use, but we know we should only use one
+            // per didOpen
+            // for proper LS interaction; so a strategy is to use the first one and rotate
+            // the others
+            // for further executions
+            synchronized (this.remoteProxies) {
+                // and we synchronize to avoid concurrent read/write on the list
+                this.remoteProxies.get(0).publishDiagnostics(
+                        new PublishDiagnosticsParams(params.getTextDocument().getUri(), this.diagnostics));
+                Collections.rotate(this.remoteProxies, 1);
+            }
+        }
 //		if (this.foldingRanges != null && !this.foldingRanges.isEmpty()) {
 //			synchronized (this.remoteProxies) {
 //				// and we synchronize to avoid concurrent read/write on the list
@@ -217,198 +215,199 @@ public class MockTextDocumentService implements TextDocumentService {
 //						new PublishDiagnosticsParams(params.getTextDocument().getUri(), this.diagnostics));
 //				Collections.rotate(this.remoteProxies, 1);
 //		}
-	}
+    }
 
-	@Override
-	public void didChange(DidChangeTextDocumentParams params) {
-		this.didChangeEvents.add(params);
-	}
+    @Override
+    public void didChange(DidChangeTextDocumentParams params) {
+        this.didChangeEvents.add(params);
+    }
 
-	@Override
-	public void didClose(DidCloseTextDocumentParams params) {
-		if (didCloseCallback != null) {
-			didCloseCallback.complete(params);
-			didCloseCallback = null;
-		}
-	}
+    @Override
+    public void didClose(DidCloseTextDocumentParams params) {
+        if (didCloseCallback != null) {
+            didCloseCallback.complete(params);
+            didCloseCallback = null;
+        }
+    }
 
-	@Override
-	public void didSave(DidSaveTextDocumentParams params) {
-		if (didSaveCallback != null) {
-			didSaveCallback.complete(params);
-			didSaveCallback = null;
-		}
-	}
+    @Override
+    public void didSave(DidSaveTextDocumentParams params) {
+        if (didSaveCallback != null) {
+            didSaveCallback.complete(params);
+            didSaveCallback = null;
+        }
+    }
 
-	@Override
-	public CompletableFuture<List<TextEdit>> willSaveWaitUntil(WillSaveTextDocumentParams params) {
-		if (mockWillSaveWaitUntilTextEdits != null) {
-			return CompletableFuture.completedFuture(mockWillSaveWaitUntilTextEdits);
-		}
-		return null;
-	}
+    @Override
+    public CompletableFuture<List<TextEdit>> willSaveWaitUntil(WillSaveTextDocumentParams params) {
+        if (mockWillSaveWaitUntilTextEdits != null) {
+            return CompletableFuture.completedFuture(mockWillSaveWaitUntilTextEdits);
+        }
+        return null;
+    }
 
-	@Override
-	public CompletableFuture<List<ColorInformation>> documentColor(DocumentColorParams params) {
-		return CompletableFuture.completedFuture(this.mockDocumentColors);
-	}
+    @Override
+    public CompletableFuture<List<ColorInformation>> documentColor(DocumentColorParams params) {
+        return CompletableFuture.completedFuture(this.mockDocumentColors);
+    }
 
-	@Override
-	public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> typeDefinition(
-			TypeDefinitionParams position) {
-		return CompletableFuture.completedFuture(Either.forRight(this.mockTypeDefinitions));
-	}
+    @Override
+    public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> typeDefinition(
+            TypeDefinitionParams position) {
+        return CompletableFuture.completedFuture(Either.forRight(this.mockTypeDefinitions));
+    }
 
-	@Override
-	public CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
-		return CompletableFuture.completedFuture(unresolved);
-	}
+    @Override
+    public CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
+        return CompletableFuture.completedFuture(unresolved);
+    }
 
-	public void setMockCompletionList(CompletionList completionList) {
-		this.mockCompletionList = completionList;
-	}
+    public void setMockCompletionList(CompletionList completionList) {
+        this.mockCompletionList = completionList;
+    }
 
-	public void setDidOpenCallback(CompletableFuture<DidOpenTextDocumentParams> didOpenExpectation) {
-		this.didOpenCallback = didOpenExpectation;
-	}
+    public void setDidOpenCallback(CompletableFuture<DidOpenTextDocumentParams> didOpenExpectation) {
+        this.didOpenCallback = didOpenExpectation;
+    }
 
-	public List<DidChangeTextDocumentParams> getDidChangeEvents() {
-		return new ArrayList<>(this.didChangeEvents);
-	}
+    public List<DidChangeTextDocumentParams> getDidChangeEvents() {
+        return new ArrayList<>(this.didChangeEvents);
+    }
 
-	public void setDidSaveCallback(CompletableFuture<DidSaveTextDocumentParams> didSaveExpectation) {
-		this.didSaveCallback = didSaveExpectation;
-	}
+    public void setDidSaveCallback(CompletableFuture<DidSaveTextDocumentParams> didSaveExpectation) {
+        this.didSaveCallback = didSaveExpectation;
+    }
 
-	public void setDidCloseCallback(CompletableFuture<DidCloseTextDocumentParams> didCloseExpectation) {
-		this.didCloseCallback = didCloseExpectation;
-	}
+    public void setDidCloseCallback(CompletableFuture<DidCloseTextDocumentParams> didCloseExpectation) {
+        this.didCloseCallback = didCloseExpectation;
+    }
 
-	public void setMockHover(Hover hover) {
-		this.mockHover = hover;
-	}
+    public void setMockHover(Hover hover) {
+        this.mockHover = hover;
+    }
 
-	public void setPrepareRenameResult(Either<Range, PrepareRenameResult> result) {
-		this.mockPrepareRenameResult = result == null ? null : result.map(Either3::forFirst, Either3::forSecond);
-	}
+    public void setMockCodeLenses(List<CodeLens> codeLenses) {
+        this.mockCodeLenses = codeLenses;
+    }
 
-	public void setMockCodeLenses(List<CodeLens> codeLenses) {
-		this.mockCodeLenses = codeLenses;
-	}
+    public void setMockDefinitionLocations(List<? extends Location> definitionLocations) {
+        this.mockDefinitionLocations = definitionLocations;
+    }
 
-	public void setMockDefinitionLocations(List<? extends Location> definitionLocations) {
-		this.mockDefinitionLocations = definitionLocations;
-	}
+    public void setMockReferences(Location... locations) {
+        this.mockReferences = locations;
+    }
 
-	public void setMockReferences(Location... locations) {
-		this.mockReferences = locations;
-	}
+    public void setMockFormattingTextEdits(List<? extends TextEdit> formattingTextEdits) {
+        this.mockFormattingTextEdits = formattingTextEdits;
+    }
 
-	public void setMockFormattingTextEdits(List<? extends TextEdit> formattingTextEdits) {
-		this.mockFormattingTextEdits = formattingTextEdits;
-	}
+    public void setMockDocumentLinks(List<DocumentLink> documentLinks) {
+        this.mockDocumentLinks = documentLinks;
+    }
 
-	public void setMockDocumentLinks(List<DocumentLink> documentLinks) {
-		this.mockDocumentLinks = documentLinks;
-	}
+    public void reset() {
+        this.mockCompletionList = new CompletionList();
+        this.mockDefinitionLocations = Collections.emptyList();
+        this.mockTypeDefinitions = Collections.emptyList();
+        this.mockHover = null;
+        this.mockCodeLenses = null;
+        this.mockReferences = null;
+        this.remoteProxies = new ArrayList<>();
+        this.mockCodeActions = new ArrayList<>();
+        this.renameProcessor = null;
+        this.prepareRenameProcessor = null;
+        this.documentSymbols = Collections.emptyList();
+        this.foldingRanges = new ArrayList<>();
+        this.codeActionRequests = 0;
+    }
 
-	public void reset() {
-		this.mockCompletionList = new CompletionList();
-		this.mockDefinitionLocations = Collections.emptyList();
-		this.mockTypeDefinitions = Collections.emptyList();
-		this.mockHover = null;
-		this.mockCodeLenses = null;
-		this.mockReferences = null;
-		this.remoteProxies = new ArrayList<>();
-		this.mockCodeActions = new ArrayList<>();
-		this.mockRenameEdit = null;
-		this.documentSymbols = Collections.emptyList();
-		this.foldingRanges = new ArrayList<>();
-		this.codeActionRequests = 0;
-	}
+    public void setDiagnostics(List<Diagnostic> diagnostics) {
+        this.diagnostics = diagnostics;
+    }
 
-	public void setDiagnostics(List<Diagnostic> diagnostics) {
-		this.diagnostics = diagnostics;
-	}
+    public void addRemoteProxy(LanguageClient remoteProxy) {
+        this.remoteProxies.add(remoteProxy);
+    }
 
-	public void addRemoteProxy(LanguageClient remoteProxy) {
-		this.remoteProxies.add(remoteProxy);
-	}
+    public void setCodeActions(List<Either<Command, CodeAction>> codeActions) {
+        this.mockCodeActions = codeActions;
+    }
 
-	public void setCodeActions(List<Either<Command, CodeAction>> codeActions) {
-		this.mockCodeActions = codeActions;
-	}
+    public void setSignatureHelp(SignatureHelp signatureHelp) {
+        this.mockSignatureHelp = signatureHelp;
+    }
 
-	public void setSignatureHelp(SignatureHelp signatureHelp) {
-		this.mockSignatureHelp = signatureHelp;
-	}
+    public void setDocumentHighlights(Map<Position, List<? extends DocumentHighlight>> documentHighlights) {
+        this.mockDocumentHighlights = documentHighlights;
+    }
 
-	public void setDocumentHighlights(Map<Position, List<? extends DocumentHighlight>> documentHighlights) {
-		this.mockDocumentHighlights = documentHighlights;
-	}
+    public void setLinkedEditingRanges(LinkedEditingRanges linkedEditingRanges) {
+        this.mockLinkedEditingRanges = linkedEditingRanges;
+    }
 
-	public void setLinkedEditingRanges(LinkedEditingRanges linkedEditingRanges) {
-		this.mockLinkedEditingRanges = linkedEditingRanges;
-	}
+    public void setDocumentColors(List<ColorInformation> colors) {
+        this.mockDocumentColors = colors;
+    }
 
-	public void setDocumentColors(List<ColorInformation> colors) {
-		this.mockDocumentColors = colors;
-	}
+    public void setPrepareRenameProcessor(Function<PrepareRenameParams, Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>> prepareRenameProcessor) {
+        this.prepareRenameProcessor = prepareRenameProcessor;
+    }
 
-	public void setRenameEdit(WorkspaceEdit edit) {
-		this.mockRenameEdit = edit;
-	}
+    public void setRenameProcessor(Function<RenameParams, WorkspaceEdit> renameProcessor) {
+        this.renameProcessor = renameProcessor;
+    }
 
-	public void setMockTypeDefinitions(List<? extends LocationLink> mockTypeDefinitions) {
-		this.mockTypeDefinitions = mockTypeDefinitions;
-	}
+    public void setMockTypeDefinitions(List<? extends LocationLink> mockTypeDefinitions) {
+        this.mockTypeDefinitions = mockTypeDefinitions;
+    }
 
-	public void setDocumentSymbols(List<DocumentSymbol> symbols) {
-		this.documentSymbols = symbols;
-	}
+    public void setDocumentSymbols(List<DocumentSymbol> symbols) {
+        this.documentSymbols = symbols;
+    }
 
-	public void setWillSaveWaitUntilCallback(List<TextEdit> textEdits) {
-		this.mockWillSaveWaitUntilTextEdits = textEdits;
-	}
+    public void setWillSaveWaitUntilCallback(List<TextEdit> textEdits) {
+        this.mockWillSaveWaitUntilTextEdits = textEdits;
+    }
 
-	public void setSemanticTokens(final SemanticTokens semanticTokens) {
-		this.mockSemanticTokens = semanticTokens;
-	}
+    public void setSemanticTokens(final SemanticTokens semanticTokens) {
+        this.mockSemanticTokens = semanticTokens;
+    }
 
-	@Override
-	public CompletableFuture<SemanticTokens> semanticTokensFull(SemanticTokensParams params) {
-		return CompletableFuture.completedFuture(this.mockSemanticTokens);
-	}
+    @Override
+    public CompletableFuture<SemanticTokens> semanticTokensFull(SemanticTokensParams params) {
+        return CompletableFuture.completedFuture(this.mockSemanticTokens);
+    }
 
-	private static final Range DUMMY_RANGE = new Range(new Position(0, 0), new Position(0, 0));
+    private static final Range DUMMY_RANGE = new Range(new Position(0, 0), new Position(0, 0));
 
-	@Override
-	public CompletableFuture<List<TypeHierarchyItem>> prepareTypeHierarchy(TypeHierarchyPrepareParams params) {
-		return CompletableFuture.completedFuture(List.of(new TypeHierarchyItem("a", SymbolKind.Class, params.getTextDocument().getUri(), DUMMY_RANGE, DUMMY_RANGE, null)));
-	}
+    @Override
+    public CompletableFuture<List<TypeHierarchyItem>> prepareTypeHierarchy(TypeHierarchyPrepareParams params) {
+        return CompletableFuture.completedFuture(List.of(new TypeHierarchyItem("a", SymbolKind.Class, params.getTextDocument().getUri(), DUMMY_RANGE, DUMMY_RANGE, null)));
+    }
 
-	@Override
-	public CompletableFuture<List<TypeHierarchyItem>> typeHierarchySubtypes(TypeHierarchySubtypesParams params) {
-		return CompletableFuture.completedFuture(List.of(
-			new TypeHierarchyItem(params.getItem().getName() + "a", SymbolKind.Class, params.getItem().getUri() + "/a", DUMMY_RANGE, DUMMY_RANGE, null),
-			new TypeHierarchyItem(params.getItem().getName() + "b", SymbolKind.Class, params.getItem().getUri() + "/b", DUMMY_RANGE, DUMMY_RANGE, null)
-		));
-	}
+    @Override
+    public CompletableFuture<List<TypeHierarchyItem>> typeHierarchySubtypes(TypeHierarchySubtypesParams params) {
+        return CompletableFuture.completedFuture(List.of(
+                new TypeHierarchyItem(params.getItem().getName() + "a", SymbolKind.Class, params.getItem().getUri() + "/a", DUMMY_RANGE, DUMMY_RANGE, null),
+                new TypeHierarchyItem(params.getItem().getName() + "b", SymbolKind.Class, params.getItem().getUri() + "/b", DUMMY_RANGE, DUMMY_RANGE, null)
+        ));
+    }
 
-	@Override
-	public CompletableFuture<List<TypeHierarchyItem>> typeHierarchySupertypes(TypeHierarchySupertypesParams params) {
-		return CompletableFuture.completedFuture(List.of(
-			new TypeHierarchyItem("X" + params.getItem().getName(), SymbolKind.Class, params.getItem().getUri() + "/X", DUMMY_RANGE, DUMMY_RANGE, null),
-			new TypeHierarchyItem("Y" + params.getItem().getName(), SymbolKind.Class, params.getItem().getUri() + "/Y", DUMMY_RANGE, DUMMY_RANGE, null)
-		));
-	}
+    @Override
+    public CompletableFuture<List<TypeHierarchyItem>> typeHierarchySupertypes(TypeHierarchySupertypesParams params) {
+        return CompletableFuture.completedFuture(List.of(
+                new TypeHierarchyItem("X" + params.getItem().getName(), SymbolKind.Class, params.getItem().getUri() + "/X", DUMMY_RANGE, DUMMY_RANGE, null),
+                new TypeHierarchyItem("Y" + params.getItem().getName(), SymbolKind.Class, params.getItem().getUri() + "/Y", DUMMY_RANGE, DUMMY_RANGE, null)
+        ));
+    }
 
-	public void setFoldingRanges(List<FoldingRange> foldingRanges) {
-		this.foldingRanges = foldingRanges;
-	}
+    public void setFoldingRanges(List<FoldingRange> foldingRanges) {
+        this.foldingRanges = foldingRanges;
+    }
 
-	@Override
-	public CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params) {
-		return CompletableFuture.completedFuture(this.foldingRanges);
-	}
+    @Override
+    public CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params) {
+        return CompletableFuture.completedFuture(this.foldingRanges);
+    }
 }


### PR DESCRIPTION
test: Add tests for rename

Fixes #253

This PR adds all tests for prepare rename / rename support with all usecases

 * when language server don't support prepare rename (see QuteRenameTest)
 * when language server supports prepare rename with only Range (see RustRenameTest)
 * when language server supports prepare rename with PrepareRenameResult (see GoRenameTest)
 * when language server supports prepare rename with PrepareRenameResult default behavior (see GoRenameTest)
 * when prepare rename throws an error when renamed cannot happen(see RustRenameTest)
 * when rename throws an error  (see GoRenameTest)
 * fixes the case when prepare rename returns null (see GoRenameTest), in this case the rename cannot happen (according to the LSP spec).