### PR TITLE
fix: fix #477 semantichilight add a one-second debounce time.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
@@ -51,6 +51,10 @@ public class LSPSemanticTokensHighlightVisitor implements HighlightVisitor {
 
     private HighlightInfoHolder myHolder;
 
+    private long lastHighlightTime = 0;
+
+    private static final long HIGHLIGHT_INTERVAL_MS = 1000; // 1 second
+
     @Override
     public boolean suitableForFile(@NotNull PsiFile file) {
         return LanguageServersRegistry.getInstance().isFileSupported(file);
@@ -128,6 +132,13 @@ public class LSPSemanticTokensHighlightVisitor implements HighlightVisitor {
     }
 
     private boolean isSemanticTokensHighlightingEnabled() {
+        // Avoid highlighting the file too often
+        long currentTime = System.currentTimeMillis();
+        if (currentTime < lastHighlightTime + HIGHLIGHT_INTERVAL_MS) {
+            return false;
+        }
+
+        lastHighlightTime = currentTime;
         return file != null;
     }
 


### PR DESCRIPTION
after apply modify:
![semantic](https://github.com/user-attachments/assets/39e70577-a0b5-46e9-a5b3-21fc05f5db56)
