### PR TITLE
fix: show LSP console in IJ 2024.2

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
@@ -53,6 +53,8 @@ import java.io.StringWriter;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.redhat.devtools.lsp4ij.internal.ApplicationUtils.invokeLaterIfNeeded;
+
 /**
  * LSP consoles
  */
@@ -456,11 +458,13 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
         if (toolWindow == null) {
             return;
         }
-        // Get the panel of the LSP tool window
-        var contentManager = toolWindow.getContentManager();
-        LSPConsoleToolWindowPanel panel = (LSPConsoleToolWindowPanel) contentManager.getContent(0).getComponent();
-        // Show log...
-        panel.showLog(params, serverDefinition);
+        invokeLaterIfNeeded(() -> {
+            // Get the panel of the LSP tool window
+            var contentManager = toolWindow.getContentManager();
+            LSPConsoleToolWindowPanel panel = (LSPConsoleToolWindowPanel) contentManager.getContent(0).getComponent();
+            // Show log...
+            panel.showLog(params, serverDefinition);
+        });
     }
 
     private void showLog(MessageParams params, LanguageServerDefinition serverDefinition) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorerLifecycleListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorerLifecycleListener.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package com.redhat.devtools.lsp4ij.console.explorer;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
 import com.redhat.devtools.lsp4ij.ServerStatus;
@@ -25,6 +24,8 @@ import org.eclipse.lsp4j.jsonrpc.messages.Message;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static com.redhat.devtools.lsp4ij.internal.ApplicationUtils.invokeLaterIfNeeded;
 
 /**
  * Language server listener to refresh the language server explorer according to the server state and fill the LSP console.
@@ -63,7 +64,7 @@ public class LanguageServerExplorerLifecycleListener implements LanguageServerLi
 
         TracingMessageConsumer tracing = getLSPRequestCacheFor(languageServer);
         String log = tracing.log(message, messageConsumer, serverTrace);
-        invokeLater(() -> showTrace(processTreeNode, log));
+        invokeLaterIfNeeded(() -> showTrace(processTreeNode, log));
     }
 
     @Override
@@ -73,7 +74,7 @@ public class LanguageServerExplorerLifecycleListener implements LanguageServerLi
             return;
         }
 
-        invokeLater(() -> showError(processTreeNode, exception));
+        invokeLaterIfNeeded(() -> showError(processTreeNode, exception));
     }
 
     private TracingMessageConsumer getLSPRequestCacheFor(LanguageServerWrapper languageServer) {
@@ -125,7 +126,7 @@ public class LanguageServerExplorerLifecycleListener implements LanguageServerLi
             final var node = processTreeNode;
             final var status = serverStatus;
             final var select = selectProcess;
-            invokeLater(() -> {
+            invokeLaterIfNeeded(() -> {
                 if (explorer.isDisposed()) {
                     return;
                 }
@@ -163,14 +164,6 @@ public class LanguageServerExplorerLifecycleListener implements LanguageServerLi
     public void dispose() {
         disposed = true;
         tracingPerServer.clear();
-    }
-
-    private static void invokeLater(Runnable runnable) {
-        if (ApplicationManager.getApplication().isDispatchThread()) {
-            runnable.run();
-        } else {
-            ApplicationManager.getApplication().invokeLater(runnable);
-        }
     }
 
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/ApplicationUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/ApplicationUtils.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal;
+
+import com.intellij.openapi.application.ApplicationManager;
+
+/**
+ * Application utilities.
+ */
+public class ApplicationUtils {
+
+    /**
+     * Invoke the given runnable later if needed.
+     *
+     * @param runnable the runnable.
+     */
+    public static void invokeLaterIfNeeded(Runnable runnable) {
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            runnable.run();
+        } else {
+            ApplicationManager.getApplication().invokeLater(runnable);
+        }
+    }
+}


### PR DESCRIPTION
I have tested IJ EAP (> 2024.2) and LSP console panel doesn't appear when language server report log on IJ start.

This PR fixes this problem.