### PR TITLE
fix: Completion additionalTextEdits generates wrong content

### DIFF
--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/BootstrapPropertiesCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/BootstrapPropertiesCompletionTest.java
@@ -60,7 +60,7 @@ public class BootstrapPropertiesCompletionTest extends LSPCompletionFixtureTestC
                 "com.ibm.ws.logging.max.files",
                 "com.ibm.ws.logging.max.file.size");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "com.ibm.ws.logging.max.file.size");
+        assertApplyCompletionItem(0, "com.ibm.ws.logging.max.file.size<caret>");
     }
 
     // ------------ Completion on property value
@@ -92,7 +92,7 @@ public class BootstrapPropertiesCompletionTest extends LSPCompletionFixtureTestC
                 "true",
                 "false");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false");
+        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false<caret>");
     }
 
     public void testCompletionOnPropertyValueWithValueAtEnd() {
@@ -120,7 +120,7 @@ public class BootstrapPropertiesCompletionTest extends LSPCompletionFixtureTestC
                           ]"""
                 , "false");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false");
+        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false<caret>");
     }
 
     public void testCompletionOnPropertyValueWithValueInsideValue() {
@@ -148,6 +148,6 @@ public class BootstrapPropertiesCompletionTest extends LSPCompletionFixtureTestC
                           ]"""
                 , "false");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false");
+        assertApplyCompletionItem(0, "com.ibm.hpel.trace.bufferingEnabled=false<caret>");
     }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/ClojureCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/ClojureCompletionTest.java
@@ -45,7 +45,7 @@ public class ClojureCompletionTest extends LSPCompletionFixtureTestCase {
                           ]"""
                 , "let", "letfn");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "(let [binding value])");
+        assertApplyCompletionItem(0, "(let [binding<caret> value])");
     }
 
     public void testCompletionWithoutTextEdit() {
@@ -70,7 +70,7 @@ public class ClojureCompletionTest extends LSPCompletionFixtureTestCase {
                           ]"""
                 , "let", "letfn");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "(let [binding value])");
