### PR TITLE
perf: LSP folding must be computed outside dumb

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
@@ -120,4 +120,9 @@ public class LSPFoldingRangeBuilder extends CustomFoldingBuilder {
     protected boolean isRegionCollapsedByDefault(@NotNull ASTNode node) {
         return false;
     }
+
+    @Override
+    public boolean isDumbAware() {
+        return false;
+    }
 }


### PR DESCRIPTION
I have noticed that with language server which support folding like go, when IJ is indexing files, the language server is started and degrade performances of the IDE.

This PR marks the LSP folding as non dumAware to avoid starting language server while indexing.