### PR TITLE
fix: Invalid encoded URI like file://c%3A/ when dir contains '.'

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -800,10 +800,15 @@ public class LSPIJUtils {
         return VfsUtil.findFileByIoFile(newFile, true);
     }
 
-    public static @Nullable VirtualFile findResourceFor(URI uri) {
+    public static @Nullable VirtualFile findResourceFor(@NotNull URI uri) {
         return LocalFileSystem.getInstance().findFileByIoFile(Paths.get(uri).toFile());
     }
 
+    /**
+     * Returns the virtual file from the given uri and null otherwise.
+     * @param uri the Uri.
+     * @return the virtual file from the given uri and null otherwise.
+     */
     public static @Nullable VirtualFile findResourceFor(@NotNull String uri) {
         if (uri.startsWith(JAR_SCHEME) || uri.startsWith(JRT_SCHEME)) {
             // ex : jar:file:///C:/Users/azerr/.m2/repository/io/quarkus/quarkus-core/3.0.1.Final/quarkus-core-3.0.1.Final.jar!/io/quarkus/runtime/ApplicationConfig.class
@@ -816,6 +821,9 @@ public class LSPIJUtils {
         if (uri.contains("%")) {
             // ex : file:///c%3A/Users/azerr/IdeaProjects/untitled7/test.js
             // the uri must be decoded (ex : file:///c:/Users) otherwise IntelliJ cannot retrieve the virtual file.
+            // Keep the original '+' after decoding the Uri
+            uri = uri.replace("+", "%2B");
+            // Decode the uri
             uri = URLDecoder.decode(uri, StandardCharsets.UTF_8);
         }
         return VirtualFileManager.getInstance().findFileByUrl(VfsUtilCore.fixURLforIDEA(uri));

--- a/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_findResourceForTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_findResourceForTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests for {@link LSPIJUtils#findResourceFor(String)}}.
+ */
+public class LSPIJUtils_findResourceForTest extends BasePlatformTestCase {
+
+    public void testSimpleUri() throws IOException {
+        assertVirtualFileExists("dir", "file.txt", getUri("dir/file.txt"));
+    }
+
+    public void testEncodedUri() throws IOException {
+        assertVirtualFileExists("dir", "file.txt", getUri("dir/file.txt", true));
+        assertVirtualFileExists("base.dir", "file.txt", getUri("base.dir/file.txt", true));
+    }
+
+    private static @NotNull String getUri(String s) {
+        return getUri(s, false);
+    }
+
+    private static @NotNull String getUri(String s, boolean encodeDriver) {
+        File file = new File(System.getProperty("java.io.tmpdir"), s);
+        String uri = LSPIJUtils.toUri(file).toASCIIString();
+        if(encodeDriver) {
+            return uri.replace("C:", "c%3A");
+        }
+        return uri;
+    }
+
+    private static void assertVirtualFileExists(@NotNull String baseDir,
+                                                @NotNull String fileName,
+                                                @NotNull String uri) throws IOException {
+        assertVirtualFileExists(baseDir, fileName, uri, true);
+    }
+
+    private static void assertVirtualFileExists(@NotNull String baseDir,
+                                                @NotNull String fileName,
+                                                @NotNull String uri,
+                                                boolean create) throws IOException {
+        if(create) {
+            createTempFileIfNeeded(baseDir, fileName);
+        }
+        VirtualFile file = LSPIJUtils.findResourceFor(uri);
+        Assert.assertNotNull("Cannot find file with the uri '" + uri  + "'", file);
+        file.refresh(true, true);
+        Assert.assertTrue("File with the uri '" + uri  + "' doesn't exist", file.exists());
+    }
+
+
+    private static void createTempFileIfNeeded(String baseDir, String fileName) throws IOException {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        Path tempFile = Paths.get(tempDir, baseDir, fileName);
+        if (Files.notExists(tempFile)) {
+            Path dir = tempFile.getParent();
+            if(Files.notExists(dir)) {
+                Files.createDirectories(dir);
+            }
+            Files.createFile(tempFile);
+        }
+    }
+
+}


### PR DESCRIPTION
fix: Invalid encoded URI like file://c%3A/ when dir contains '.'

Fixes #520