+        assertApplyCompletionItem(0, "(let [binding<caret> value])");
     }
 
     public void testCompletionWithoutTextEditAndCaretInsideToken() {
@@ -95,7 +95,7 @@ public class ClojureCompletionTest extends LSPCompletionFixtureTestCase {
                           ]"""
                 , "let", "letfn");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "(let [binding value])t");
+        assertApplyCompletionItem(0, "(let [binding<caret> value])t");
     }
 
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/GoCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/GoCompletionTest.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionFixtureTestCase;
+
+/**
+ * Completion tests by emulating LSP 'textDocument/completion' responses
+ * from the go language server which uses additionalTextEdits.
+ */
+public class GoCompletionTest extends LSPCompletionFixtureTestCase {
+
+    public GoCompletionTest() {
+        super("*.go");
+    }
+
+    public void testCompletionWithAdditionalTextEdits() {
+        // 1. Test completion items result
+        assertCompletion("test.go",
+                """
+                        package src
+                         
+                        import "math/rand"
+                         
+                        func foo() {
+                          for
+                        }
+                        """, """                
+                        {
+                             "isIncomplete": true,
+                             "items": [
+                               {
+                                 "label": "format",
+                                 "kind": 9,
+                                 "detail": "\\"go/format\\"",
+                                 "documentation": {
+                                   "kind": "markdown",
+                                   "value": ""
+                                 },
+                                 "preselect": true,
+                                 "sortText": "00000",
+                                 "filterText": "format",
+                                 "insertTextFormat": 2,
+                                 "textEdit": {
+                                   "range": {
+                                     "start": {
+                                       "line": 5,
+                                       "character": 2
+                                     },
+                                     "end": {
+                                       "line": 5,
+                                       "character": 5
+                                     }
+                                   },
+                                   "newText": "format"
+                                 },
+                                 "additionalTextEdits": [
+                                   {
+                                     "range": {
+                                       "start": {
+                                         "line": 2,
+                                         "character": 7
+                                       },
+                                       "end": {
+                                         "line": 2,
+                                         "character": 7
+                                       }
+                                     },
+                                     "newText": "(\\n\\t\\"go/format\\"\\n\\t"
+                                   },
+                                   {
+                                     "range": {
+                                       "start": {
+                                         "line": 2,
+                                         "character": 18
+                                       },
+                                       "end": {
+                                         "line": 2,
+                                         "character": 18
+                                       }
+                                     },
+                                     "newText": "\\n)"
+                                   }
+                                 ]
+                               },
+                               {
+                                 "label": "format",
+                                 "kind": 9,
+                                 "detail": "\\"mvdan.cc/gofumpt/format\\"",
+                                 "documentation": {
+                                   "kind": "markdown",
+                                   "value": ""
+                                 },
+                                 "sortText": "00001",
+                                 "filterText": "format",
+                                 "insertTextFormat": 2,
+                                 "textEdit": {
+                                   "range": {
+                                     "start": {
+                                       "line": 5,
+                                       "character": 2
+                                     },
+                                     "end": {
+                                       "line": 5,
+                                       "character": 5
+                                     }
+                                   },
+                                   "newText": "format"
+                                 },
+                                 "additionalTextEdits": [
+                                   {
+                                     "range": {
+                                       "start": {
+                                         "line": 2,
+                                         "character": 7
+                                       },
+                                       "end": {
+                                         "line": 2,
+                                         "character": 7
+                                       }
+                                     },
+                                     "newText": "(\\n\\t"
+                                   },
+                                   {
+                                     "range": {
+                                       "start": {
+                                         "line": 3,
+                                         "character": 0
+                                       },
+                                       "end": {
+                                         "line": 3,
+                                         "character": 0
+                                       }
+                                     },
+                                     "newText": "\\n\\t\\"mvdan.cc/gofumpt/format\\"\\n)\\n"
+                                   }
+                                 ]
+                               }
+                             ]
+                           }
+                          """
+                , "format");
+        // 2. Test new editor content after applying the first completion item
+        assertApplyCompletionItem(0, """
+                package src
+                 
+                import (
+                	"go/format"
+                	"math/rand"
+                )
+                
+                func foo() {
+                  format<caret>
+                }
+                """);
+    }
+
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/MicroProfileConfigPropertiesCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/MicroProfileConfigPropertiesCompletionTest.java
@@ -62,7 +62,7 @@ public class MicroProfileConfigPropertiesCompletionTest extends LSPCompletionFix
                 "config_ordinal",
                 "quarkus.banner.enabled");
         // 2. Test new editor content after applying the second completion item
-        assertApplyCompletionItem(1, "quarkus.banner.enabled=false");
+        assertApplyCompletionItem(1, "quarkus.banner.enabled=false<caret>");
     }
 
     public void testCompletionOnPropertyKeyWithNotEmptyContent() {
@@ -101,7 +101,7 @@ public class MicroProfileConfigPropertiesCompletionTest extends LSPCompletionFix
                 ,
                 "quarkus.banner.enabled");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "quarkus.banner.enabled=false");
+        assertApplyCompletionItem(0, "quarkus.banner.enabled=false<caret>");
     }
 
     // ------------ Completion on property value
@@ -173,7 +173,7 @@ public class MicroProfileConfigPropertiesCompletionTest extends LSPCompletionFix
                 "false",
                 "true");
         // 2. Test new editor content after applying the second completion item
-        assertApplyCompletionItem(1, "quarkus.banner.enabled=true");
+        assertApplyCompletionItem(1, "quarkus.banner.enabled=true<caret>");
     }
 
     public void testCompletionOnPropertyValueWithNotEmptyContent() {
@@ -242,6 +242,6 @@ public class MicroProfileConfigPropertiesCompletionTest extends LSPCompletionFix
                 ,
                 "true");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "quarkus.banner.enabled=true");
+        assertApplyCompletionItem(0, "quarkus.banner.enabled=true<caret>");
     }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/QuteCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/QuteCompletionTest.java
@@ -92,7 +92,7 @@ public class QuteCompletionTest extends LSPCompletionFixtureTestCase {
         assertApplyCompletionItem(0, """
                 <ul>
                     {#for item in items}
-                        {item.name}
+                        {item.name}<caret>
                     {/for}
                 </ul>
                 """);

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionTest.java
@@ -52,7 +52,7 @@ public class TypeScriptCompletionTest extends LSPCompletionFixtureTestCase {
                          }"""
                 , "charAt");
         // 2. Test new editor content after applying the first completion item
-        assertApplyCompletionItem(0, "''.charAt");
+        assertApplyCompletionItem(0, "''.charAt<caret>");
     }
 
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionFixtureTestCase.java
@@ -84,7 +84,16 @@ public abstract class LSPCompletionFixtureTestCase extends LSPCodeInsightFixture
      */
     public void assertApplyCompletionItem(int selectedItemIndex,
                                           @NotNull String expectedEditorContentText) {
+        String expected = expectedEditorContentText;
+        int expectedCaretOffset = expectedEditorContentText.indexOf("<caret>");
+        if (expectedCaretOffset != -1) {
+            expected = expectedEditorContentText.substring(0, expectedCaretOffset) + expectedEditorContentText.substring("<caret>".length() + expectedCaretOffset);
+        }
         myFixture.selectItem(myFixture.getLookupElements()[selectedItemIndex]);
-        assertEquals(expectedEditorContentText, myFixture.getEditor().getDocument().getText());
+        var editor = myFixture.getEditor();
+        assertEquals(expected, editor.getDocument().getText());
+        if (expectedCaretOffset != -1) {
+            assertEquals(expectedCaretOffset, editor.getCaretModel().getOffset());
+        }
     }
 }


### PR DESCRIPTION
fix: Completion additionalTextEdits generates wrong content

Fixes #300

![GoCompletionImport](https://github.com/redhat-developer/lsp4ij/assets/1932211/1473f182-366a-4e67-80c8-3488c9321576)
