### PR TITLE
feat: improve semantic tokens color attributes

### DIFF
--- a/docs/LSPSupport.md
+++ b/docs/LSPSupport.md
@@ -480,46 +480,47 @@ The following table lists the currently predefined mappings:
  * the `DefaultLanguageHighlighterColors` column defines the standard `TextAttributesKey` used by IntelliJ that `SemanticTokensHighlightingColors` inherits.
 
 | Semantic token types | Semantic modifier types | SemanticTokensHighlightingColors | (inherited from) DefaultLanguageHighlighterColors |
-|----------------------|------------------------|----------------------------------|---------------------------------------------------|
-| namespace            | definition             | NAMESPACE_DECLARATION            | CLASS_NAME                                        |
-| namespace            | declaration            | NAMESPACE_DECLARATION            | CLASS_NAME                                        |
-| namespace            |                        | NAMESPACE                        | CLASS_REFERENCE                                   |
-| class                | definition             | CLASS_DECLARATION                | CLASS_NAME                                        |
-| class                | declaration            | CLASS_DECLARATION                | CLASS_NAME                                        |
-| class                |                        | CLASS                            | CLASS_REFERENCE                                   |
-| enum                 |                        | ENUM                             | CLASS_NAME                                        |
-| interface            |                        | INTERFACE                        | INTERFACE_NAME                                    |
-| struct               |                        | STRUCT                           | CLASS_NAME                                        |
-| typeParameter        |                        | TYPE_PARAMETER                   | PARAMETER                                         |
-| type                 |                        | TYPE                             | CLASS_NAME                                        |
-| parameter            |                        | PARAMETER                        | PARAMETER                                         |
-| variable             | static + readonly      | STATIC_READONLY_VARIABLE         | CONSTANT                                          |
-| variable             | static                 | STATIC_VARIABLE                  | STATIC_FIELD                                      |
-| variable             | readonly               | READONLY_VARIABLE                | LOCAL_VARIABLE                                    |
-| variable             |                        | VARIABLE                         | REASSIGNED_LOCAL_VARIABLE                         |
-| property             | static + readonly      | STATIC_READONLY_PROPERTY         | CONSTANT                                          |
-| property             | static                 | STATIC_PROPERTY                  | STATIC_FIELD                                      |
-| property             | readonly               | READONLY_PROPERTY                | INSTANCE_FIELD                                    |
-| property             |                        | PROPERTY                         | INSTANCE_FIELD                                    |
-| enumMember           |                        | ENUM_MEMBER                      | STATIC_FIELD                                      |
-| decorator            |                        | DECORATOR                        | METADATA                                          |
-| event                |                        | EVENT                            | PREDEFINED_SYMBOL                                 |
-| function             | definition             | FUNCTION_DECLARATION             | FUNCTION_DECLARATION                              |
-| function             | declaration            | FUNCTION_DECLARATION             | FUNCTION_DECLARATION                              |
-| function             |                        | FUNCTION                         | FUNCTION_CALL                                     |
-| method               | definition             | METHOD_DECLARATION               | FUNCTION_DECLARATION                              |
-| method               | declaration            | METHOD_DECLARATION               | FUNCTION_DECLARATION                              |
-| method               | static                 | STATIC_METHOD                    | STATIC_METHOD                                     |
-| method               |                        | METHOD                           | FUNCTION_CALL                                     |
-| macro                |                        | MACRO                            | KEYWORD                                           |
-| label                |                        | LABEL                            | LABEL                                             |
-| comment              |                        | COMMENT                          | LINE_COMMENT                                      |
-| string               |                        | STRING                           | STRING                                            |
-| keyword              |                        | KEYWORD                          | KEYWORD                                           |
-| number               |                        | NUMBER                           | NUMBER                                            |
-| regexp               |                        | REGEXP                           | VALID_STRING_ESCAPE                               |
-| modifier             |                        | MODIFIER                         | KEYWORD                                           |
-| operator             |                        | OPERATOR                         | OPERATION_SIGN                                    |
+|----------------------|-------------------------|----------------------------------|---------------------------------------------------|
+| namespace            | definition              | NAMESPACE_DECLARATION            | CLASS_NAME                                        |
+| namespace            | declaration             | NAMESPACE_DECLARATION            | CLASS_NAME                                        |
+| namespace            |                         | NAMESPACE                        | CLASS_REFERENCE                                   |
+| class                | definition              | CLASS_DECLARATION                | CLASS_NAME                                        |
+| class                | declaration             | CLASS_DECLARATION                | CLASS_NAME                                        |
+| class                |                         | CLASS                            | CLASS_REFERENCE                                   |
+| enum                 |                         | ENUM                             | CLASS_NAME                                        |
+| interface            |                         | INTERFACE                        | INTERFACE_NAME                                    |
+| struct               |                         | STRUCT                           | CLASS_NAME                                        |
+| typeParameter        |                         | TYPE_PARAMETER                   | PARAMETER                                         |
+| type                 |                         | TYPE                             | CLASS_NAME                                        |
+| parameter            |                         | PARAMETER                        | PARAMETER                                         |
+| variable             | static + readonly       | STATIC_READONLY_VARIABLE         | CONSTANT                                          |
+| variable             | static                  | STATIC_VARIABLE                  | STATIC_FIELD                                      |
+| variable             | readonly                | READONLY_VARIABLE                | LOCAL_VARIABLE                                    |
+| variable             |                         | VARIABLE                         | REASSIGNED_LOCAL_VARIABLE                         |
+| property             | static + readonly       | STATIC_READONLY_PROPERTY         | CONSTANT                                          |
+| property             | static                  | STATIC_PROPERTY                  | STATIC_FIELD                                      |
+| property             | readonly                | READONLY_PROPERTY                | INSTANCE_FIELD                                    |
+| property             |                         | PROPERTY                         | INSTANCE_FIELD                                    |
+| enumMember           |                         | ENUM_MEMBER                      | STATIC_FIELD                                      |
+| decorator            |                         | DECORATOR                        | METADATA                                          |
+| event                |                         | EVENT                            | PREDEFINED_SYMBOL                                 |
+| function             | defaultLibrary          | DEFAULT_LIBRARY_FUNCTION         | STATIC_METHOD                                     |
+| function             | definition              | FUNCTION_DECLARATION             | FUNCTION_DECLARATION                              |
+| function             | declaration             | FUNCTION_DECLARATION             | FUNCTION_DECLARATION                              |
+| function             |                         | FUNCTION                         | FUNCTION_CALL                                     |
+| method               | definition              | METHOD_DECLARATION               | FUNCTION_DECLARATION                              |
+| method               | declaration             | METHOD_DECLARATION               | FUNCTION_DECLARATION                              |
+| method               | static                  | STATIC_METHOD                    | STATIC_METHOD                                     |
+| method               |                         | METHOD                           | FUNCTION_CALL                                     |
+| macro                |                         | MACRO                            | KEYWORD                                           |
+| label                |                         | LABEL                            | LABEL                                             |
+| comment              |                         | COMMENT                          | LINE_COMMENT                                      |
+| string               |                         | STRING                           | STRING                                            |
+| keyword              |                         | KEYWORD                          | KEYWORD                                           |
+| number               |                         | NUMBER                           | NUMBER                                            |
+| regexp               |                         | REGEXP                           | VALID_STRING_ESCAPE                               |
+| modifier             |                         | MODIFIER                         | KEYWORD                                           |
+| operator             |                         | OPERATOR                         | OPERATION_SIGN                                    |
 
 If you need other mapping:
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/DefaultSemanticTokensColorsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/DefaultSemanticTokensColorsProvider.java
@@ -126,6 +126,11 @@ public class DefaultSemanticTokensColorsProvider implements SemanticTokensColors
             // function: for identifiers that declare a function.
             case SemanticTokenTypes.Function:
                 if (hasTokenModifiers(tokenModifiers,
+                        SemanticTokenModifiers.DefaultLibrary)) {
+                    // with defaultLibrary modifiers
+                    return SemanticTokensHighlightingColors.DEFAULT_LIBRARY_FUNCTION;
+                }
+                if (hasTokenModifiers(tokenModifiers,
                         SemanticTokenModifiers.Declaration,
                         SemanticTokenModifiers.Definition)) {
                     // with declaration, definition modifiers

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/SemanticTokensColorSettingsPage.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/SemanticTokensColorSettingsPage.java
@@ -70,7 +70,7 @@ public class SemanticTokensColorSettingsPage implements ColorSettingsPage, Displ
             // property
             new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.property.static"), SemanticTokensHighlightingColors.STATIC_PROPERTY),
             new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.property.static.readonly"), SemanticTokensHighlightingColors.STATIC_READONLY_PROPERTY),
-            new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.property"), SemanticTokensHighlightingColors.READONLY_PROPERTY),
+            new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.property"), SemanticTokensHighlightingColors.PROPERTY),
             new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.property.readonly"), SemanticTokensHighlightingColors.READONLY_PROPERTY),
 
             // enumMember
@@ -85,6 +85,7 @@ public class SemanticTokensColorSettingsPage implements ColorSettingsPage, Displ
             // function
             new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.function.call"), SemanticTokensHighlightingColors.FUNCTION),
             new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.function.declaration"), SemanticTokensHighlightingColors.FUNCTION_DECLARATION),
+            new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.function.defaultLibrary"), SemanticTokensHighlightingColors.DEFAULT_LIBRARY_FUNCTION),
 
             // method
             new AttributesDescriptor(LanguageServerBundle.message("options.lsp.attribute.descriptor.method.call"), SemanticTokensHighlightingColors.METHOD),
@@ -141,8 +142,59 @@ public class SemanticTokensColorSettingsPage implements ColorSettingsPage, Displ
     @Override
     public @NonNls @NotNull String getDemoText() {
         return """
-                public class <LSP_CLASS_DECLARATION>SomeClass</LSP_CLASS_DECLARATION><<typeParameter>T</typeParameter> extends <interface>Runnable</interface>> { // some comment
+                <LSP_COMMENT>// Here is a Java sample</LSP_COMMENT>
+                package <LSP_NAMESPACE>com</LSP_NAMESPACE>;
+                
+                <LSP_DECORATOR>@Deprecated</LSP_DECORATOR>(since = <LSP_STRING>"1.0.0"</LSP_STRING>)
+                <LSP_MODIFIER>public</LSP_MODIFIER> <LSP_MODIFIER>class</LSP_MODIFIER> <LSP_CLASS_DECLARATION>Bar</LSP_CLASS_DECLARATION><<LSP_TYPE_PARAMETER>T</LSP_TYPE_PARAMETER> extends <LSP_INTERFACE>Runnable</LSP_INTERFACE>> {
+
+                    <LSP_MODIFIER>private</LSP_MODIFIER> <LSP_MODIFIER>static</LSP_MODIFIER> <LSP_MODIFIER>final</LSP_MODIFIER> int <LSP_STATIC_READONLY_PROPERTY>CONSTANT</LSP_STATIC_READONLY_PROPERTY> = <LSP_NUMBER>1234</LSP_NUMBER>;
+                    <LSP_MODIFIER>private</LSP_MODIFIER> <LSP_MODIFIER>static</LSP_MODIFIER> int <LSP_STATIC_PROPERTY>GLOBAL</LSP_STATIC_PROPERTY>;
+                    <LSP_MODIFIER>private</LSP_MODIFIER> <LSP_MODIFIER>final</LSP_MODIFIER> int <LSP_READONLY_PROPERTY>readOnlyField</LSP_READONLY_PROPERTY> = <LSP_NUMBER>5678</LSP_NUMBER>;
+                    <LSP_MODIFIER>private</LSP_MODIFIER> int <LSP_PROPERTY>field</LSP_PROPERTY>;
+
+                    <LSP_MODIFIER>public</LSP_MODIFIER> int <LSP_METHOD_DECLARATION>someMethod</LSP_METHOD_DECLARATION>() {
+                        <LSP_CLASS>var</LSP_CLASS> <LSP_VARIABLE>bar</LSP_VARIABLE> = new <LSP_CLASS>Bar</LSP_CLASS><?>();
+                        <LSP_STATIC_METHOD>staticMethod</LSP_STATIC_METHOD>();
+                        <LSP_METHOD>someMethod</LSP_METHOD>();
+                        <LSP_KEYWORD>return</LSP_KEYWORD> <LSP_NUMBER>1</LSP_NUMBER> <LSP_OPERATOR>+</LSP_OPERATOR> <LSP_NUMBER>2</LSP_NUMBER> <LSP_OPERATOR>+</LSP_OPERATOR> <LSP_PROPERTY>field</LSP_PROPERTY>;
+                    }
+
+                    <LSP_MODIFIER>public</LSP_MODIFIER> <LSP_MODIFIER>static</LSP_MODIFIER> <LSP_CLASS>String</LSP_CLASS> <LSP_METHOD_DECLARATION>staticMethod</LSP_METHOD_DECLARATION>() {
+                        <LSP_KEYWORD>return</LSP_KEYWORD> <LSP_STRING>"foo"</LSP_STRING>;
+                    }
                 }
+                
+                <LSP_COMMENT>// Here is a TypeScript sample</LSP_COMMENT>
+                <LSP_KEYWORD>function</LSP_KEYWORD> <LSP_FUNCTION_DECLARATION>foo</LSP_FUNCTION_DECLARATION>() {
+                    <LSP_DEFAULT_LIBRARY_FUNCTION>print</LSP_DEFAULT_LIBRARY_FUNCTION>(<LSP_STRING>"bar"</LSP_STRING>)
+                }
+                
+                <LSP_COMMENT>// Here is a Go sample</LSP_COMMENT>
+                <LSP_KEYWORD>package</LSP_KEYWORD> <LSP_NAMESPACE>src</LSP_NAMESPACE>
+                
+                <LSP_KEYWORD>import</LSP_KEYWORD> (
+                	"<LSP_NAMESPACE>fmt</LSP_NAMESPACE>"
+                )
+                
+                <LSP_KEYWORD>func</LSP_KEYWORD> <LSP_FUNCTION_DECLARATION>foo</LSP_FUNCTION_DECLARATION>() {
+                    <LSP_KEYWORD>const</LSP_KEYWORD> <LSP_READONLY_VARIABLE>s</LSP_READONLY_VARIABLE> = <LSP_STRING>""</LSP_STRING>;
+                    <LSP_NAMESPACE>fmt</LSP_NAMESPACE>.<LSP_FUNCTION>Printf</LSP_FUNCTION>(<LSP_STRING>"s: %v\\n"</LSP_STRING>, <LSP_READONLY_VARIABLE>s</LSP_READONLY_VARIABLE>)
+                }
+                
+                <LSP_COMMENT>;; Here is a Clojure sample</LSP_COMMENT>
+
+                (<LSP_MACRO>defn</LSP_MACRO> <LSP_FUNCTION_DECLARATION>my-zipmap</LSP_FUNCTION_DECLARATION> [<LSP_VARIABLE>keys</LSP_VARIABLE> <LSP_VARIABLE>vals</LSP_VARIABLE>]
+                  (<LSP_MACRO>loop</LSP_MACRO> [<LSP_VARIABLE>my-map</LSP_VARIABLE> {}
+                         <LSP_VARIABLE>my-keys</LSP_VARIABLE> (<LSP_FUNCTION>seq</LSP_FUNCTION> <LSP_VARIABLE>keys</LSP_VARIABLE>)
+                         <LSP_VARIABLE>my-vals</LSP_VARIABLE> (<LSP_FUNCTION>seq</LSP_FUNCTION> <LSP_VARIABLE>vals</LSP_VARIABLE>)]
+                    (<LSP_FUNCTION>if</LSP_FUNCTION> (<LSP_MACRO>and</LSP_MACRO> <LSP_VARIABLE>my-keys</LSP_VARIABLE> <LSP_VARIABLE>my-vals</LSP_VARIABLE>)
+                      (<LSP_FUNCTION>recur</LSP_FUNCTION> (<LSP_FUNCTION>assoc</LSP_FUNCTION> <LSP_VARIABLE>my-map</LSP_VARIABLE> (<LSP_FUNCTION>first</LSP_FUNCTION> <LSP_VARIABLE>my-keys</LSP_VARIABLE>) (<LSP_FUNCTION>first</LSP_FUNCTION> <LSP_VARIABLE>my-vals</LSP_VARIABLE>))
+                             (<LSP_FUNCTION>next</LSP_FUNCTION> <LSP_VARIABLE>my-keys</LSP_VARIABLE>)
+                             (<LSP_FUNCTION>next</LSP_FUNCTION> <LSP_VARIABLE>my-vals</LSP_VARIABLE>))
+                      <LSP_VARIABLE>my-map</LSP_VARIABLE>)))
+                (<LSP_FUNCTION>my-zipmap</LSP_FUNCTION> [:<LSP_KEYWORD>a</LSP_KEYWORD> :<LSP_KEYWORD>b</LSP_KEYWORD> :<LSP_KEYWORD>c</LSP_KEYWORD>] [1 2 3])
+                <LSP_MACRO>-></LSP_MACRO> {:<LSP_KEYWORD>b</LSP_KEYWORD> 2, :<LSP_KEYWORD>c</LSP_KEYWORD> 3, :<LSP_KEYWORD>a</LSP_KEYWORD> 1}
                 """;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/SemanticTokensHighlightingColors.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/SemanticTokensHighlightingColors.java
@@ -68,6 +68,7 @@ public class SemanticTokensHighlightingColors {
     // function
     public static final TextAttributesKey FUNCTION = TextAttributesKey.createTextAttributesKey("LSP_FUNCTION", DefaultLanguageHighlighterColors.FUNCTION_CALL);
     public static final TextAttributesKey FUNCTION_DECLARATION = TextAttributesKey.createTextAttributesKey("LSP_FUNCTION_DECLARATION", DefaultLanguageHighlighterColors.FUNCTION_DECLARATION);
+    public static final TextAttributesKey DEFAULT_LIBRARY_FUNCTION = TextAttributesKey.createTextAttributesKey("LSP_DEFAULT_LIBRARY_FUNCTION", DefaultLanguageHighlighterColors.STATIC_METHOD);
 
     // method
     public static final TextAttributesKey METHOD = TextAttributesKey.createTextAttributesKey("LSP_METHOD", DefaultLanguageHighlighterColors.FUNCTION_CALL);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/inspector/SemanticTokensInspectorToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/inspector/SemanticTokensInspectorToolWindowPanel.java
@@ -88,12 +88,17 @@ public class SemanticTokensInspectorToolWindowPanel extends SimpleToolWindowPane
                 semanticTokensInspectorDetail.isShowTokenType(),
                 semanticTokensInspectorDetail.isShowTokenModifiers(),
                 project);
-        ApplicationManager.getApplication().invokeLater(() -> {
+        ApplicationManager.getApplication()
+                .invokeLater(() -> {
             // get the proper editor from the file tab
             var editorData = getEditorFor(data.file());
 
             // Update the editor with the LSP semantic tokens' information.
             var editor = editorData.editor();
+            if (editor.getText().equals(text)) {
+                // Don't refresh the editor
+                return;
+            }
             editor.setText(text);
 
             // Select the proper tab of the file

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -138,7 +138,8 @@
         <extensionPoint
                 name="semanticTokensColorsProvider"
                 beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.SemanticTokensColorsProviderExtensionPointBean">
-            <with attribute="class" implements="com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorsProvider"/>
+            <with attribute="class"
+                  implements="com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorsProvider"/>
         </extensionPoint>
 
     </extensionPoints>
@@ -504,8 +505,10 @@
 
     </extensions>
 
-    <!-- Semantic Tokens Inspector -->
+    <!-- Semantic Tokens -->
     <extensions defaultExtensionNs="com.intellij">
+
+        <!-- Semantic Tokens Inspector -->
 
         <projectService
                 id="com.redhat.devtools.lsp4ij.features.semanticTokens.inspector.SemanticTokensInspectorManager"
@@ -519,6 +522,19 @@
                 doNotActivateOnStart="true"
                 icon="AllIcons.General.InspectionsEye"/>
 
+        <!-- Color Schemes -->
+        <additionalTextAttributes
+                scheme="Dark"
+                file="colorSchemes/SemanticTokensDark.xml"/>
+        <additionalTextAttributes
+                scheme="High contrast"
+                file="colorSchemes/SemanticTokensHighContrast.xml"/>
+        <additionalTextAttributes
+                scheme="IntelliJ Light"
+                file="colorSchemes/SemanticTokensIntelliJLight.xml"/>
+        <additionalTextAttributes
+                scheme="Light"
+                file="colorSchemes/SemanticTokensLight.xml"/>
     </extensions>
 
     <!-- Launch configuration Language servers -->

--- a/src/main/resources/colorSchemes/SemanticTokensDark.xml
+++ b/src/main/resources/colorSchemes/SemanticTokensDark.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<list>
+    <option name="LSP_TYPE_PARAMETER">
+        <value>
+            <option name="FOREGROUND" value="16BAAC" />
+        </value>
+    </option>
+</list>

--- a/src/main/resources/colorSchemes/SemanticTokensHighConstrat.xml
+++ b/src/main/resources/colorSchemes/SemanticTokensHighConstrat.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0'?>
+<list>
+    <option name="LSP_TYPE_PARAMETER">
+        <value>
+            <option name="FOREGROUND" value="37cccc" />
+            <option name="FONT_TYPE" value="1" />
+        </value>
+    </option>
+</list>

--- a/src/main/resources/colorSchemes/SemanticTokensIntelliJLight.xml
+++ b/src/main/resources/colorSchemes/SemanticTokensIntelliJLight.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<list>
+    <option name="LSP_TYPE_PARAMETER">
+        <value>
+            <option name="FOREGROUND" value="7e8a" />
+        </value>
+    </option>
+</list>

--- a/src/main/resources/colorSchemes/SemanticTokensLight.xml
+++ b/src/main/resources/colorSchemes/SemanticTokensLight.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<list>
+    <option name="LSP_TYPE_PARAMETER">
+        <value>
+            <option name="FOREGROUND" value="7e8a" />
+        </value>
+    </option>
+</list>

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -183,6 +183,7 @@ options.lsp.attribute.descriptor.decorator=Decorator
 options.lsp.attribute.descriptor.event=Event
 options.lsp.attribute.descriptor.function.call=Functions//Function call
 options.lsp.attribute.descriptor.function.declaration=Functions//Function declaration
+options.lsp.attribute.descriptor.function.defaultLibrary=Functions//Default library
 options.lsp.attribute.descriptor.method.call=Methods//Method call
 options.lsp.attribute.descriptor.method.declaration=Methods//Method declaration
 options.lsp.attribute.descriptor.method.static=Methods//Static Method

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LuaSemanticTokensTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LuaSemanticTokensTest.java
@@ -51,7 +51,7 @@ public class LuaSemanticTokensTest extends LSPSemanticTokensFixtureTestCase {
                     12,
                     512
                   ]
-                }                          
+                }
                 """,
                 """
                         --<LSP_COMMENT>[[
@@ -60,7 +60,7 @@ public class LuaSemanticTokensTest extends LSPSemanticTokensFixtureTestCase {
                           ** ===================================================================
                           --]]
                         
-                        <LSP_FUNCTION>print</LSP_FUNCTION>("memory-allocation errors")
+                        <LSP_DEFAULT_LIBRARY_FUNCTION>print</LSP_DEFAULT_LIBRARY_FUNCTION>("memory-allocation errors")
                         """
         );
     }


### PR DESCRIPTION
feat: improve semantic tokens color attributes

This PR improve the color page with sample:

![image](https://github.com/redhat-developer/lsp4ij/assets/1932211/fa7bfe8a-5b56-4675-a791-384ba430c484)

You can click on tree node to select attribute in the editor and select a token in the editor to select the proper node.

This PR also adds:

 * color sheme for type parameter (I did the same thing than Java type parameter)
 * the support of defaultLibrary for function