### PR TITLE
fix: send didOpen before refreshing editors after a project indexing

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServiceAccessor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServiceAccessor.java
@@ -157,7 +157,8 @@ public class LanguageServiceAccessor implements Disposable {
         }
     }
 
-    private void sendDidOpenAndRefreshEditorFeatureFor(@NotNull VirtualFile file, @NotNull LanguageServerDefinition serverDefinition) {
+    private void sendDidOpenAndRefreshEditorFeatureFor(@NotNull VirtualFile file,
+                                                       @NotNull LanguageServerDefinition serverDefinition) {
         ReadAction.nonBlocking(() -> {
                     // Try to send a textDocument/didOpen notification if the file is associated to the language server definition
                     LanguageServiceAccessor.getInstance(project)

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/ProjectIndexingListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/ProjectIndexingListener.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.lsp4ij.client;
 import com.intellij.util.indexing.diagnostic.ProjectDumbIndexingHistory;
 import com.intellij.util.indexing.diagnostic.ProjectIndexingActivityHistoryListener;
 import com.intellij.util.indexing.diagnostic.ProjectScanningHistory;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager;
 import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureType;
 import org.jetbrains.annotations.ApiStatus;
@@ -35,7 +36,7 @@ public class ProjectIndexingListener implements ProjectIndexingActivityHistoryLi
     public void onFinishedDumbIndexing(@NotNull ProjectDumbIndexingHistory history) {
         ProjectIndexingManager manager = ProjectIndexingManager.getInstance(history.getProject());
         manager.dumbIndexing = false;
-        refreshEditorsFeaturesNeeded(manager);
+        refreshEditorsFeaturesIfNeeded(manager);
     }
 
     @Override
@@ -47,20 +48,32 @@ public class ProjectIndexingListener implements ProjectIndexingActivityHistoryLi
     public void onFinishedScanning(@NotNull ProjectScanningHistory history) {
         ProjectIndexingManager manager = ProjectIndexingManager.getInstance(history.getProject());
         manager.scanning = false;
-        refreshEditorsFeaturesNeeded(manager);
+        refreshEditorsFeaturesIfNeeded(manager);
     }
 
-    private void refreshEditorsFeaturesNeeded(ProjectIndexingManager manager) {
+    private void refreshEditorsFeaturesIfNeeded(ProjectIndexingManager manager) {
         if (!manager.isIndexingAll()) {
             // All opened project are indexed,
             // refresh all editors which edit the files to refresh
-            while(!manager.filesToRefresh.isEmpty()) {
+            while (!manager.filesToRefresh.isEmpty()) {
                 var files = new HashSet<>(manager.filesToRefresh);
-                for(var file : files) {
-                    // Refresh all features (code vision, inlay hints, folding,etc)
-                    // of editors which edit the current file.
-                    EditorFeatureManager.getInstance(manager.project)
-                            .refreshEditorFeature(file, EditorFeatureType.ALL, true);
+                for (var file : files) {
+
+                    // Try to send a textDocument/didOpen notification if the file is associated to the language server definition
+                    LanguageServiceAccessor.getInstance(manager.project)
+                            .getLanguageServers(file, null, null)
+                            .thenAccept(servers -> {
+                                // textDocument/didOpen notification has been sent
+                                if (servers.isEmpty()) {
+                                    return;
+                                }
+
+                                // Refresh all features (code vision, inlay hints, folding,etc)
+                                // of editors which edit the current file.
+                                EditorFeatureManager.getInstance(manager.project)
+                                        .refreshEditorFeature(file, EditorFeatureType.ALL, true);
+
+                            });
                 }
                 manager.filesToRefresh.removeAll(files);
             }


### PR DESCRIPTION
fix: send didOpen before refreshing editors after a project indexing