### PR TITLE
fix: actions not getting enabled on 2024.2

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPGoToAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPGoToAction.java
@@ -126,6 +126,6 @@ public abstract class AbstractLSPGoToAction extends AnAction {
 
     @Override
     public final @NotNull ActionUpdateThread getActionUpdateThread() {
-        return ActionUpdateThread.EDT;
+        return ActionUpdateThread.BGT;
     }
 }


### PR DESCRIPTION
`AnActionEvent.getData(CommonDataKeys.VIRTUAL_FILE)` is a lazily computed value, which are forbidden to be retrieved on the EDT since 2024.2 (implicitly returning a null VirtualFile, and logging a stacktrace).

This caused the `Go To -> LSP *` actions to stay perpetually disabled.

Fixes #371 