### PR TITLE
fix: No `textDocument/didOpen` sent when server is restarted

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/AbstractLSPFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/AbstractLSPFeature.java
@@ -99,7 +99,6 @@ public abstract class AbstractLSPFeature implements Disposable {
 
     @Override
     public void dispose() {
-        clientFeatures = null;
     }
 
     public abstract void setServerCapabilities(@Nullable ServerCapabilities serverCapabilities);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPInlayHintsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPInlayHintsProvider.java
@@ -23,6 +23,8 @@ import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.commands.CommandExecutor;
 import com.redhat.devtools.lsp4ij.commands.LSPCommandContext;
+import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager;
+import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureType;
 import org.eclipse.lsp4j.Command;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,8 +36,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-
-import static com.redhat.devtools.lsp4ij.internal.InlayHintsFactoryBridge.refreshInlayHints;
 
 /*
  * Abstract class used to display IntelliJ inlay hints.
@@ -95,7 +95,8 @@ public abstract class AbstractLSPInlayHintsProvider implements InlayHintsProvide
                                     // Check if PsiFile was not modified
                                     if (modificationStamp == psiFile.getModificationStamp()) {
                                         // All pending futures are finished, refresh the inlay hints
-                                        refreshInlayHints(psiFile, new Editor[]{editor}, false);
+                                        EditorFeatureManager.getInstance(project)
+                                                        .refreshEditorFeature(psiFile.getVirtualFile(), EditorFeatureType.INLAY_HINT, false);
                                     }
                                     return null;
                                 });

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/DummyCodeVisionProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/DummyCodeVisionProvider.java
@@ -39,7 +39,7 @@ public class DummyCodeVisionProvider implements CodeVisionProvider {
     private final List<CodeVisionRelativeOrdering> relativeOrderings;
 
     public DummyCodeVisionProvider(int index) {
-        id = LSPCodeLensProvider.LSP_CODE_LENS_PROVIDER_ID + index;
+        id =DummyCodeVisionProviderFactory.generateProviderId(index);
         // Keep the proper order of LSP CodeLens
         relativeOrderings = List.of(new CodeVisionRelativeOrdering.CodeVisionRelativeOrderingAfter(getPreviousProviderId(index)));
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/DummyCodeVisionProviderFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/DummyCodeVisionProviderFactory.java
@@ -18,16 +18,29 @@ import kotlin.sequences.SequencesKt;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
  * Factory to create 10 dummy code vision provider with ids 'LSPCodelensProvider0', 'LSPCodelensProvider1', etc
  */
 public class DummyCodeVisionProviderFactory implements CodeVisionProviderFactory {
+
+    private static final int NB_PROVIDERS  = 10;
+
+    public static final Collection<String> LSP_CODE_VISION_PROVIDER_IDS;
+
+    static {
+        LSP_CODE_VISION_PROVIDER_IDS =new ArrayList<>();
+        LSP_CODE_VISION_PROVIDER_IDS.add( LSPCodeLensProvider.LSP_CODE_LENS_PROVIDER_ID);
+        for (int i = 0; i < NB_PROVIDERS; i++) {
+            LSP_CODE_VISION_PROVIDER_IDS.add( generateProviderId(i));
+        }
+    }
     @NotNull
     @Override
     public Sequence<CodeVisionProvider<?>> createProviders(@NotNull Project project) {
-        CodeVisionProvider<?>[] s = createDummyProviders(10);
+        CodeVisionProvider<?>[] s = createDummyProviders(NB_PROVIDERS);
         return SequencesKt.sequenceOf(s);
     }
 
@@ -37,5 +50,9 @@ public class DummyCodeVisionProviderFactory implements CodeVisionProviderFactory
             list.add(new DummyCodeVisionProvider(i));
         }
         return list.toArray(new CodeVisionProvider<?>[size]);
+    }
+
+    static String generateProviderId(int index) {
+        return LSPCodeLensProvider.LSP_CODE_LENS_PROVIDER_ID + index;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/CodeVisionEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/CodeVisionEditorFeature.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal.editor;
+
+import com.intellij.codeInsight.codeVision.CodeVisionHost;
+import com.intellij.codeInsight.codeVision.CodeVisionInitializer;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
+import com.redhat.devtools.lsp4ij.features.codeLens.DummyCodeVisionProviderFactory;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Code vision feature to refresh IntelliJ code vision (even if Psi file doesn't change).
+ *
+ * Bridge class which consumes CodeVisionPassFactory with Java Reflection to support any IntelliJ version:
+ *
+ * <ul>
+ *     <li>with old version (< 2024.3): CodeVisionPassFactory.Companion.clearModificationStamp(editor)</li>
+ *     <li>with new version (>= 2024.3):  CodeVisionPassFactory.ModificationStampUtil.clearModificationStamp(editor)</li>
+ * </ul>
+ */
+@ApiStatus.Internal
+public class CodeVisionEditorFeature implements EditorFeature {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CodeVisionEditorFeature.class);
+
+    private static final String CODE_VISION_PASS_FACTORY_CLASS = "com.intellij.codeInsight.hints.codeVision.CodeVisionPassFactory";
+
+    // CodeVisionPassFactory.Companion
+    private static Object companionInstance;
+
+    // CodeVisionPassFactory.clearModificationStamp(editor)
+    private static Method clearModificationStampMethod;
+
+    @Override
+    public EditorFeatureType getFeatureType() {
+        return EditorFeatureType.CODE_VISION;
+    }
+
+    @Override
+    public void clearEditorCache(@NotNull Editor editor) {
+        try {
+            // Clear the modification stamp stored in the editor user-data
+            // (with the key PSI_MODIFICATION_STAMP)
+            // to refresh the code vision even if Psi file has not changed
+            // see https://github.com/JetBrains/intellij-community/blob/7c8933354e46a99e1f41022aaa6552d2c0455eec/platform/lang-impl/src/com/intellij/codeInsight/hints/codeVision/CodeVisionPassFactory.kt#L32
+            loadCodeVisionPassFactoryIfNeeded();
+            clearModificationStampMethod.invoke(companionInstance, editor);
+        } catch (Exception e) {
+            LOGGER.error("Error while calling CodeVisionPassFactory.ModificationStampUtil.clearModificationStamp(editor)", e);
+        }
+    }
+
+    @Override
+    public void clearLSPCache(PsiFile file) {
+        // Evict the cache of LSP requests from codeLens support
+        var fileSupport = LSPFileSupport.getSupport(file);
+        fileSupport.getCodeLensSupport().cancel();
+    }
+
+    @Override
+    public void collectUiRunnable(@NotNull Editor editor,
+                                  @NotNull PsiFile file,
+                                  @NotNull List<Runnable> runnableList) {
+        Runnable runnable = () -> {
+            // Get the IntelliJ code vision host and fire an event to refresh only LSP code vision
+            var codeVisionHost = CodeVisionInitializer.Companion.getInstance(file.getProject()).getCodeVisionHost();
+            codeVisionHost.getInvalidateProviderSignal().fire(new CodeVisionHost.LensInvalidateSignal(editor, DummyCodeVisionProviderFactory.LSP_CODE_VISION_PROVIDER_IDS));
+        };
+        runnableList.add(runnable);
+    }
+
+    private static void loadCodeVisionPassFactoryIfNeeded() throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException, NoSuchMethodException {
+        if (companionInstance != null) {
+            return;
+        }
+        loadCodeVisionPassFactory();
+    }
+
+    private static synchronized void loadCodeVisionPassFactory() throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchFieldException, NoSuchMethodException {
+        if (companionInstance != null) {
+            return;
+        }
+        Class<?> codeVisionPassFactoryClass = loadCodeVisionPassFactoryClass();
+        // Create instance of CodeVisionPassFactory
+        Object codeVisionPassFactoryInstance = codeVisionPassFactoryClass.getConstructors()[0].newInstance();
+
+        // Get CodeVisionPassFactory.ModificationStampUtil which defines relevant methods
+        Class<?> companionClass = codeVisionPassFactoryClass.getClasses()[0];
+        Field companionField = getCompanionInstance(codeVisionPassFactoryClass);
+        companionField.setAccessible(true);
+        Object companionInstance = companionField.get(codeVisionPassFactoryInstance);
+
+        // Get
+        // - CodeVisionPassFactory.ModificationStampUtil.clearModificationStamp(editor) method -> New version of IJ (>= 2024.3)
+        // - CodeVisionPassFactory.Companion.clearModificationStamp(editor) method -> Old version of IJ (< 2024.3)
+        clearModificationStampMethod = companionClass.getMethod("clearModificationStamp", Editor.class);
+        clearModificationStampMethod.setAccessible(true);
+        CodeVisionEditorFeature.companionInstance = companionInstance;
+    }
+
+    private static Class<?> loadCodeVisionPassFactoryClass() throws ClassNotFoundException {
+        try {
+            return Class.forName(CODE_VISION_PASS_FACTORY_CLASS);
+        } catch (Exception e) {
+            // Do nothing
+        }
+        LOGGER.error("Error while trying to initialize CodeVisionEditorFeature from classes " + CODE_VISION_PASS_FACTORY_CLASS);
+        throw new ClassNotFoundException(CODE_VISION_PASS_FACTORY_CLASS);
+    }
+
+    private static Field getCompanionInstance(Class<?> codeVisionPassFactoryClass) throws NoSuchFieldException {
+        try {
+            return codeVisionPassFactoryClass.getDeclaredField("ModificationStampUtil");
+        } catch (NoSuchFieldException e) {
+            // Old version of IJ (< 2024.3)
+            return codeVisionPassFactoryClass.getDeclaredField("Companion");
+        }
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeature.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal.editor;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * The editor feature.
+ */
+@ApiStatus.Internal
+public interface EditorFeature {
+
+    /**
+     * Returns the editor feature type.
+     *
+     * @return the editor feature type.
+     */
+    EditorFeatureType getFeatureType();
+
+    /**
+     * Clear notification stamp from the given editor.
+     *
+     * @param editor the editor.
+     */
+    void clearEditorCache(@NotNull Editor editor);
+
+    /**
+     * Clear LSP data cache (ex : LSP CodeLens).
+     *
+     * @param file the Psi file.
+     */
+    void clearLSPCache(PsiFile file);
+
+    /**
+     * Collect runnable which must be executed on UI step.
+     *
+     * @param editor       the editor to refresh.
+     * @param file         the file edited
+     * @param runnableList the Ui runnable list.
+     */
+    void collectUiRunnable(@NotNull Editor editor,
+                           @NotNull PsiFile file,
+                           @NotNull List<Runnable> runnableList);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal.editor;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * Editor feature manager used to refresh IntelliJ visible feature of editors from a given project:
+ *
+ * <ul>
+ *     <li>refresh 'Code Visions' from a given editor.</li>
+ *     <li>refresh 'Inlay Hints'  from a given editor.</li>
+ *     <li>refresh 'Folding' from a given editor.</li>
+ * </ul>
+ * <p>
+ * As IntelliJ doesn't provide some API to refresh those visible feature, we need to use Java reflection.
+ */
+@ApiStatus.Internal
+public class EditorFeatureManager implements Disposable {
+
+    private final @NotNull Project project;
+
+    private final Map<EditorFeatureType, EditorFeature> editorFeatures;
+
+    private EditorFeatureManager(@NotNull Project project) {
+        this.project = project;
+        this.editorFeatures = new LinkedHashMap<>();
+        addEditorFeature(new CodeVisionEditorFeature());
+        addEditorFeature(new FoldingEditorFeature());
+        addEditorFeature(new InlayHintsEditorFeature());
+    }
+
+    private void addEditorFeature(EditorFeature editorFeature) {
+        editorFeatures.put(editorFeature.getFeatureType(), editorFeature);
+    }
+
+    public static EditorFeatureManager getInstance(@NotNull Project project) {
+        return project.getService(EditorFeatureManager.class);
+    }
+
+    /**
+     * Refresh IntelliJ editor feature (code visions, inlay hints, folding, etc).
+     *
+     * @param file          the file opened in one or several editors.
+     * @param featureType   the feature type to refresh (code visions, inlay hints, folding, etc, or all)
+     * @param clearLSPCache true if LSP feature data cache (ex : LSP CodeLens) must be evicted and false otherwise.
+     */
+    public void refreshEditorFeature(@NotNull VirtualFile file,
+                                     @NotNull EditorFeatureType featureType,
+                                     boolean clearLSPCache) {
+        ReadAction.nonBlocking((Callable<List<Runnable>>) () -> {
+                    // Get the Psi file.
+                    PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+                    if (psiFile == null) {
+                        return null;
+                    }
+
+                    // Get opened editors used to display the content of the file.
+                    Editor[] editors = LSPIJUtils.editorsForFile(file, project);
+                    if (editors.length == 0) {
+                        return null;
+                    }
+
+                    if (clearLSPCache) {
+                        // Clear LSP cache
+                        clearLSPCache(psiFile, featureType);
+                    }
+
+                    final List<Runnable> runnables = new ArrayList<>();
+                    for (Editor editor : editors) {
+                        // Clear editor cache according the feature type
+                        // (IntelliJ stores generally the modification time stamp of the Psi file to avoid refreshing the feature if Psi file doesn't change)
+                        clearEditorCache(editor, featureType);
+                        // Collect runnable which must be executed on UI step.
+                        collectUiRunnables(psiFile, editor, featureType, runnables);
+                    }
+                    return runnables;
+                })
+                .finishOnUiThread(ModalityState.any(), runnables -> {
+                    if (runnables == null) {
+                        return;
+                    }
+                    for (var runnable : runnables) {
+                        runnable.run();
+                    }
+                }).submit(AppExecutorUtil.getAppExecutorService());
+    }
+
+    private void clearEditorCache(Editor editor, @NotNull EditorFeatureType featureType) {
+        if (featureType == EditorFeatureType.ALL) {
+            editorFeatures.values().forEach(feature -> feature.clearEditorCache(editor));
+        } else {
+            getEditorFeature(featureType).clearEditorCache(editor);
+        }
+    }
+
+    private void clearLSPCache(PsiFile psiFile, @NotNull EditorFeatureType featureType) {
+        if (featureType == EditorFeatureType.ALL) {
+            editorFeatures.values().forEach(feature -> feature.clearLSPCache(psiFile));
+        } else {
+            getEditorFeature(featureType).clearLSPCache(psiFile);
+        }
+    }
+
+
+    private void collectUiRunnables(@NotNull PsiFile psiFile,
+                                    @NotNull Editor editor,
+                                    @NotNull EditorFeatureType featureType,
+                                    @NotNull List<Runnable> runnables) {
+        if (featureType == EditorFeatureType.ALL) {
+            editorFeatures.values().forEach(feature -> feature.collectUiRunnable(editor, psiFile, runnables));
+        } else {
+            getEditorFeature(featureType).collectUiRunnable(editor, psiFile, runnables);
+        }
+    }
+
+    private EditorFeature getEditorFeature(@NotNull EditorFeatureType featureType) {
+        return editorFeatures.get(featureType);
+    }
+
+    @Override
+    public void dispose() {
+        // Do nothing
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureType.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureType.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal.editor;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * The editor feature type ro refresh.
+ */
+@ApiStatus.Internal
+public enum EditorFeatureType {
+    CODE_VISION,
+    INLAY_HINT,
+    FOLDING,
+    ALL
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/FoldingEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/FoldingEditorFeature.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal.editor;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Folding feature to refresh IntelliJ folding (even if Psi file doesn't change).
+ *
+ * Bridge class which consumes FoldingEditor with Java Reflection because FoldingEditorFeature#clearFoldingCache(editor) is private.
+ */
+@ApiStatus.Internal
+public class FoldingEditorFeature implements EditorFeature {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FoldingEditorFeature.class);
+
+    private static final String FOLDING_UPDATE_CLASS = "com.intellij.codeInsight.folding.impl.FoldingUpdate";
+
+    // CodeVisionPassFactory.clearModificationStamp(editor)
+    private static Method clearFoldingCacheMethod;
+    private static Boolean loaded;
+
+    @Override
+    public EditorFeatureType getFeatureType() {
+        return EditorFeatureType.FOLDING;
+    }
+
+    @Override
+    public void clearEditorCache(@NotNull Editor editor) {
+        try {
+            // Clear the modification stamp stored in the editor user-data
+            // (with the key CODE_FOLDING_KEY)
+            // to refresh the folding even if Psi file has not changed
+            // see https://github.com/JetBrains/intellij-community/blob/7c8933354e46a99e1f41022aaa6552d2c0455eec/platform/lang-impl/src/com/intellij/codeInsight/folding/impl/FoldingUpdate.java#L66
+            loadFoldingUpdateIfNeeded();
+            if (clearFoldingCacheMethod != null) {
+                clearFoldingCacheMethod.invoke(null, editor);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error while calling FoldingUpdate.clearFoldingCache(editor)", e);
+        }
+    }
+
+    @Override
+    public void clearLSPCache(PsiFile file) {
+        // Evict the cache of LSP requests from folding range support
+        var fileSupport = LSPFileSupport.getSupport(file);
+        fileSupport.getFoldingRangeSupport().cancel();
+    }
+
+    @Override
+    public void collectUiRunnable(@NotNull Editor editor, @NotNull PsiFile file, @NotNull List<Runnable> runnableList) {
+        // Do nothing
+    }
+
+    private static void loadFoldingUpdateIfNeeded() {
+        if (loaded != null) {
+            return;
+        }
+        loadFoldingUpdate();
+    }
+
+    private static synchronized void loadFoldingUpdate() {
+        if (loaded != null) {
+            return;
+        }
+        try {
+            Class<?> foldingUpdateClass = loadFoldingUpdateClass();
+            // Get FoldingUpdate.clearFoldingCache(editor) method
+            clearFoldingCacheMethod = foldingUpdateClass.getDeclaredMethod("clearFoldingCache", Editor.class);
+            clearFoldingCacheMethod.setAccessible(true);
+            FoldingEditorFeature.loaded = Boolean.TRUE;
+        }
+        catch(Exception e) {
+            FoldingEditorFeature.loaded = Boolean.FALSE;
+            LOGGER.error("Error while loading FoldingUpdate.clearFoldingCache(editor)", e);
+        }
+    }
+
+
+    private static Class<?> loadFoldingUpdateClass() throws ClassNotFoundException {
+            try {
+                return Class.forName(FOLDING_UPDATE_CLASS);
+            } catch (Exception e) {
+                // Do nothing
+            }
+        LOGGER.error("Error while trying to load FoldingEditorFeature from classes " + FOLDING_UPDATE_CLASS);
+        throw new ClassNotFoundException(FOLDING_UPDATE_CLASS);
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -200,6 +200,8 @@
         <projectService
                 serviceImplementation="com.redhat.devtools.lsp4ij.LanguageServerManager"/>
         <projectService
+                serviceImplementation="com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager"/>
+        <projectService
                 serviceImplementation="com.redhat.devtools.lsp4ij.LanguageServiceAccessor"/>
         <projectService
                 serviceImplementation="com.redhat.devtools.lsp4ij.lifecycle.LanguageServerLifecycleManager"/>


### PR DESCRIPTION
fix: No `textDocument/didOpen` sent when server is restarted

Fixes #585