### PR TITLE
fix: Semantic token color providers not being applied to language server definition

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
@@ -136,7 +136,7 @@ public class LanguageServersRegistry {
                 if (semanticTokensColorsProvider != null) {
                     serverDefinition.setSemanticTokensColorsProvider(semanticTokensColorsProvider);
                 }
-                addServerDefinitionWithoutNotification(new ExtensionLanguageServerDefinition(server), mappingsForServer);
+                addServerDefinitionWithoutNotification(serverDefinition, mappingsForServer);
             }
         }
 


### PR DESCRIPTION
Fixed a typo in LanguageServersRegistry that ignored SemanticTokensColorsProviders during language server registration from extension points.