### PR TITLE
fix: prevent from NPE CancellationSupport

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
@@ -101,16 +101,15 @@ public abstract class AbstractLSPFeatureSupport<Params, Result> {
      * Cancel all LSP requests.
      */
     public void cancel() {
+        // Store the CancellationSupport in a local variable to prevent from NPE (very rare case)
+        CancellationSupport cancellation = cancellationSupport;
         var future = this.future;
         if (future != null && !future.isCancelled() && !future.isDone()) {
             future.cancel(true);
         }
         this.future = null;
-        // Store the CancellationSupport in a local variable to prevent from NPE (very rare case)
-        CancellationSupport cancellation = cancellationSupport;
         if (cancellation != null) {
             cancellation.cancel();
         }
-        cancellationSupport = null;
     }
 }


### PR DESCRIPTION
fix: prevent from NPE CancellationSupport

I cannot reproduce his issue, but @ia3andy reported me that he had this error sometimes:

```
java.lang.IllegalArgumentException: Argument for @NotNull parameter 'cancellationSupport' of com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionCodeActionSupport.doLoad must not be null
	at com.redhat.devtools.lsp4ij.features.codeAction.intention.LSPIntentionCodeActionSupport.$$$reportNull$$$0(LSPIntentionCodeActionSupport.java)
	at com.redhat.devtools.lsp4ij.features.codeAction.intention.LSPIntentionCodeActionSupport.doLoad(LSPIntentionCodeActionSupport.java)
	at com.redhat.devtools.lsp4ij.features.codeAction.intention.LSPIntentionCodeActionSupport.doLoad(LSPIntentionCodeActionSupport.java:43)
	at com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport.load(AbstractLSPFeatureSupport.java:88)
	at com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport.load(AbstractLSPDocumentFeatureSupport.java:65)
	at com.redhat.devtools.lsp4ij.features.AbstractLSPFeatureSupport.getFeatureData(AbstractLSPFeatureSupport.java:49)
```

and it should fix too https://github.com/redhat-developer/lsp4ij/issues/486