### PR TITLE
docs: Add Liberty Tools for IntelliJ to the list of projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Here are some projects that use LSP4IJ:
  * [Intellij KCL](https://github.com/kcl-lang/intellij-kcl)
  * [Ruff for PyCharm](https://github.com/koxudaxi/ruff-pycharm-plugin)
  * [Intellij Gleam](https://github.com/themartdev/intellij-gleam)
+ * [Liberty Tools for IntelliJ](https://github.com/OpenLiberty/liberty-tools-intellij)
 
 ## Requirements
 


### PR DESCRIPTION
As requested by @angelozerr.