### PR TITLE
fix: Address editor in RustRover's Memory View tab triggers LSP requests

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
@@ -552,7 +552,7 @@ public class LanguageServersRegistry {
      * @return true if the language of the file is supported by a language server and false otherwise.
      */
     public boolean isFileSupported(@Nullable VirtualFile file, @NotNull Project project) {
-        if (file == null) {
+        if (file == null || !file.isInLocalFileSystem()) {
             return false;
         }
         Language language = LSPIJUtils.getFileLanguage(file, project);


### PR DESCRIPTION
fix: Address editor in RustRover's Memory View tab triggers LSP requests

Fixes #560

Signed-off-by: azerr <azerr@redhat.com>