### PR TITLE
fix: compare two filenames before trying to rename the file

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -71,15 +71,14 @@ class LSPFileListener implements FileEditorManagerListener, VirtualFileListener 
         // Either a file (Test1.java) has been renamed (to Test2.java) by using Refactor / Rename from IJ
         // or a "properties" file is changed or saved.
         if (isRenameFile(event)) {
-            return;
-        }
-        // 1. Send a textDocument/didClose for the old file name (Test1.java) followed
-        //    by a textDocument/didOpen for the new file name (Test2.java)
-        VirtualFile newFile = event.getFile();
-        URI oldFileUri = didRename(newFile.getParent(), (String) event.getOldValue(), newFile);
+            // 1. Send a textDocument/didClose for the old file name (Test1.java) followed
+            //    by a textDocument/didOpen for the new file name (Test2.java)
+            VirtualFile newFile = event.getFile();
+            URI oldFileUri = didRename(newFile.getParent(), (String) event.getOldValue(), newFile);
 
-        // 2. Send a workspace/didChangeWatchedFiles
-        moveFile(oldFileUri, newFile);
+            // 2. Send a workspace/didChangeWatchedFiles
+            moveFile(oldFileUri, newFile);
+        }
     }
 
     private static boolean isRenameFile(@NotNull VirtualFilePropertyEvent event) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -70,7 +70,7 @@ class LSPFileListener implements FileEditorManagerListener, VirtualFileListener 
     public void propertyChanged(@NotNull VirtualFilePropertyEvent event) {
         // Either a file (Test1.java) has been renamed (to Test2.java) by using Refactor / Rename from IJ
         // or a "properties" file is changed or saved.
-        if (!isRenameFile(event)) {
+        if (isRenameFile(event)) {
             return;
         }
         // 1. Send a textDocument/didClose for the old file name (Test1.java) followed
@@ -86,7 +86,7 @@ class LSPFileListener implements FileEditorManagerListener, VirtualFileListener 
         if (event.getPropertyName().equals(VirtualFile.PROP_NAME) &&
                 event.getOldValue() instanceof String oldValue &&
                 event.getNewValue() instanceof String newValue) {
-            return Objects.equals(oldValue, newValue);
+            return !Objects.equals(oldValue, newValue);
         }
         return false;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -69,15 +69,22 @@ class LSPFileListener implements FileEditorManagerListener, VirtualFileListener 
     @Override
     public void propertyChanged(@NotNull VirtualFilePropertyEvent event) {
         if (event.getPropertyName().equals(VirtualFile.PROP_NAME) && event.getOldValue() instanceof String) {
+            String oldValue = (String) event.getOldValue();
+            String newValue = null;
             // A file (Test1.java) has been renamed (to Test2.java) by using Refactor / Rename from IJ
+            // or a "properties" file is changed or saved.
+            if (event.getNewValue() instanceof String) {
+                newValue = (String) event.getNewValue();
+            }
+            if (!oldValue.equals(newValue)) {
+                // 1. Send a textDocument/didClose for the old file name (Test1.java) followed
+                //    by a textDocument/didOpen for the new file name (Test2.java)
+                VirtualFile newFile = event.getFile();
+                URI oldFileUri = didRename(newFile.getParent(), oldValue, newFile);
 
-            // 1. Send a textDocument/didClose for the old file name (Test1.java) followed
-            //    by a textDocument/didOpen for the new file name (Test2.java)
-            VirtualFile newFile = event.getFile();
-            URI oldFileUri = didRename(newFile.getParent(), (String) event.getOldValue(), newFile);
-
-            // 2. Send a workspace/didChangeWatchedFiles
-            moveFile(oldFileUri, newFile);
+                // 2. Send a workspace/didChangeWatchedFiles
+                moveFile(oldFileUri, newFile);
+            }
         }
     }
 


### PR DESCRIPTION
Compare the oldValue to the newValue. In the case of a file name change only execute the rename code if the two names are different. 

Fixes #577