### PR TITLE
feat: Diagnostic tags support

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/ClientCapabilitiesFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/ClientCapabilitiesFactory.java
@@ -90,6 +90,8 @@ public class ClientCapabilitiesFactory {
         publishDiagnosticsCapabilities.setDataSupport(Boolean.TRUE);
         publishDiagnosticsCapabilities.setCodeDescriptionSupport(Boolean.TRUE);
         publishDiagnosticsCapabilities.setRelatedInformation(Boolean.TRUE);
+        DiagnosticsTagSupport tagSupport = new DiagnosticsTagSupport(List.of(DiagnosticTag.Unnecessary, DiagnosticTag.Deprecated));
+        publishDiagnosticsCapabilities.setTagSupport(tagSupport);
         textDocumentClientCapabilities.setPublishDiagnostics(publishDiagnosticsCapabilities);
 
         // Code Action support


### PR DESCRIPTION
feat: Diagnostic tags support

Here a demo with Lua LS which returns a diagntics tag  Unnecessary(1): 

![DiagnosticTagDemo](https://github.com/redhat-developer/lsp4ij/assets/1932211/578add55-254d-4a0b-8f6d-748ff888f44d)

Fixes #355 
Fixes #358 
