### PR TITLE
fix: triggered characters for completion/signatureHelp doesn't work with registerCapability

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -1095,41 +1095,6 @@ public class LanguageServerWrapper implements Disposable {
         return fileOperationsManager.canDidRenameFiles(LSPIJUtils.toUri(file), file.isDirectory());
     }
 
-    /**
-     * Returns true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
-     *
-     * @param charTyped the current typed character.
-     * @return true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
-     */
-    public boolean isCompletionTriggerCharactersSupported(String charTyped) {
-        if (serverCapabilities == null) {
-            return false;
-        }
-        var triggerCharacters = serverCapabilities.getCompletionProvider() != null ? serverCapabilities.getCompletionProvider().getTriggerCharacters() : null;
-        if (triggerCharacters == null || triggerCharacters.isEmpty()) {
-            return false;
-        }
-        return triggerCharacters.contains(charTyped);
-    }
-
-    /**
-     * Returns true if the given character is defined as "signature trigger" in the server capability of the language server and false otherwise.
-     *
-     * @param charTyped the current typed character.
-     * @return true if the given character is defined as "signature trigger" in the server capability of the language server and false otherwise.
-     */
-    public boolean isSignatureTriggerCharactersSupported(String charTyped) {
-        if (serverCapabilities == null) {
-            return false;
-        }
-
-        var triggerCharacters = serverCapabilities.getSignatureHelpProvider() != null ? serverCapabilities.getSignatureHelpProvider().getTriggerCharacters() : null;
-        if (triggerCharacters == null || triggerCharacters.isEmpty()) {
-            return false;
-        }
-        return triggerCharacters.contains(charTyped);
-    }
-
     public LSPClientFeatures getClientFeatures() {
         if (clientFeatures == null) {
             clientFeatures = getOrCreateClientFeatures();

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionFeature.java
@@ -101,9 +101,15 @@ public class LSPCompletionFeature extends AbstractLSPDocumentFeature {
         return getCompletionCapabilityRegistry().isResolveCompletionSupported(file);
     }
 
-    public boolean isCompletionTriggerCharactersSupported(@NotNull PsiFile file, String completionChar) {
-        // TODO: manage documentSelector for trigger character
-        return getClientFeatures().getServerWrapper().isCompletionTriggerCharactersSupported(completionChar);
+    /**
+     * Returns true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
+     *
+     * @param file the file.
+     * @param charTyped the current typed character.
+     * @return true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
+     */
+    public boolean isCompletionTriggerCharactersSupported(@NotNull PsiFile file, String charTyped) {
+        return getCompletionCapabilityRegistry().isCompletionTriggerCharactersSupported(file, charTyped);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPSignatureHelpFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPSignatureHelpFeature.java
@@ -56,4 +56,15 @@ public class LSPSignatureHelpFeature extends AbstractLSPDocumentFeature {
         }
     }
 
+    /**
+     * Returns true if the given character is defined as "signature trigger" in the server capability of the language server and false otherwise.
+     *
+     * @param file the file.
+     * @param charTyped the current typed character.
+     * @return true if the given character is defined as "signature trigger" in the server capability of the language server and false otherwise.
+     */
+    public boolean isSignatureTriggerCharactersSupported(@NotNull PsiFile file, String charTyped) {
+        return getSignatureHelpCapabilityRegistry().isSignatureTriggerCharactersSupported(file, charTyped);
+    }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPTypedHandlerDelegate.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPTypedHandlerDelegate.java
@@ -60,11 +60,15 @@ public class LSPTypedHandlerDelegate extends TypedHandlerDelegate {
 
     private static boolean hasLanguageServerSupportingCompletionTriggerCharacters(char charTyped, Project project, PsiFile file) {
         return LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.isCompletionTriggerCharactersSupported(String.valueOf(charTyped)));
+                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures()
+                        .getCompletionFeature()
+                        .isCompletionTriggerCharactersSupported(file, String.valueOf(charTyped)));
     }
 
     private static boolean hasLanguageServerSupportingSignatureTriggerCharacters(char charTyped, Project project, PsiFile file) {
         return LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.isSignatureTriggerCharactersSupported(String.valueOf(charTyped)));
+                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures()
+                                .getSignatureHelpFeature()
+                                .isSignatureTriggerCharactersSupported(file, String.valueOf(charTyped)));
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/CompletionCapabilityRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/CompletionCapabilityRegistry.java
@@ -40,7 +40,7 @@ public class CompletionCapabilityRegistry extends TextDocumentServerCapabilityRe
         super(clientFeatures);
     }
 
