### PR TITLE
fix: rootUri must not end with a slash

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -125,12 +124,9 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
 
     @Override
     public CompletableFuture<List<WorkspaceFolder>> workspaceFolders() {
-        Project project = wrapper.getProject();
-        if (project != null) {
-            List<WorkspaceFolder> folders = List.of(LSPIJUtils.toWorkspaceFolder(project));
-            return CompletableFuture.completedFuture(folders);
-        }
-        return CompletableFuture.completedFuture(Collections.emptyList());
+        return CompletableFuture.supplyAsync(() -> {
+            return LSPIJUtils.toWorkspaceFolders(project);
+        });
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/StreamConnectionProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/StreamConnectionProvider.java
@@ -10,13 +10,13 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.server;
 
+import com.intellij.openapi.vfs.VirtualFile;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 
 /**
  * Stream connection provider API used to:
@@ -48,7 +48,7 @@ public interface StreamConnectionProvider {
     /**
      * User provided initialization options.
      */
-    default Object getInitializationOptions(URI rootUri) {
+    default Object getInitializationOptions(VirtualFile rootUri) {
         return null;
     }
 
@@ -74,7 +74,7 @@ public interface StreamConnectionProvider {
      * @return the initial trace level to set
      * @see "https://microsoft.github.io/language-server-protocol/specification#initialize"
      */
-    default String getTrace(URI rootUri) {
+    default String getTrace(VirtualFile rootUri) {
         return "off"; //$NON-NLS-1$
     }
 
@@ -87,7 +87,7 @@ public interface StreamConnectionProvider {
      * @param languageServer the language server receiving/sending the message.
      * @param rootUri        the root Uri.
      */
-    default void handleMessage(Message message, LanguageServer languageServer, URI rootUri) {
+    default void handleMessage(Message message, LanguageServer languageServer, VirtualFile rootUri) {
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedStreamConnectionProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedStreamConnectionProvider.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package com.redhat.devtools.lsp4ij.server.definition.launching;
 
+import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider;
 import org.jetbrains.annotations.NotNull;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +70,7 @@ public class UserDefinedStreamConnectionProvider extends ProcessStreamConnection
     }
 
     @Override
-    public Object getInitializationOptions(URI rootUri) {
+    public Object getInitializationOptions(VirtualFile rootUri) {
         return serverDefinition.getLanguageServerInitializationOptions();
     }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockConnectionProvider.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockConnectionProvider.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package com.redhat.devtools.lsp4ij.mock;
 
+import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.server.CannotStartProcessException;
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
@@ -21,7 +22,6 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
-import java.net.URI;
 import java.nio.channels.Channels;
 import java.nio.channels.Pipe;
 import java.nio.charset.StandardCharsets;
@@ -109,7 +109,7 @@ public class MockConnectionProvider implements StreamConnectionProvider {
 	public static final Collection<Message> cancellations = new ArrayList<>();
 
 	@Override
-	public void handleMessage(Message message, LanguageServer languageServer, @Nullable URI rootURI) {
+	public void handleMessage(Message message, LanguageServer languageServer, @Nullable VirtualFile rootURI) {
 		if (message.toString().contains("cancelRequest")) {
 			cancellations.add(message);
 		}


### PR DESCRIPTION
fix: rootUri must not end with a slash

 * before the PR:

```
Params: {
  "rootPath": "/C:/Users/azerr/IdeaProjects/pyright-langserver-for-pycharm-test/",
  "rootUri": "file:///C:/Users/azerr/IdeaProjects/pyright-langserver-for-pycharm-test/",
```
 * with vscode:

```
Params: {
    "rootPath": "c:\\Users\\azerr\\IdeaProjects\\pyright-langserver-for-pycharm-test",
    "rootUri": "file:///c%3A/Users/azerr/IdeaProjects/pyright-langserver-for-pycharm-test",
```

 * after the PR:

```
Params: {
  "rootPath": "C:/Users/azerr/IdeaProjects/pyright-langserver-for-pycharm-test",
  "rootUri": "file:///C:/Users/azerr/IdeaProjects/pyright-langserver-for-pycharm-test",
```