### PR TITLE
fix: prevent NPE when isEnabled is called from plugin ls definition

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
@@ -56,7 +56,22 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
     private final List<Pair<List<FileNameMatcher>, String>> languageIdFileNameMatcherMappings;
     private boolean enabled;
 
-    public LanguageServerDefinition(@NotNull String id, @NotNull String name, String description, boolean isSingleton, Integer lastDocumentDisconnectedTimeout, boolean supportsLightEdit) {
+    public LanguageServerDefinition(@NotNull String id,
+                                    @NotNull String name,
+                                    String description,
+                                    boolean isSingleton,
+                                    Integer lastDocumentDisconnectedTimeout,
+                                    boolean supportsLightEdit) {
+        this(id, name, description, isSingleton, lastDocumentDisconnectedTimeout, supportsLightEdit, true);
+    }
+
+    protected LanguageServerDefinition(@NotNull String id,
+                                       @NotNull String name,
+                                       String description,
+                                       boolean isSingleton,
+                                       Integer lastDocumentDisconnectedTimeout,
+                                       boolean supportsLightEdit,
+                                       boolean updateEnabled) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -66,7 +81,10 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
         this.languageIdFileTypeMappings = new ConcurrentHashMap<>();
         this.languageIdFileNameMatcherMappings = new CopyOnWriteArrayList<>();
         this.supportsLightEdit = supportsLightEdit;
-        setEnabled(true, null);
+        if (updateEnabled) {
+            // Enable by default language server
+            setEnabled(true, null);
+        }
     }
 
     /**
@@ -114,6 +132,7 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
     /**
      * Returns true if the language server definition is enabled and false otherwise.
      *
+     * @param project the project and null otherwise.
      * @return true if the language server definition is enabled and false otherwise.
      */
     @Override
@@ -124,8 +143,8 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
     /**
      * Set enabled the language server definition.
      *
-     * @param enabled        enabled the language server definition.
-     * @param project
+     * @param enabled enabled the language server definition.
+     * @param project the project and null otherwise.
      */
     public void setEnabled(boolean enabled, @Nullable Project project) {
         this.enabled = enabled;

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/ExtensionLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/extension/ExtensionLanguageServerDefinition.java
@@ -41,8 +41,10 @@ public class ExtensionLanguageServerDefinition extends LanguageServerDefinition 
     private Icon icon;
 
     public ExtensionLanguageServerDefinition(ServerExtensionPointBean element) {
-        super(element.id, element.getName(), element.getDescription(), element.singleton, element.lastDocumentDisconnectedTimeout, element.supportsLightEdit);
+        super(element.id, element.getName(), element.getDescription(), element.singleton, element.lastDocumentDisconnectedTimeout, element.supportsLightEdit, false);
         this.extension = element;
+        // Enable by default language server from plugin
+        super.setEnabled(true, null);
     }
 
     @Override
@@ -89,12 +91,12 @@ public class ExtensionLanguageServerDefinition extends LanguageServerDefinition 
         try {
             var factory = getFactory();
             if (factory instanceof LanguageServerEnablementSupport languageServerEnablementSupport) {
-                languageServerEnablementSupport.isEnabled(project);
+                return languageServerEnablementSupport.isEnabled(project);
             }
         } catch (Exception e) {
             LOGGER.warn("Exception occurred while getting enabled", e); //$NON-NLS-1$
         }
-        return true;
+        return super.isEnabled(project);
     }
 
     @Override
@@ -103,6 +105,8 @@ public class ExtensionLanguageServerDefinition extends LanguageServerDefinition 
             var factory = getFactory();
             if (factory instanceof LanguageServerEnablementSupport languageServerEnablementSupport) {
                 languageServerEnablementSupport.setEnabled(enabled, project);
+            } else {
+                super.setEnabled(enabled, project);
             }
         } catch (Exception e) {
             LOGGER.warn("Exception occurred while setting enabled", e); //$NON-NLS-1$


### PR DESCRIPTION
fix: prevent NPE when isEnabled is called from plugin ls definition