### PR TITLE
fix: No way to display the semantic token inspector tab once closed

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -515,7 +515,7 @@
                 id="Semantic Tokens Inspector"
                 anchor="bottom"
                 factoryClass="com.redhat.devtools.lsp4ij.features.semanticTokens.inspector.SemanticTokensInspectorToolWindowFactory"
-                canCloseContents="true"
+                canCloseContents="false"
                 doNotActivateOnStart="true"
                 icon="AllIcons.General.InspectionsEye"/>
 


### PR DESCRIPTION
fix: No way to display the semantic token inspector tab once closed

Fixes #407

This PR forbids the close of the inspector like LSP console.

You can remove it from slide bar if you wish.