### PR TITLE
feat: Support for labelDetails completionItem

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
@@ -225,6 +225,8 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
         if (isDeprecated()) {
             presentation.setStrikeout(true);
         }
+        var labelDetails = item.getLabelDetails();
+        presentation.setTailText(labelDetails != null ? labelDetails.getDetail() : null);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/ClientCapabilitiesFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/ClientCapabilitiesFactory.java
@@ -117,12 +117,13 @@ public class ClientCapabilitiesFactory {
         completionItemCapabilities
                 .setDocumentationFormat(List.of(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
         completionItemCapabilities.setInsertTextModeSupport(new CompletionItemInsertTextModeSupportCapabilities(List.of(InsertTextMode.AsIs, InsertTextMode.AdjustIndentation)));
-
         completionItemCapabilities.setResolveSupport(new CompletionItemResolveSupportCapabilities(
                 List.of(
                         "documentation",
                         "detail",
                         "additionalTextEdits")));
+        completionItemCapabilities.setDeprecatedSupport(Boolean.TRUE);
+        completionItemCapabilities.setLabelDetailsSupport(Boolean.TRUE);
         CompletionCapabilities completionCapabilities = new CompletionCapabilities(completionItemCapabilities);
         completionCapabilities.setCompletionList(new CompletionListCapabilities(List.of("editRange")));
         textDocumentClientCapabilities.setCompletion(completionCapabilities);


### PR DESCRIPTION
feat: Support for labelDetails completionItem

Given this rust file:

```
fn main() {
    CharArr|
}
```

You should see the completion wich render labelDetails#detail as completion tail text:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/4dacf029-8435-46da-8b67-67e9a6df6c9f)

I tried to have the same render than vscode:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/dcdf1c75-5e0e-4877-869a-160f28ad5c6e)

Here LSP traces:

```
[Trace - 17:18:10] Received response 'textDocument/completion - (227)' in 13ms.
Result: {
  "isIncomplete": true,
  "items": [
    {
      "label": "CharArraySearcher",
      "labelDetails": {
        "detail": " (use std::str::pattern::CharArraySearcher)",
        "description": "CharArraySearcher\u003c\u0027_, _\u003e"
      },
      "kind": 22,
      "detail": "CharArraySearcher\u003c\u0027_, _\u003e",
      "documentation": {
        "kind": "markdown",
        "value": "Associated type for `\u003c[char; N] as Pattern\u003c\u0027a\u003e\u003e::Searcher`."
      },
      "deprecated": false,
      "sortText": "fffffff0",
      "filterText": "CharArraySearcher",
      "textEdit": {
        "range": {
          "start": {
            "line": 4,
            "character": 4
          },
          "end": {
            "line": 4,
            "character": 11
          }
        },
        "newText": "CharArraySearcher"
      },
      "additionalTextEdits": [],
      "data": {
        "position": {
          "textDocument": {
            "uri": "file:///C:/Users/azerr/test-rust/foo/src/main.rs"
          },
          "position": {
            "line": 4,
            "character": 11
          }
        },
        "imports": [
          {
            "full_import_path": "std::str::pattern::CharArraySearcher",
            "imported_name": "CharArraySearcher"
          }
        ]
      }
    },

```