### PR TITLE
fix: prevent from "implementation class is not specified" with documentMatcher

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/FileNamePatternMappingExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/FileNamePatternMappingExtensionPointBean.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.extensions.RequiredElement;
 import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
 import com.redhat.devtools.lsp4ij.DocumentMatcher;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -69,12 +70,15 @@ public class FileNamePatternMappingExtensionPointBean extends BaseKeyedLazyInsta
     public String documentMatcher;
 
     public @NotNull DocumentMatcher getDocumentMatcher() {
-        try {
-            return super.getInstance();
+        if (StringUtils.isNotBlank(documentMatcher)) {
+            try {
+                return super.getInstance();
+            }
+            catch(Exception e) {
+                // Do nothing
+            }
         }
-        catch(Exception e) {
-            return DEFAULT_DOCUMENT_MATCHER;
-        }
+        return DEFAULT_DOCUMENT_MATCHER;
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/FileTypeMappingExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/FileTypeMappingExtensionPointBean.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.extensions.RequiredElement;
 import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
 import com.redhat.devtools.lsp4ij.DocumentMatcher;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -68,12 +69,15 @@ public class FileTypeMappingExtensionPointBean extends BaseKeyedLazyInstance<Doc
     public String documentMatcher;
 
     public @NotNull DocumentMatcher getDocumentMatcher() {
-        try {
-            return super.getInstance();
+        if (StringUtils.isNotBlank(documentMatcher)) {
+            try {
+                return super.getInstance();
+            }
+            catch(Exception e) {
+                // Do nothing
+            }
         }
-        catch(Exception e) {
-            return DEFAULT_DOCUMENT_MATCHER;
-        }
+        return DEFAULT_DOCUMENT_MATCHER;
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/LanguageMappingExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/LanguageMappingExtensionPointBean.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.extensions.RequiredElement;
 import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
 import com.redhat.devtools.lsp4ij.DocumentMatcher;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -69,12 +70,15 @@ public class LanguageMappingExtensionPointBean extends BaseKeyedLazyInstance<Doc
     public String documentMatcher;
 
     public @NotNull DocumentMatcher getDocumentMatcher() {
-        try {
-            return super.getInstance();
+        if (StringUtils.isNotBlank(documentMatcher)) {
+            try {
+                return super.getInstance();
+            }
+            catch(Exception e) {
+                // Do nothing
+            }
         }
-        catch(Exception e) {
-            return DEFAULT_DOCUMENT_MATCHER;
-        }
+        return DEFAULT_DOCUMENT_MATCHER;
     }
 
     @Override


### PR DESCRIPTION
fix: prevent from "implementation class is not specified" with documentMatcher

When documentMatcher is not declared in languageMapping, fileTypeMapping, etc, the following exception is thrown https://github.com/JetBrains/intellij-community/blob/def6433a5dd9f0a984cbc6e2835d27c97f2cb5f0/platform/core-api/src/com/intellij/serviceContainer/LazyExtensionInstance.java#L55

We catch this method, but it is cleaner to avoid calling getInstance if documentMatcher is not declared.