### PR TITLE
fix: synchronize registerCapability to avoid loosing some capability

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -120,12 +120,12 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
 
     @Override
     public CompletableFuture<Void> registerCapability(RegistrationParams params) {
-        return CompletableFuture.runAsync(() -> wrapper.registerCapability(params));
+        return wrapper.registerCapability(params);
     }
 
     @Override
     public CompletableFuture<Void> unregisterCapability(UnregistrationParams params) {
-        return CompletableFuture.runAsync(() -> wrapper.unregisterCapability(params));
+        return wrapper.unregisterCapability(params);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
@@ -729,17 +729,8 @@ public class LSPClientFeatures implements Disposable {
         if (codeLensFeature != null) {
             codeLensFeature.dispose();
         }
-        if (documentColorFeature != null) {
-            documentColorFeature.dispose();
-        }
         if (completionFeature != null) {
             completionFeature.dispose();
-        }
-        if (codeActionFeature != null) {
-            codeActionFeature.dispose();
-        }
-        if (codeActionFeature != null) {
-            codeActionFeature.dispose();
         }
         if (declarationFeature != null) {
             declarationFeature.dispose();
@@ -747,17 +738,20 @@ public class LSPClientFeatures implements Disposable {
         if (definitionFeature != null) {
             definitionFeature.dispose();
         }
-        if (documentLinkFeature != null) {
-            documentLinkFeature.dispose();
+        if (diagnosticFeature != null) {
+            diagnosticFeature.dispose();
+        }
+        if (documentColorFeature != null) {
+            documentColorFeature.dispose();
         }
         if (documentHighlightFeature != null) {
             documentHighlightFeature.dispose();
         }
+        if (documentLinkFeature != null) {
+            documentLinkFeature.dispose();
+        }
         if (documentSymbolFeature != null) {
             documentSymbolFeature.dispose();
-        }
-        if (diagnosticFeature != null) {
-            diagnosticFeature.dispose();
         }
         if (foldingRangeFeature != null) {
             foldingRangeFeature.dispose();
@@ -765,14 +759,14 @@ public class LSPClientFeatures implements Disposable {
         if (formattingFeature != null) {
             formattingFeature.dispose();
         }
+        if (hoverFeature != null) {
+            hoverFeature.dispose();
+        }
         if (implementationFeature != null) {
             implementationFeature.dispose();
         }
         if (inlayHintFeature != null) {
             inlayHintFeature.dispose();
-        }
-        if (hoverFeature != null) {
-            hoverFeature.dispose();
         }
         if (referencesFeature != null) {
             referencesFeature.dispose();
@@ -807,32 +801,26 @@ public class LSPClientFeatures implements Disposable {
         if (completionFeature != null) {
             completionFeature.setServerCapabilities(serverCapabilities);
         }
-        if (codeActionFeature != null) {
-            codeActionFeature.setServerCapabilities(serverCapabilities);
-        }
-        if (codeActionFeature != null) {
-            codeActionFeature.setServerCapabilities(serverCapabilities);
-        }
         if (declarationFeature != null) {
             declarationFeature.setServerCapabilities(serverCapabilities);
         }
         if (definitionFeature != null) {
             definitionFeature.setServerCapabilities(serverCapabilities);
         }
+        if (diagnosticFeature != null) {
+            diagnosticFeature.setServerCapabilities(serverCapabilities);
+        }
         if (documentColorFeature != null) {
             documentColorFeature.setServerCapabilities(serverCapabilities);
-        }
-        if (documentLinkFeature != null) {
-            documentLinkFeature.setServerCapabilities(serverCapabilities);
         }
         if (documentHighlightFeature != null) {
             documentHighlightFeature.setServerCapabilities(serverCapabilities);
         }
+        if (documentLinkFeature != null) {
+            documentLinkFeature.setServerCapabilities(serverCapabilities);
+        }
         if (documentSymbolFeature != null) {
             documentSymbolFeature.setServerCapabilities(serverCapabilities);
-        }
-        if (diagnosticFeature != null) {
-            diagnosticFeature.setServerCapabilities(serverCapabilities);
         }
         if (foldingRangeFeature != null) {
             foldingRangeFeature.setServerCapabilities(serverCapabilities);
@@ -840,14 +828,14 @@ public class LSPClientFeatures implements Disposable {
         if (formattingFeature != null) {
             formattingFeature.setServerCapabilities(serverCapabilities);
         }
+        if (hoverFeature != null) {
+            hoverFeature.setServerCapabilities(serverCapabilities);
+        }
         if (implementationFeature != null) {
             implementationFeature.setServerCapabilities(serverCapabilities);
         }
         if (inlayHintFeature != null) {
             inlayHintFeature.setServerCapabilities(serverCapabilities);
-        }
-        if (hoverFeature != null) {
-            hoverFeature.setServerCapabilities(serverCapabilities);
         }
         if (referencesFeature != null) {
             referencesFeature.setServerCapabilities(serverCapabilities);

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/TextDocumentServerCapabilityRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/TextDocumentServerCapabilityRegistry.java
@@ -39,7 +39,7 @@ public abstract class TextDocumentServerCapabilityRegistry<T extends TextDocumen
     }
 
     @Nullable
-    public T registerCapability(@NotNull JsonObject registerOptions) {
+    public synchronized T registerCapability(@NotNull JsonObject registerOptions) {
         T t = create(registerOptions);
         if (t != null) {
             dynamicCapabilities.add(t);


### PR DESCRIPTION
fix: synchronize registerCapability to avoid loosing some capability

With IJ Quarkus there are 2 textDocument/completion options which are registered with MP LS:

 * one for microprofile-properties language
 * one for Java language

I cannot explain why but it seems when we use CompletableFuture#runAsync, we loose some of one register capability.

It causes the following problem:

 * sometimes completion is working only with microprofile-config.properties and not with Java
 * sometimes completion is working only with Java but not with microprofile-config.properties 

This PR avoids using runAsync and it seems it is working better?