### PR TITLE
fix: Method/function completions don't (consistently?) use an insert handler with parens for args

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
@@ -954,7 +954,6 @@ public class LSPClientFeatures implements Disposable {
      */
     @Override
     public void dispose() {
-        serverWrapper = null;
         if (callHierarchyFeature != null) {
             callHierarchyFeature.dispose();
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionProposal.java
@@ -97,6 +97,7 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
 
     @Override
     public void handleInsert(@NotNull InsertionContext context) {
+        updateCompletionItemFromResolved();
         Template template = null;
         if (item.getInsertTextFormat() == InsertTextFormat.Snippet) {
             // Insert text has snippet syntax, ex : ${1:name}
@@ -134,6 +135,26 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
             if (popupController != null) {
                 popupController.autoPopupParameterInfo(editor, null);
             }
+        }
+    }
+
+    private void updateCompletionItemFromResolved() {
+        CompletionItem resolved = resolvedCompletionItemFuture != null ? resolvedCompletionItemFuture.getNow(null) : null;
+        if(resolved == null) {
+            return;
+        }
+        if (resolved.getInsertTextFormat() != null) {
+            item.setInsertTextFormat(resolved.getInsertTextFormat());
+        }
+        if (resolved.getInsertText() != null) {
+            // A sample use case is with typescript-language-server which updates insertText on resolve completion
+            // to insert function/method signature with snippet.
+            // Before resolve -> bar
+            // After resolve -> bar()$0
+            item.setInsertText(resolved.getInsertText());
+        }
+        if (resolved.getInsertTextMode() != null) {
+            item.setInsertTextMode(resolved.getInsertTextMode());
         }
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
@@ -105,6 +105,10 @@ public class EditorFeatureManager implements Disposable {
                 })
                 .coalesceBy(file, featureType, clearLSPCache)
                 .finishOnUiThread(ModalityState.any(), context -> {
+                    if (context == null) {
+                        // No opened editors associated from any language servers.
+                        return;
+                    }
                     DaemonCodeAnalyzer.getInstance(project).restart(context.file());
                     for (var runnable : context.runnables()) {
                         runnable.run();

--- a/src/main/resources/templates/typescript-language-server/settings.json
+++ b/src/main/resources/templates/typescript-language-server/settings.json
@@ -1,4 +1,7 @@
 {
+  "completions": {
+    "completeFunctionCalls": true
+  },
   "typescript": {
     "inlayHints": {
       "includeInlayEnumMemberValueHints": true,


### PR DESCRIPTION
fix: Method/function completions don't (consistently?) use an insert handler with parens for args

Fixes #610