### PR TITLE
fix: Error while calling ModificationStampUtil.clearModificationStamp(editor)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/FoldingEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/FoldingEditorFeature.java
@@ -34,8 +34,8 @@ public class FoldingEditorFeature implements EditorFeature {
     private static final String FOLDING_UPDATE_CLASS = "com.intellij.codeInsight.folding.impl.FoldingUpdate";
 
     // CodeVisionPassFactory.clearModificationStamp(editor)
-    private static Method clearFoldingCacheMethod;
-    private static Boolean loaded;
+    private Method clearFoldingCacheMethod;
+    private Boolean loaded;
 
     @Override
     public EditorFeatureType getFeatureType() {
@@ -70,14 +70,14 @@ public class FoldingEditorFeature implements EditorFeature {
         // Do nothing
     }
 
-    private static void loadFoldingUpdateIfNeeded() {
+    private void loadFoldingUpdateIfNeeded() {
         if (loaded != null) {
             return;
         }
         loadFoldingUpdate();
     }
 
-    private static synchronized void loadFoldingUpdate() {
+    private synchronized void loadFoldingUpdate() {
         if (loaded != null) {
             return;
         }
@@ -86,10 +86,10 @@ public class FoldingEditorFeature implements EditorFeature {
             // Get FoldingUpdate.clearFoldingCache(editor) method
             clearFoldingCacheMethod = foldingUpdateClass.getDeclaredMethod("clearFoldingCache", Editor.class);
             clearFoldingCacheMethod.setAccessible(true);
-            FoldingEditorFeature.loaded = Boolean.TRUE;
+            this.loaded = Boolean.TRUE;
         }
         catch(Exception e) {
-            FoldingEditorFeature.loaded = Boolean.FALSE;
+            this.loaded = Boolean.FALSE;
             LOGGER.error("Error while loading FoldingUpdate.clearFoldingCache(editor)", e);
         }
     }


### PR DESCRIPTION

This PR should fix the following error:

```
Error while calling ModificationStampUtil.clearModificationStamp(editor)

java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "o" is null
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.checkReceiver(DirectMethodHandleAccessor.java:196)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:99)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.redhat.devtools.lsp4ij.internal.editor.CodeVisionEditorFeature.clearEditorCache(CodeVisionEditorFeature.java:69)
	at com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager.lambda$clearEditorCache$2(EditorFeatureManager.java:117)
	at java.base/java.util.LinkedHashMap$LinkedValues.forEach(LinkedHashMap.java:833)
	at com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager.clearEditorCache(EditorFeatureManager.java:117)
	at com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager.lambda$refreshEditorFeature$0(EditorFeatureManager.java:100)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$OTelMonitor.callWrapped(NonBlockingReadActionImpl.java:857)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$OTelMonitor$MonitoredComputation.call(NonBlockingReadActionImpl.java:889)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.insideReadAction(NonBlockingReadActionImpl.java:618)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$attemptComputation$4(NonBlockingReadActionImpl.java:581)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:351)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:971)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runInReadActionWithWriteActionPriority$0(ProgressIndicatorUtils.java:95)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:66)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:157)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runWithWriteActionPriority$1(ProgressIndicatorUtils.java:140)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:98)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:223)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:45)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:222)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:674)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:749)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:673)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:79)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:203)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:98)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runWithWriteActionPriority(ProgressIndicatorUtils.java:137)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runInReadActionWithWriteActionPriority(ProgressIndicatorUtils.java:95)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.attemptComputation(NonBlockingReadActionImpl.java:581)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$transferToBgThread$1(NonBlockingReadActionImpl.java:480)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$transferToBgThread$2(NonBlockingReadActionImpl.java:495)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:735)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:732)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:732)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```