### PR TITLE
docs: Add Lean4ij to "Who is using LSP4IJ?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Here are some projects that use LSP4IJ:
  * [ZigBrains](https://github.com/FalsePattern/ZigBrains)
  * [Pyright for PyCharm](https://github.com/InSyncWithFoo/pyright-for-pycharm)
  * [Intellij EmmyLua2](https://github.com/EmmyLua/Intellij-EmmyLua2)
+ * [Lean4ij](https://github.com/onriv/lean4ij)
 
 ## Requirements
 


### PR DESCRIPTION
Add [Lean4ij](https://github.com/onriv/lean4ij), a plugin using LSP4IJ for connecting to the Lean4 lsp server, to the section  "Who is using LSP4IJ?" in readme.