### PR TITLE
fix: resolve additionalTextEdits if empty

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
@@ -331,7 +331,7 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
             }
 
             List<TextEdit> additionalEdits = item.getAdditionalTextEdits();
-            if (additionalEdits == null && supportResolveCompletion) {
+            if ((additionalEdits == null || additionalEdits.isEmpty()) && supportResolveCompletion) {
                 // The LSP completion item 'additionalEdits' is not filled, try to resolve it.
                 CompletionItem resolved = getResolvedCompletionItem();
                 if (resolved != null) {

--- a/src/main/resources/templates/rust-analyzer/initializationOptions.json
+++ b/src/main/resources/templates/rust-analyzer/initializationOptions.json
@@ -1,16 +1,84 @@
 {
-  "imports" : {
-    "granularity" : {
-      "group" : "module"
+  "imports": {
+    "granularity": {
+      "group": "module"
     },
-    "prefix" : "self"
+    "prefix": "self"
   },
-  "cargo" : {
-    "buildScripts" : {
-      "enable" : true
+  "cargo": {
+    "buildScripts": {
+      "enable": true
     }
   },
-  "procMacro" : {
-    "enable" : true
+  "completion": {
+    "autoimport": {
+      "enable": true
+    },
+    "autoself": {
+      "enable": true
+    },
+    "callable": {
+      "snippets": "fill_arguments"
+    },
+    "fullFunctionSignatures": {
+      "enable": false
+    },
+    "limit": null,
+    "postfix": {
+      "enable": true
+    },
+    "privateEditable": {
+      "enable": false
+    },
+    "snippets": {
+      "custom": {
+        "Arc::new": {
+          "postfix": "arc",
+          "body": "Arc::new(${receiver})",
+          "requires": "std::sync::Arc",
+          "description": "Put the expression into an `Arc`",
+          "scope": "expr"
+        },
+        "Rc::new": {
+          "postfix": "rc",
+          "body": "Rc::new(${receiver})",
+          "requires": "std::rc::Rc",
+          "description": "Put the expression into an `Rc`",
+          "scope": "expr"
+        },
+        "Box::pin": {
+          "postfix": "pinbox",
+          "body": "Box::pin(${receiver})",
+          "requires": "std::boxed::Box",
+          "description": "Put the expression into a pinned `Box`",
+          "scope": "expr"
+        },
+        "Ok": {
+          "postfix": "ok",
+          "body": "Ok(${receiver})",
+          "description": "Wrap the expression in a `Result::Ok`",
+          "scope": "expr"
+        },
+        "Err": {
+          "postfix": "err",
+          "body": "Err(${receiver})",
+          "description": "Wrap the expression in a `Result::Err`",
+          "scope": "expr"
+        },
+        "Some": {
+          "postfix": "some",
+          "body": "Some(${receiver})",
+          "description": "Wrap the expression in an `Option::Some`",
+          "scope": "expr"
+        }
+      }
+    }
+  },
+  "termSearch": {
+    "enable": false,
+    "fuel": 200
+  },
+  "procMacro": {
+    "enable": true
   }
 }


### PR DESCRIPTION
Given this Rust file:

```
fn main() {
    Arc|
}
```

When completion is applied for Arc in vscode it generates the import like this:

```
use std::sync::Arc;

fn main() {
    Arc
}
```

In IJ it doesn't generate the `use std::sync::Arc;` because in LSP4IJ we don't resolve additionalTextEdits if it is empty and Rust return empty additionalTextEdits .

This PR fixes the problem:

![RustCompletionUser](https://github.com/redhat-developer/lsp4ij/assets/1932211/e989e8d6-458d-47a1-8118-f6982aee8955)
