### PR TITLE
fix: Enable Find Usages menu for custom file type different from TEXT and textmate

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPFindActionTracker.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPFindActionTracker.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.usages;
+
+import com.intellij.find.actions.FindUsagesAction;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.ex.AnActionListener;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.usages.UsageTargetUtil;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * "Find Usages" action execution tracker used to know if {@link LSPUsageTargetProvider}
+ * must return LSP {@link com.intellij.usages.UsageTarget} or not:
+ *
+ * <ul>
+ *     <li>when no UsageTarget is already associated to a language, the LSP UsageTarget must be returned to enable the `Find usages` command.</li>
+ *     <li>when a UsageTarget is already associated to a language (e.g. Java in IDEA), the LSP UsageTarget must not be returned,
+ *     to avoid overriding the platform native support for `Find usages` for that language.</li>
+ * </ul>
+ */
+public class LSPFindActionTracker implements AnActionListener {
+
+    @Override
+    public void beforeActionPerformed(@NotNull AnAction action, @NotNull AnActionEvent event) {
+        if (action instanceof FindUsagesAction) {
+            // Before executing "Find Usages"....
+
+            // The Find usages can be processed if
+            // - Psi file and editor exists
+            // - or Psi element exists
+            PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
+            Editor editor = event.getData(CommonDataKeys.EDITOR);
+            PsiElement psiElement = event.getData(CommonDataKeys.PSI_ELEMENT);
+            if ((editor == null || psiFile == null) && psiElement == null) {
+                return;
+            }
+
+            // Find usages will be processed...
+
+            // Disable collection of LSP UsageTarget
+            if (psiFile != null) {
+                LSPUsageTargetProvider.setDisabled(psiFile, true);
+            }
+            if (psiElement != null) {
+                LSPUsageTargetProvider.setDisabled(psiElement, true);
+            }
+
+            // Collect other usage targets while the LSP Usage Target is disabled
+            var result = UsageTargetUtil.findUsageTargets(id -> event.getDataContext().getData(id));
+            if (result == null || result.length == 0) {
+                // No other existing usage targets, re-enable the LSP usage target
+                // to contribute to the `Find Usages` command
+                if (psiFile != null) {
+                    LSPUsageTargetProvider.setDisabled(psiFile, null);
+                }
+                if (psiElement != null) {
+                    LSPUsageTargetProvider.setDisabled(psiElement, null);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPFindUsagesHandlerFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPFindUsagesHandlerFactory.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.lsp4ij.usages;
 import com.intellij.find.findUsages.FindUsagesHandler;
 import com.intellij.find.findUsages.FindUsagesHandlerFactory;
 import com.intellij.psi.PsiElement;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,8 +24,8 @@ public class LSPFindUsagesHandlerFactory extends FindUsagesHandlerFactory {
     @Override
     public boolean canFindUsages(@NotNull PsiElement element) {
         // Execute the dummy LSP find usage handler to collect references, implementations
-        // with LSPUsageSearcher.
-        return element instanceof LSPUsageTriggeredPsiElement;
+        // with LSPUsageSearcher if file is associated to a language server.
+        return LanguageServersRegistry.getInstance().isFileSupported(element.getContainingFile());
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPFindUsagesProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPFindUsagesProvider.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.usages;
+
+import com.intellij.lang.findUsages.FindUsagesProvider;
+import com.intellij.psi.PsiElement;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+/**
+ * Dummy class solely used to decide if the "Find Usages" menu action must be shown
+ * (if file is associated to a language server) or hidden otherwise.
+ *
+ * This class is associated to the LSPFindUsagesProvider singleton when language server mappings are loaded / updated
+ * in the {@link LanguageServersRegistry#updateFindUsagesProvider(Set)}}.
+ *
+ * See <a href="https://github.com/JetBrains/intellij-community/blob/e0de7cbb9e6045d682229032e2cbc47304c5310d/platform/lang-impl/src/com/intellij/find/actions/FindUsagesInFileAction.java#L111">canFindUsages</a>
+ */
+public class LSPFindUsagesProvider implements FindUsagesProvider {
+    @Override
+    public boolean canFindUsagesFor(@NotNull PsiElement psiElement) {
+        return true;
+    }
+
+    @Override
+    public @Nullable @NonNls String getHelpId(@NotNull PsiElement psiElement) {
+        return null;
+    }
+
+    @Override
+    public @Nls @NotNull String getType(@NotNull PsiElement element) {
+        return "LSP TYPE";
+    }
+
+    @Override
+    public @Nls @NotNull String getDescriptiveName(@NotNull PsiElement element) {
+        return "LSP description";
+    }
+
+    @Override
+    public @Nls @NotNull String getNodeText(@NotNull PsiElement element, boolean useFullName) {
+        return "LSP node";
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -150,7 +150,7 @@
         <!-- LSP textDocument/completion request support -->
         <typedHandler id="LSPTypedHandlerDelegate"
                       order="last"
-                      implementation="com.redhat.devtools.lsp4ij.features.completion.LSPTypedHandlerDelegate" />
+                      implementation="com.redhat.devtools.lsp4ij.features.completion.LSPTypedHandlerDelegate"/>
         <completion.contributor
                 id="LSPCompletionContributor"
                 language="any"
@@ -243,6 +243,7 @@
         <findUsagesHandlerFactory
                 implementation="com.redhat.devtools.lsp4ij.usages.LSPFindUsagesHandlerFactory"/>
         <usageTypeProvider
+                order="last"
                 implementation="com.redhat.devtools.lsp4ij.usages.LSPUsageTypeProvider"/>
 
         <!-- LSP textDocument/rename request support -->
@@ -380,15 +381,15 @@
 
         <notificationGroup
                 id="LSP/window/showMessage"
-                displayType="BALLOON" />
+                displayType="BALLOON"/>
 
         <notificationGroup
                 id="LSP/window/showMessageRequest"
-                displayType="STICKY_BALLOON" />
+                displayType="STICKY_BALLOON"/>
 
         <notificationGroup
                 id="LSP4IJ general notifications"
-                displayType="BALLOON" />
+                displayType="BALLOON"/>
     </extensions>
 
     <!-- Actions to execute LSP features Find Implementation, etc -->
@@ -494,13 +495,15 @@
         <listener
                 topic="com.intellij.openapi.project.ProjectManagerListener"
                 class="com.redhat.devtools.lsp4ij.ConnectDocumentToLanguageServerSetupParticipant"/>
+        <listener topic="com.intellij.openapi.actionSystem.ex.AnActionListener"
+                  class="com.redhat.devtools.lsp4ij.usages.LSPFindActionTracker"/>
     </applicationListeners>
 
     <projectListeners>
         <listener topic="com.intellij.refactoring.listeners.RefactoringEventListener"
                   class="com.redhat.devtools.lsp4ij.features.refactoring.LSPRefactoringListener"/>
         <listener topic="com.intellij.codeInsight.lookup.LookupManagerListener"
-                  class="com.redhat.devtools.lsp4ij.features.completion.LSPCompletionContributor$LSPLookupManagerListener" />
+                  class="com.redhat.devtools.lsp4ij.features.completion.LSPCompletionContributor$LSPLookupManagerListener"/>
     </projectListeners>
 
 </idea-plugin>


### PR DESCRIPTION
fix: Enable Find Usages menu for custom file type different from TEXT and textmate

Fixes #351

Here a screenshot with Lua:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/549b29a4-d7aa-43f7-b85b-aed818541954)

and the result:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/af81289c-b753-487f-8583-37bb6e102e0e)

please note that the right textarea is not filled correctly, I don't know why?