### PR TITLE
fix: The plaintext rendering color on the completion document is too dark.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/SyntaxColorationCodeBlockRenderer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/SyntaxColorationCodeBlockRenderer.java
@@ -180,9 +180,7 @@ public class SyntaxColorationCodeBlockRenderer implements NodeRenderer {
             // Case 2: Try to highlight code block with TextMate
             if (!(HAS_TEXTMATE_SUPPORT && TextMateHighlighterHelper.highlightWithTextMate(code, language , this.fileName, html))) {
                 // Case 3 : no highlight
-                html.withAttr().tag("code");
                 html.text(node.getContentChars());
-                html.tag("/code");
             }
         }
         html.tag("/pre").closePre();

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/documentation/MarkdownConverterTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/documentation/MarkdownConverterTest.java
@@ -127,13 +127,13 @@ public class MarkdownConverterTest extends LSPCodeInsightFixtureTestCase {
                 """;
         String html = """
                 <p>Here's some java code:</p>
-                <pre><code>    @Test
+                <pre>    @Test
                     public void linksConversion() {
                         String markdown = &quot;Here is a link [example](https://example.com)&quot;;
                         String html = &quot;&lt;p&gt;Here is a link &lt;a href=\\&quot;https://example.com\\&quot;&gt;example&lt;/a&gt;&lt;/p&gt;\\n&quot;;
                         assertEquals(html, convert(markdown));
                     }
-                </code></pre>
+                </pre>
                 """;
         assertEquals(html, toHtml(markdown));
 
@@ -152,14 +152,14 @@ public class MarkdownConverterTest extends LSPCodeInsightFixtureTestCase {
                 """;
         html = """
                 <p>Here's some XML code:</p>
-                <pre><code>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+                <pre>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
                 &lt;note&gt;
                   &lt;to&gt;Angelo&lt;/to&gt;
                   &lt;from&gt;Fred&lt;/from&gt;
                   &lt;heading&gt;Tests&lt;/heading&gt;
                   &lt;body&gt;I wrote them!&lt;/body&gt;
                 &lt;/note&gt;
-                </code></pre>
+                </pre>
                 """;
         assertEquals(html, toHtml(markdown));
     }


### PR DESCRIPTION
fix: The plaintext rendering color on the completion document is too dark.

Fixes #368

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/0c5d294c-86d3-422b-9e9e-e0c7ba02b1b7)
