### PR TITLE
fix: LSP textDocument/definition doens't open the file when range start / end are equals

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElementFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElementFactory.java
@@ -122,7 +122,7 @@ public interface LSPPsiElementFactory<T extends LSPPsiElement> {
         if (document == null) {
             return null;
         }
-        TextRange textRange = LSPIJUtils.toTextRange(range, document);
+        TextRange textRange = LSPIJUtils.toTextRange(range, document, true);
         if (textRange == null) {
             return null;
         }


### PR DESCRIPTION
fix: LSP textDocument/definition doens't open the file when range start / end are equals

Fixes #430