### PR TITLE
feat: Add support for Next/Previous Method actions

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
@@ -99,7 +99,12 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
                              @NotNull PsiFile psiFile) {
         SymbolKind symbolKind = documentSymbol.getKind();
         // TODO: This works quite well without having to implement MethodNavigationOffsetProvider
-        if ((symbolKind == SymbolKind.Method) || (symbolKind == SymbolKind.Function)) {
+        if ((symbolKind == SymbolKind.Class) ||
+            (symbolKind == SymbolKind.Interface) ||
+            (symbolKind == SymbolKind.Enum) ||
+            (symbolKind == SymbolKind.Struct) ||
+            (symbolKind == SymbolKind.Method) ||
+            (symbolKind == SymbolKind.Function)) {
             Position startPosition = documentSymbol.getSelectionRange().getStart();
             Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());
             if (document != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
@@ -20,6 +20,7 @@ import com.redhat.devtools.lsp4ij.server.capabilities.DocumentSymbolCapabilityRe
 import com.redhat.devtools.lsp4ij.ui.IconMapper;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SymbolKind;
 import org.jetbrains.annotations.ApiStatus;
@@ -114,9 +115,10 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
             (symbolKind == SymbolKind.Struct) ||
             (symbolKind == SymbolKind.Method) ||
             (symbolKind == SymbolKind.Function)) {
-            Position startPosition = documentSymbol.getSelectionRange().getStart();
+            Range selectionRange = documentSymbol.getSelectionRange();
+            Position startPosition = selectionRange != null ? selectionRange.getStart() : null;
             Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());
-            if (document != null) {
+            if ((startPosition != null) && (document != null)) {
                 return LSPIJUtils.toOffset(startPosition, document);
             }
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
@@ -101,8 +101,7 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
      * reported as having a text offset.
      *
      * @param documentSymbol the document symbol
-     * @param psiFile the file
-     *
+     * @param psiFile        the file
      * @return the start of the symbol's selection range if valid; otherwise 0
      */
     public int getTextOffset(@NotNull DocumentSymbol documentSymbol,
@@ -110,11 +109,11 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
         SymbolKind symbolKind = documentSymbol.getKind();
         // TODO: This works quite well without having to implement MethodNavigationOffsetProvider
         if ((symbolKind == SymbolKind.Class) ||
-            (symbolKind == SymbolKind.Interface) ||
-            (symbolKind == SymbolKind.Enum) ||
-            (symbolKind == SymbolKind.Struct) ||
-            (symbolKind == SymbolKind.Method) ||
-            (symbolKind == SymbolKind.Function)) {
+                (symbolKind == SymbolKind.Interface) ||
+                (symbolKind == SymbolKind.Enum) ||
+                (symbolKind == SymbolKind.Struct) ||
+                (symbolKind == SymbolKind.Method) ||
+                (symbolKind == SymbolKind.Function)) {
             Range selectionRange = documentSymbol.getSelectionRange();
             Position startPosition = selectionRange != null ? selectionRange.getStart() : null;
             Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.client.features;
 
 import com.intellij.ide.structureView.StructureViewTreeElement;
+import com.intellij.openapi.editor.Document;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.features.documentSymbol.DocumentSymbolData;
@@ -18,7 +19,9 @@ import com.redhat.devtools.lsp4ij.features.documentSymbol.LSPDocumentSymbolStruc
 import com.redhat.devtools.lsp4ij.server.capabilities.DocumentSymbolCapabilityRegistry;
 import com.redhat.devtools.lsp4ij.ui.IconMapper;
 import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SymbolKind;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -90,6 +93,20 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
     public @Nullable String getLocationString(@NotNull DocumentSymbol documentSymbol,
                                               @NotNull PsiFile psiFile) {
         return documentSymbol.getDetail();
+    }
+
+    public int getTextOffset(@NotNull DocumentSymbol documentSymbol,
+                             @NotNull PsiFile psiFile) {
+        SymbolKind symbolKind = documentSymbol.getKind();
+        // TODO: This works quite well without having to implement MethodNavigationOffsetProvider
+        if ((symbolKind == SymbolKind.Method) || (symbolKind == SymbolKind.Function)) {
+            Position startPosition = documentSymbol.getSelectionRange().getStart();
+            Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());
+            if (document != null) {
+                return LSPIJUtils.toOffset(startPosition, document);
+            }
+        }
+        return 0;
     }
 
     public void navigate(@NotNull DocumentSymbol documentSymbol,

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
@@ -95,6 +95,15 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
         return documentSymbol.getDetail();
     }
 
+    /**
+     * Finds the text offset of the symbol as the start of its selection range. Only types and methods/functions are
+     * reported as having a text offset.
+     *
+     * @param documentSymbol the document symbol
+     * @param psiFile the file
+     *
+     * @return the start of the symbol's selection range if valid; otherwise 0
+     */
     public int getTextOffset(@NotNull DocumentSymbol documentSymbol,
                              @NotNull PsiFile psiFile) {
         SymbolKind symbolKind = documentSymbol.getKind();

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/DocumentSymbolData.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/DocumentSymbolData.java
@@ -72,6 +72,11 @@ public class DocumentSymbolData extends FakePsiElement {
     }
 
     @Override
+    public int getTextOffset() {
+        return getClientFeatures().getDocumentSymbolFeature().getTextOffset(documentSymbol, psiFile);
+    }
+
+    @Override
     public void navigate(boolean requestFocus) {
         getClientFeatures().getDocumentSymbolFeature().navigate(documentSymbol, psiFile, requestFocus);
     }


### PR DESCRIPTION
Issue 618 - This provides a simple implementation of **Next/Previous Method** actions based on the existing structure view implementation by returning text offsets for name identifiers of methods and functions from the structure view. Ideally it would be implemented via `MethodNavigationOffsetProvider` -- and perhaps it should be -- but the only down-side to this approach is that when the **Previous Method** action is triggered from the first method/function in the file, it does navigate to the beginning of the file because text offset 0 is returned for other elements.