### PR TITLE
fix: Inserted completions for methods/functions still don't include argument parens consistently

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionFeature.java
@@ -104,7 +104,7 @@ public class LSPCompletionFeature extends AbstractLSPDocumentFeature {
     /**
      * Returns true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
      *
-     * @param file the file.
+     * @param file      the file.
      * @param charTyped the current typed character.
      * @return true if the given character is defined as "completion trigger" in the server capability of the language server and false otherwise.
      */
@@ -214,6 +214,7 @@ public class LSPCompletionFeature extends AbstractLSPDocumentFeature {
 
     /**
      * Don't override this method, we need to revisit the API and the prefix computation (to customize it).
+     *
      * @param completionPrefix
      * @param result
      * @param lookupItem
@@ -243,6 +244,18 @@ public class LSPCompletionFeature extends AbstractLSPDocumentFeature {
         }
     }
 
+    /**
+     * Returns true if completion item must be resolved and false otherwise when completion item is applied.
+     *
+     * @param item the completion item which is applied.
+     * @param file the file.
+     * @return true if completion item must be resolved and false otherwise when completion item is applied.
+     */
+    public boolean shouldResolveOnApply(@NotNull CompletionItem item,
+                                        @NotNull PsiFile file) {
+        return true;
+    }
+
     public CompletionCapabilityRegistry getCompletionCapabilityRegistry() {
         if (completionCapabilityRegistry == null) {
             initCompletionCapabilityRegistry();
@@ -261,7 +274,7 @@ public class LSPCompletionFeature extends AbstractLSPDocumentFeature {
 
     @Override
     public void setServerCapabilities(@Nullable ServerCapabilities serverCapabilities) {
-        if(completionCapabilityRegistry != null) {
+        if (completionCapabilityRegistry != null) {
             completionCapabilityRegistry.setServerCapabilities(serverCapabilities);
         }
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionProposal.java
@@ -139,8 +139,12 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
     }
 
     private void updateCompletionItemFromResolved() {
-        CompletionItem resolved = resolvedCompletionItemFuture != null ? resolvedCompletionItemFuture.getNow(null) : null;
-        if(resolved == null) {
+        if (!completionContext.isResolveCompletionSupported() ||
+                !completionFeature.shouldResolveOnApply(item, file)) {
+            return;
+        }
+        CompletionItem resolved = getResolvedCompletionItem();
+        if (resolved == null) {
             return;
         }
         if (resolved.getInsertTextFormat() != null) {
@@ -169,7 +173,6 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
                 && (template.getSegmentsCount() > 0 // There are some tabstops, e.g. $0, $1
                 || !template.getVariables().isEmpty()); // There are some placeholders, e.g ${1:name}
     }
-
 
     /**
      * Update the insert text with the given new value <code>newText</code>.


### PR DESCRIPTION
fix: Inserted completions for methods/functions still don't include argument parens consistently

Fixes #627