### PR TITLE
fix: IllegalArgumentException: Argument for @NotNull parameter 'fragment' of com/intellij/ui/SimpleColoredComponent.append must not be null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerProcessTreeNode.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerProcessTreeNode.java
@@ -43,7 +43,7 @@ public class LanguageServerProcessTreeNode extends DefaultMutableTreeNode {
     public LanguageServerProcessTreeNode(LanguageServerWrapper languageServer, DefaultTreeModel treeModel) {
         this.languageServer = languageServer;
         this.treeModel = treeModel;
-        this.serverStatus = ServerStatus.none;
+        setServerStatus(ServerStatus.none);
     }
 
     public void setServerStatus(ServerStatus serverStatus) {


### PR DESCRIPTION
fix: IllegalArgumentException: Argument for @NotNull parameter 'fragment' of com/intellij/ui/SimpleColoredComponent.append must not be null

Fixes #473

I cannot reproduce the issue, but this PR initialize the displayName filed in the process tree node constructor. In this case displayName will be never null and we will avoid the error of the reported issue.