### PR TITLE
feat: show notification error when command doesn't exist.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/commands/LSPCommandContext.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/commands/LSPCommandContext.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings;
 import org.eclipse.lsp4j.Command;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,28 +28,38 @@ import java.awt.event.InputEvent;
  */
 public class LSPCommandContext {
 
+    public static enum ExecutedBy {
+        CODE_LENS,
+        INLAY_HINT,
+        CODE_ACTION,
+        COMPLETION,
+        OTHER;
+    }
+
     @NotNull
     private final Command command;
     @NotNull
     private final Project project;
+    private boolean showNotificationError;
     @Nullable
     private VirtualFile file;
     @Nullable
-    private  PsiFile psiFile;
+    private PsiFile psiFile;
     @Nullable
-    private  Editor editor;
+    private Editor editor;
     @Nullable
-    private  Component source;
+    private Component source;
     @Nullable
-    private  InputEvent inputEvent;
+    private InputEvent inputEvent;
     @Nullable
     private LanguageServerItem preferredLanguageServer;
 
     public LSPCommandContext(@NotNull Command command,
                              @NotNull PsiFile psiFile,
+                             @NotNull ExecutedBy executedBy,
                              @Nullable Editor editor,
                              @Nullable LanguageServerItem preferredLanguageServer) {
-        this(command, psiFile.getProject());
+        this(command, psiFile.getProject(), executedBy);
         this.setPsiFile(psiFile);
         this.setEditor(editor);
         this.setPreferredLanguageServer(preferredLanguageServer);
@@ -56,8 +67,15 @@ public class LSPCommandContext {
 
     public LSPCommandContext(@NotNull Command command,
                              @NotNull Project project) {
+        this(command, project, ExecutedBy.OTHER);
+    }
+
+    public LSPCommandContext(@NotNull Command command,
+                             @NotNull Project project,
+                             @NotNull ExecutedBy executedBy) {
         this.command = command;
         this.project = project;
+        this.showNotificationError = UserDefinedLanguageServerSettings.getInstance(project).isShowNotificationErrorForCommand(executedBy);
     }
 
     @NotNull
@@ -70,12 +88,22 @@ public class LSPCommandContext {
         return project;
     }
 
+    @Nullable
     public LanguageServerItem getPreferredLanguageServer() {
         return preferredLanguageServer;
     }
 
     public LSPCommandContext setPreferredLanguageServer(LanguageServerItem preferredLanguageServer) {
         this.preferredLanguageServer = preferredLanguageServer;
+        return this;
+    }
+
+    public boolean isShowNotificationError() {
+        return showNotificationError;
+    }
+
+    public LSPCommandContext setShowNotificationError(boolean showNotificationError) {
+        this.showNotificationError = showNotificationError;
         return this;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPInlayHintsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPInlayHintsProvider.java
@@ -165,7 +165,7 @@ public abstract class AbstractLSPInlayHintsProvider implements InlayHintsProvide
         if (command == null) {
             return;
         }
-        LSPCommandContext context = new LSPCommandContext(command, file, editor, languageServer)
+        LSPCommandContext context = new LSPCommandContext(command, file, LSPCommandContext.ExecutedBy.INLAY_HINT, editor, languageServer)
                 .setSource(event != null ? (Component) event.getSource() : null)
                         .setInputEvent(event);
         CommandExecutor.executeCommand(context);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/LSPLazyCodeActionIntentionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/LSPLazyCodeActionIntentionAction.java
@@ -128,7 +128,7 @@ public class LSPLazyCodeActionIntentionAction implements IntentionAction {
                                 @NotNull PsiFile file,
                                 @NotNull Editor editor,
                                 @NotNull LanguageServerItem languageServer) {
-        CommandExecutor.executeCommand(new LSPCommandContext(command, file, editor, languageServer));
+        CommandExecutor.executeCommand(new LSPCommandContext(command, file, LSPCommandContext.ExecutedBy.CODE_ACTION, editor, languageServer));
     }
 
     private LanguageServerItem getLanguageServer() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
@@ -237,7 +237,7 @@ public class LSPCodeLensProvider implements CodeVisionProvider<Void> {
         }
         // Code lens defines a command, create a clickable code vsion to execute the command.
         return new ClickableTextCodeVisionEntry(text, providerId, (e, editor) -> {
-            LSPCommandContext context = new LSPCommandContext(command, psiFile, editor, languageServer)
+            LSPCommandContext context = new LSPCommandContext(command, psiFile, LSPCommandContext.ExecutedBy.CODE_LENS, editor, languageServer)
                     .setInputEvent(e);
             if (languageServer.isResolveCodeLensSupported()) {
                 languageServer.getTextDocumentService()

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
@@ -369,7 +369,7 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
                                              Editor editor,
                                              LanguageServerItem languageServer) {
         // Execute custom command of the completion item.
-        CommandExecutor.executeCommand(new LSPCommandContext(command, file, editor, languageServer));
+        CommandExecutor.executeCommand(new LSPCommandContext(command, file, LSPCommandContext.ExecutedBy.COMPLETION, editor, languageServer));
     }
 
     public @Nullable Range getTextEditRange() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.xmlb.annotations.Tag;
 import com.intellij.util.xmlb.annotations.XCollection;
+import com.redhat.devtools.lsp4ij.commands.LSPCommandContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.redhat.devtools.lsp4ij.settings.LanguageServerView.isEquals;
 
@@ -174,6 +177,7 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
 
     /**
      * Tells whether the save tip balloon is shown when changing language server configuration
+     *
      * @return true if the balloon should be shown, false otherwise
      */
     public boolean showSaveTipOnConfigurationChange() {
@@ -183,10 +187,31 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
     /**
      * Sets the value if the save tip balloon should be shown on language server configuration change
      * There is no way to set this value to true at the moment, it can only be disabled
+     *
      * @param value true if the balloon should be shown, false otherwise
      */
     public void showSaveTipOnConfigurationChange(boolean value) {
         this.myState.showSaveTipOnConfigurationChange = value;
+    }
+
+    /**
+     * Returns true if notification error must be shown for the executed by command and false otherwise.
+     *
+     * @param executedBy command executed by.
+     * @return true if notification error must be shown for the executed by command and false otherwise.
+     */
+    public boolean isShowNotificationErrorForCommand(LSPCommandContext.ExecutedBy executedBy) {
+        return this.myState.showNotificationErrorForCommand.get(executedBy.name());
+    }
+
+    /**
+     * Set true if notification error must be shown for the executed by command and false otherwise.
+     *
+     * @param executedBy command executed by.
+     * @param enabled    the enabled state.
+     */
+    public void setShowNotificationErrorForCommand(LSPCommandContext.ExecutedBy executedBy, boolean enabled) {
+        this.myState.showNotificationErrorForCommand.put(executedBy.name(), enabled);
     }
 
     public static class LanguageServerDefinitionSettings {
@@ -240,8 +265,11 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
         @Tag("state")
         @XCollection
         public Map<String, LanguageServerDefinitionSettings> myState = new TreeMap<>();
+        public Map<String, Boolean> showNotificationErrorForCommand;
 
         MyState() {
+            showNotificationErrorForCommand = Stream.of(LSPCommandContext.ExecutedBy.values())
+                    .collect(Collectors.toMap(s -> s.name(), s -> true));
         }
 
         private boolean showSaveTipOnConfigurationChange = true;

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -153,3 +153,8 @@ lsp.refactor.rename.symbol.handler.title=Rename LSP Symbol
 lsp.refactor.rename.cannot.be.renamed.error=The element can't be renamed.
 lsp.refactor.rename.prepare.progress.title=Prepare renaming for ''{0}'' file at {1} offset...
 lsp.refactor.rename.progress.title=Renaming ''{0}'' file with ''{1}'' new name...
+
+# LSP Command
+lsp.command.error.title=Cannot execute ''{0}'' command.
+lsp.command.error.with.ls.content=Missing ''{0}'' command! It was referenced by ''{1}''. It needs to be contributed by an [IntelliJ plugin](https://github.com/redhat-developer/lsp4ij/blob/main/docs/DeveloperGuide.md#lsp-commands).
+lsp.command.error.without.ls.content=Missing ''{0}'' command! It needs to be contributed by an [IntelliJ plugin](https://github.com/redhat-developer/lsp4ij/blob/main/docs/DeveloperGuide.md#lsp-commands).


### PR DESCRIPTION
feat: show notification error when command doesn't exist.

Here a sample with Clojure LSP when you click on CodeLens references:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/8ce0e394-713e-4363-bab6-f20a37378138)
