### PR TITLE
chore: tweak mock server sleep time for LSPRenameFixtureTestCase

### DIFF
--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPRenameFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPRenameFixtureTestCase.java
@@ -141,7 +141,7 @@ public abstract class LSPRenameFixtureTestCase extends LSPCodeInsightFixtureTest
                               boolean waitFor) {
         updateRenameCapabilities(jsonPrepareRenameResponse);
 
-        MockLanguageServer.INSTANCE.setTimeToProceedQueries(450);
+        MockLanguageServer.INSTANCE.setTimeToProceedQueries(500);
         PsiFile file = myFixture.configureByText(fileName, text);
 
         // Prepare rename response


### PR DESCRIPTION
trial n error approach to fix LSPRenameFixtureTestCase tests occasionally failing on GHA mac
