### PR TITLE
fix: Language server console is always showing timer with "stopping pid" message, even if the file is open.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -601,6 +601,7 @@ public class LanguageServerWrapper implements Disposable {
     private CompletableFuture<LanguageServer> connect(@NotNull URI fileUri,
                                                       @Nullable VirtualFile optionalFile,
                                                       @Nullable Document optionalDocument) {
+        removeStopTimer(false);
 
         var ls = getLanguageServerWhenDidOpen(fileUri);
         if (ls != null) {


### PR DESCRIPTION
fix: Language server console is always showing timer with "stopping pid" message, even if the file is open.

Fixes #302