### PR TITLE
fix: Use Locale.ROOT for capitalizing / decapitalizing locale insensitive strings.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/SeverityMapping.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/SeverityMapping.java
@@ -21,6 +21,8 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Locale;
+
 /**
  * Utility class to map language servers' {@link DiagnosticSeverity} to Intellij's {@link HighlightSeverity}, and vice-versa.
  */
@@ -84,7 +86,7 @@ public class SeverityMapping {
      * @return {@link DiagnosticSeverity} as lower case, or <code>none</code> if severity is <code>null</code>.
      */
     public static @NotNull String toString(@Nullable DiagnosticSeverity severity) {
-        return (severity == null)? NONE_SEVERITY : severity.name().toLowerCase();
+        return (severity == null)? NONE_SEVERITY : severity.name().toLowerCase(Locale.ROOT);
     }
 
     public static DiagnosticSeverity getSeverity(String inspectionId, InspectionProfile profile) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -238,7 +239,7 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
     public String getLanguageId(@Nullable VirtualFile file,
                                 @NotNull Project project) {
         if (file == null) {
-            return FileTypes.UNKNOWN.getName().toLowerCase();
+            return FileTypes.UNKNOWN.getName().toLowerCase(Locale.ROOT);
         }
         Language language = LSPIJUtils.getFileLanguage(file, project);
         return getLanguageId(language, file.getFileType(), file.getName());
@@ -300,10 +301,10 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentItem
         if (language != null) {
             // The language exists, use its ID with lower case
-            return language.getID().toLowerCase();
+            return language.getID().toLowerCase(Locale.ROOT);
         }
         // Returns the existing file type or 'unknown' with lower case
-        return fileName.toLowerCase();
+        return fileName.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/ui/IconMapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ui/IconMapper.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -117,7 +118,7 @@ public class IconMapper {
         if (!isValidHexColor(hexValue)) {
             return null;
         }
-        return colorToIconCache.computeIfAbsent(hexValue.toUpperCase(), key -> {
+        return colorToIconCache.computeIfAbsent(hexValue.toUpperCase(Locale.ROOT), key -> {
             try {
                 Color decodedColor = java.awt.Color.decode(key);
                 return new ColorIcon(ICON_SIZE, decodedColor, true);


### PR DESCRIPTION
We just resolved this issue in Liberty Tools for IntelliJ: https://github.com/OpenLiberty/liberty-tools-intellij/issues/1092. I noticed a few instances of it in LSP4IJ.