### PR TITLE
update RADME: Add Vespa Schema Language Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Here are some projects that use LSP4IJ:
  * [Ruff for PyCharm](https://github.com/koxudaxi/ruff-pycharm-plugin)
  * [Intellij Gleam](https://github.com/themartdev/intellij-gleam)
  * [Liberty Tools for IntelliJ](https://github.com/OpenLiberty/liberty-tools-intellij)
+ * [Vespa Schema Language Support](https://github.com/vespa-engine/vespa/tree/master/integration/schema-language-server/clients/intellij)
 
 ## Requirements
 


### PR DESCRIPTION
Add Vespa Schema Language Support to the list of who is using LSP4IJ in the README.