### PR TITLE
fix: trim spaces for user defined ls command.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/CommandUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/CommandUtils.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.server.definition.launching;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Command utilities.
+ */
+public class CommandUtils {
+
+    /**
+     * Returns the commands to execute with {@link Process} from the given commandline.
+     *
+     * @param commandLine the command line.
+     *
+     * @return the commands to execute with {@link Process} from the given commandline.
+     */
+    @NotNull
+    public static List<String> createCommands(@NotNull String commandLine) {
+        List<String> commands = new ArrayList<>();
+        StringBuilder commandPart = new StringBuilder();
+        boolean inString = false;
+        for (int i = 0; i < commandLine.length(); i++) {
+            char c = commandLine.charAt(i);
+            switch(c) {
+                case '"':
+                    inString = !inString;
+                    break;
+                case ' ':
+                    if (inString) {
+                        commandPart.append(c);
+                    } else {
+                        addArg(commandPart, commands);
+                        commandPart.setLength(0);
+                    }
+                    break;
+                default:
+                    commandPart.append(c);
+                    break;
+            }
+        }
+        if (commandPart.length() > 0) {
+            addArg(commandPart, commands);
+            commandPart.setLength(0);
+        }
+        return commands;
+    }
+
+    private static void addArg(StringBuilder commandPart, List<String> commands) {
+        String arg = commandPart.toString().trim();
+        if (!arg.isEmpty()) {
+            commands.add(arg);
+        }
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedStreamConnectionProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedStreamConnectionProvider.java
@@ -17,12 +17,10 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 /**
- * {@link ProcessStreamConnectionProvider} implementation to start a the language server with a
+ * {@link ProcessStreamConnectionProvider} implementation to start a language server with a
  * process command defined by the user.
  */
 public class UserDefinedStreamConnectionProvider extends ProcessStreamConnectionProvider {
@@ -33,40 +31,10 @@ public class UserDefinedStreamConnectionProvider extends ProcessStreamConnection
                                                @NotNull Map<String, String> userEnvironmentVariables,
                                                boolean includeSystemEnvironmentVariables,
                                                @NotNull UserDefinedLanguageServerDefinition serverDefinition) {
-        super.setCommands(createCommands(commandLine));
+        super.setCommands(CommandUtils.createCommands(commandLine));
         super.setUserEnvironmentVariables(userEnvironmentVariables);
         super.setIncludeSystemEnvironmentVariables(includeSystemEnvironmentVariables);
         this.serverDefinition = serverDefinition;
-    }
-
-    private List<String> createCommands(String commandLine) {
-        List<String> commands = new ArrayList<>();
-        StringBuilder commandPart = new StringBuilder();
-        boolean inString = false;
-        for (int i = 0; i < commandLine.length(); i++) {
-            char c = commandLine.charAt(i);
-            switch(c) {
-                case '"':
-                    inString = !inString;
-                    break;
-                case ' ':
-                    if (inString) {
-                        commandPart.append(c);
-                    } else {
-                        commands.add(commandPart.toString());
-                        commandPart.setLength(0);
-                    }
-                    break;
-                default:
-                    commandPart.append(c);
-                    break;
-            }
-        }
-        if (commandPart.length() > 0) {
-            commands.add(commandPart.toString());
-            commandPart.setLength(0);
-        }
-        return commands;
     }
 
     @Override

--- a/src/test/java/com/redhat/devtools/lsp4ij/server/definition/launching/CommandUtilsTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/server/definition/launching/CommandUtilsTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.server.definition.launching;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Tests for {@link CommandUtils}.
+ */
+public class CommandUtilsTest {
+
+    @Test
+    public void testCommand() {
+        assertCommand("foo bar",
+                "foo",
+                "bar"
+        );
+    }
+
+    @Test
+    public void testCommandWithSpaces() {
+        assertCommand("foo",
+                "foo");
+        assertCommand("foo bar",
+                "foo",
+                "bar");
+        assertCommand("foo   bar",
+                "foo",
+                "bar");
+        assertCommand("   foo   bar   ",
+                "foo",
+                "bar");
+    }
+
+    @Test
+    public void testGolpsCommand() {
+        assertCommand("sh -c gopls -mode=stdio",
+                "sh",
+                "-c",
+                "gopls",
+                "-mode=stdio"
+        );
+    }
+
+    @Test
+    public void testGolpsCommandWithSpaces() {
+        assertCommand("    sh    -c    gopls    -mode=stdio",
+                "sh",
+                "-c",
+                "gopls",
+                "-mode=stdio"
+        );
+    }
+
+    @Test
+    public void testCommandWithQuote() {
+        assertCommand("    \"C:\\Users\\USERNAME\\A FOLDER WITH SPACE\\node_modules/.bin/typescript-language-server.cmd\"    --stdio   ",
+                "C:\\Users\\USERNAME\\A FOLDER WITH SPACE\\node_modules/.bin/typescript-language-server.cmd",
+                "--stdio"
+        );
+    }
+
+    private static void assertCommand(String command, String... expected) {
+        List<String> actual = CommandUtils.createCommands(command);
+        Assert.assertArrayEquals(expected, actual.toArray());
+    }
+}


### PR DESCRIPTION
fix: trim spaces for user defined ls command.

This PR fixes the issue https://github.com/redhat-developer/lsp4ij/issues/513#issuecomment-2333854146

![image](https://github.com/user-attachments/assets/04c95c12-080d-4fba-8b2d-61165399b640)
