### PR TITLE
fix: Completion label matching always ends very early

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionProposal.java
@@ -627,4 +627,11 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
                 .builder(getItem().getLabel())
                 .presentation();
     }
+
+    @Override
+    public boolean isWorthShowingInAutoPopup() {
+        // leaves the completion popup open all the time when there is only one item
+        return true;
+    }
+
 }


### PR DESCRIPTION
Fixes #383