### PR TITLE
docs: Add `intellij-haskell-lsp` to "Who is using LSP4IJ?" section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Here are some projects that use LSP4IJ:
  * [Quarkus Tools for IntelliJ](https://github.com/redhat-developer/intellij-quarkus)
  * [Inga for IntelliJ](https://github.com/seachicken/intellij-inga)
  * [IntelliJ SumnekoLua](https://github.com/CppCXY/Intellij-SumnekoLua)
+ * [Haskell LSP for IntelliJ](https://github.com/rockofox/intellij-haskell-lsp)
 
 ## Requirements
 


### PR DESCRIPTION
As requested by @angelozerr

https://github.com/rockofox/intellij-haskell-lsp/commit/8d699390213a0513ada37904a8e9d77eab50353e#commitcomment-143551798