-    class ExtendedCompletionFormattingRegistrationOptions extends CompletionRegistrationOptions  implements ExtendedDocumentSelector.DocumentFilersProvider {
+    class ExtendedCompletionFormattingRegistrationOptions extends CompletionRegistrationOptions implements ExtendedDocumentSelector.DocumentFilersProvider {
         private transient ExtendedDocumentSelector documentSelector;
 
         @Override
@@ -79,4 +79,31 @@ public class CompletionCapabilityRegistry extends TextDocumentServerCapabilityRe
         return super.isSupported(file, RESOLVE_SERVER_CAPABILITIES_PREDICATE, RESOLVE_REGISTRATION_OPTIONS_PREDICATE);
     }
 
+    /**
+     * Returns true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
+     *
+     * @param file      the file.
+     * @param charTyped the current typed character.
+     * @return true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
+     */
+    public boolean isCompletionTriggerCharactersSupported(@NotNull PsiFile file,
+                                                          String charTyped) {
+        return super.isSupported(file,
+                sc -> isCompletionTriggerCharactersSupported(sc, charTyped),
+                o -> isMatchTriggerCharacters(o.getTriggerCharacters(), charTyped));
+    }
+
+    private static boolean isCompletionTriggerCharactersSupported(@Nullable ServerCapabilities serverCapabilities,
+                                                                  String charTyped) {
+        var triggerCharacters = serverCapabilities.getCompletionProvider() != null ? serverCapabilities.getCompletionProvider().getTriggerCharacters() : null;
+        return isMatchTriggerCharacters(triggerCharacters, charTyped);
+    }
+
+    private static boolean isMatchTriggerCharacters(@Nullable List<String> characters,
+                                                    @NotNull String charTyped) {
+        if (characters == null || characters.isEmpty()) {
+            return false;
+        }
+        return characters.contains(charTyped);
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/SignatureHelpCapabilityRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/SignatureHelpCapabilityRegistry.java
@@ -63,4 +63,32 @@ public class SignatureHelpCapabilityRegistry extends TextDocumentServerCapabilit
         return super.isSupported(file, SERVER_CAPABILITIES_PREDICATE);
     }
 
+    /**
+     * Returns true if the given character is defined as "signature trigger" in the server capability of the language server and false otherwise.
+     *
+     * @param file      the file.
+     * @param charTyped the current typed character.
+     * @return true if the given character is defined as "signature trigger" in the server capability of the language server and false otherwise.
+     */
+    public boolean isSignatureTriggerCharactersSupported(@NotNull PsiFile file,
+                                                          String charTyped) {
+        return super.isSupported(file,
+                sc -> isSignatureTriggerCharactersSupported(sc, charTyped),
+                o -> isMatchTriggerCharacters(o.getTriggerCharacters(), charTyped));
+    }
+
+    private static boolean isSignatureTriggerCharactersSupported(@Nullable ServerCapabilities serverCapabilities,
+                                                                  String charTyped) {
+        var triggerCharacters = serverCapabilities.getSignatureHelpProvider() != null ? serverCapabilities.getSignatureHelpProvider().getTriggerCharacters() : null;
+        return isMatchTriggerCharacters(triggerCharacters, charTyped);
+    }
+
+    private static boolean isMatchTriggerCharacters(@Nullable List<String> characters,
+                                                    @NotNull String charTyped) {
+        if (characters == null || characters.isEmpty()) {
+            return false;
+        }
+        return characters.contains(charTyped);
+    }
+
 }


### PR DESCRIPTION
fix: triggered characters for completion/signatureHelp doesn't work with registerCapability