### PR TITLE
fix: Make go to definition/declaration/implementation target the name identifier (issue 628)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -1197,4 +1197,28 @@ public class LSPIJUtils {
         }
         return project.getName();
     }
+
+    /**
+     * Extracts the most specific location information from the provided list of locations or location links.
+     *
+     * @param locations the locations/links
+     * @return the most specific location information that was found based on the provided locations/links
+     */
+    public static @NotNull List<Location> getLocations(@Nullable Either<List<? extends Location>, List<? extends LocationLink>> locations) {
+        if (locations == null) {
+            // textDocument/definition may return null
+            return Collections.emptyList();
+        }
+        if (locations.isLeft()) {
+            return locations.getLeft()
+                    .stream()
+                    .map(l -> new Location(l.getUri(), l.getRange()))
+                    .toList();
+
+        }
+        return locations.getRight()
+                .stream()
+                .map(l -> new Location(l.getTargetUri(), l.getTargetSelectionRange() != null ? l.getTargetSelectionRange() : l.getTargetRange()))
+                .toList();
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPDeclarationSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPDeclarationSupport.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.features.declaration;
 
 import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
@@ -19,7 +20,6 @@ import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -83,23 +83,6 @@ public class LSPDeclarationSupport extends AbstractLSPDocumentFeatureSupport<LSP
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .declaration(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DECLARATION)
-                .thenApplyAsync(locations -> {
-                    if (locations == null) {
-                        // textDocument/declaration may return null
-                        return Collections.emptyList();
-                    }
-                    if (locations.isLeft()) {
-                        return locations.getLeft()
-                                .stream()
-                                .map(l -> new Location(l.getUri(), l.getRange()))
-                                .toList();
-
-                    }
-                    return locations.getRight()
-                            .stream()
-                            .map(l -> new Location(l.getTargetUri(), l.getTargetRange()))
-                            .toList();
-                });
+                .thenApplyAsync(LSPIJUtils::getLocations);
     }
-
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPImplementationSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPImplementationSupport.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.features.implementation;
 
 import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
@@ -19,7 +20,6 @@ import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -83,23 +83,6 @@ public class LSPImplementationSupport extends AbstractLSPDocumentFeatureSupport<
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .implementation(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_IMPLEMENTATION)
-                .thenApplyAsync(locations -> {
-                    if (locations == null) {
-                        // textDocument/implementation may return null
-                        return Collections.emptyList();
-                    }
-                    if (locations.isLeft()) {
-                        return locations.getLeft()
-                                .stream()
-                                .map(l -> new Location(l.getUri(), l.getRange()))
-                                .toList();
-
-                    }
-                    return locations.getRight()
-                            .stream()
-                            .map(l -> new Location(l.getTargetUri(), l.getTargetRange()))
-                            .toList();
-                });
+                .thenApplyAsync(LSPIJUtils::getLocations);
     }
-
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPDefinitionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPDefinitionSupport.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.features.navigation;
 
 import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
@@ -19,7 +20,6 @@ import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -83,23 +83,6 @@ public class LSPDefinitionSupport extends AbstractLSPDocumentFeatureSupport<LSPD
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .definition(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DECLARATION)
-                .thenApplyAsync(locations -> {
-                    if (locations == null) {
-                        // textDocument/definition may return null
-                        return Collections.emptyList();
-                    }
-                    if (locations.isLeft()) {
-                        return locations.getLeft()
-                                .stream()
-                                .map(l -> new Location(l.getUri(), l.getRange()))
-                                .toList();
-
-                    }
-                    return locations.getRight()
-                            .stream()
-                            .map(l -> new Location(l.getTargetUri(), l.getTargetRange()))
-                            .toList();
-                });
+                .thenApplyAsync(LSPIJUtils::getLocations);
     }
-
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPTypeDefinitionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPTypeDefinitionSupport.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.features.typeDefinition;
 
 import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
@@ -19,7 +20,6 @@ import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
 import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -83,23 +83,6 @@ public class LSPTypeDefinitionSupport extends AbstractLSPDocumentFeatureSupport<
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .typeDefinition(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_TYPE_DEFINITION)
-                .thenApplyAsync(locations -> {
-                    if (locations == null) {
-                        // textDocument/typeDefinition may return null
-                        return Collections.emptyList();
-                    }
-                    if (locations.isLeft()) {
-                        return locations.getLeft()
-                                .stream()
-                                .map(l -> new Location(l.getUri(), l.getRange()))
-                                .toList();
-
-                    }
-                    return locations.getRight()
-                            .stream()
-                            .map(l -> new Location(l.getTargetUri(), l.getTargetRange()))
-                            .toList();
-                });
+                .thenApplyAsync(LSPIJUtils::getLocations);
     }
-
 }


### PR DESCRIPTION
Issue 628 - When available, the target selection range should be used from the location link instead of the target range. That helps place the caret at the beginning of the target name identifier instead of the beginning of the entire target declaration. This logic has been extracted into a utility method, and all existing implementations of the same logic now use that method.