### PR TITLE
fix: make Semantic Tokens editor read-only

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/inspector/SemanticTokensInspectorToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/inspector/SemanticTokensInspectorToolWindowPanel.java
@@ -159,6 +159,7 @@ public class SemanticTokensInspectorToolWindowPanel extends SimpleToolWindowPane
         semanticTokenEditor.setLineWrap(true);
         semanticTokenEditor.setWrapStyleWord(true);
         semanticTokenEditor.setFont(JBFont.regular());
+        semanticTokenEditor.setEditable(false);
         return semanticTokenEditor;
     }
 


### PR DESCRIPTION
Users should not be able to write in the semantic tokens editor (new content is deleted after being added). This PR makes the ST editor non-editable.

Signed-off-by: Fred Bricon <fbricon@gmail.com>
