### PR TITLE
fix: IJ can freeze with execution of LSP References action

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPGoToAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPGoToAction.java
@@ -12,21 +12,27 @@ package com.redhat.devtools.lsp4ij.features;
 
 import com.intellij.codeInsight.TargetElementUtil;
 import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsContexts;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.client.ExecuteLSPFeatureStatus;
-import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
+import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
 import com.redhat.devtools.lsp4ij.usages.LSPUsagesManager;
 import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -72,20 +78,30 @@ public abstract class AbstractLSPGoToAction extends AnAction {
         }
         // Consume LSP 'textDocument/implementation' request
         int offset = TargetElementUtil.adjustOffset(psiFile, document, editor.getCaretModel().getOffset());
-        CompletableFuture<List<Location>> locationsFuture = getLocations(psiFile, document, editor, offset);
 
-        if (isDoneNormally(locationsFuture)) {
-            // textDocument/implementations has been collected correctly
-            List<Location> locations = locationsFuture.getNow(null);
-            if (locations != null) {
-                DataContext dataContext = e.getDataContext();
-                // Call "Find Usages" in popup mode.
-                LSPUsagesManager.getInstance(project).findShowUsagesInPopup(locations, usageType, dataContext, null);
+        ProgressManager.getInstance().run(new Task.Backgroundable(project, getProgressTitle(psiFile, offset), true) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                List<Location> locations = null;
+                try {
+                    CompletableFuture<List<Location>> locationsFuture = getLocations(psiFile, document, editor, offset);
+
+                    if (isDoneNormally(locationsFuture)) {
+                        // textDocument/(declaration|implementation|references|typeDefinition) has been collected correctly
+                        locations = locationsFuture.getNow(null);
+                    }
+                } finally {
+                    final List<Location> resultLocations = locations != null ? locations : Collections.emptyList();
+                    DataContext dataContext = e.getDataContext();
+                    // Call "Find Usages" in popup mode.
+                    ApplicationManager.getApplication()
+                            .invokeLater(() ->
+                                    LSPUsagesManager.getInstance(project).findShowUsagesInPopup(resultLocations, usageType, dataContext, null)
+                            );
+                }
             }
-        }
+        });
     }
-
-    protected abstract CompletableFuture<List<Location>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset);
 
     @Override
     public final void update(@NotNull AnActionEvent e) {
@@ -112,7 +128,40 @@ public abstract class AbstractLSPGoToAction extends AnAction {
                 .hasAny(file.getVirtualFile(), ls -> canSupportFeature(ls.getClientFeatures(), file));
     }
 
-    protected abstract boolean canSupportFeature(@NotNull LSPClientFeatures clientFeatures, @NotNull PsiFile file);
+
+    /**
+     * Returns the progress title used by the task monitor which execute the LSP GoTo feature.
+     *
+     * @param psiFile the Psi file.
+     * @param offset  the offset.
+     * @return the progress title used by the task monitor which execute the LSP GoTo feature.
+     */
+    protected abstract @NlsContexts.ProgressTitle @NotNull String getProgressTitle(@NotNull PsiFile psiFile,
+                                                                                   int offset);
+
+    /**
+     * Returns the LSP {@link Location} list result of the execution of the LSP GoTo feature.
+     *
+     * @param psiFile  the Psi file.
+     * @param document the document.
+     * @param editor   the editor.
+     * @param offset   the offset.
+     * @return the LSP {@link Location} list result of the execution of the LSP GoTo feature.
+     */
+    protected abstract CompletableFuture<List<Location>> getLocations(@NotNull PsiFile psiFile,
+                                                                      @NotNull Document document,
+                                                                      @NotNull Editor editor,
+                                                                      int offset);
+
+    /**
+     * Returns true if the action is supported by the client features of the language server and false otherwise.
+     *
+     * @param clientFeatures the client features.
+     * @param file           the Psi file.
+     * @return true if the action is supported by the client features of the language server and false otherwise.
+     */
+    protected abstract boolean canSupportFeature(@NotNull LSPClientFeatures clientFeatures,
+                                                 @NotNull PsiFile file);
 
     @Override
     public final @NotNull ActionUpdateThread getActionUpdateThread() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
@@ -43,7 +44,10 @@ public class LSPGoToDeclarationAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<Location>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
+    protected CompletableFuture<List<Location>> getLocations(@NotNull PsiFile psiFile,
+                                                             @NotNull Document document,
+                                                             @NotNull Editor editor,
+                                                             int offset) {
         LSPDeclarationSupport declarationSupport = LSPFileSupport.getSupport(psiFile).getDeclarationSupport();
         var params = new LSPDeclarationParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<Location>> declarationsFuture = declarationSupport.getDeclarations(params);
@@ -66,4 +70,9 @@ public class LSPGoToDeclarationAction extends AbstractLSPGoToAction {
         return clientFeatures.getDeclarationFeature().isDeclarationSupported(file);
     }
 
+    @Override
+    protected @NotNull String getProgressTitle(@NotNull PsiFile psiFile,
+                                               int offset) {
+        return LanguageServerBundle.message("lsp.goto.declaration.progress.title", psiFile.getName(), offset);
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
@@ -64,6 +65,12 @@ public class LSPGoToImplementationAction extends AbstractLSPGoToAction {
     @Override
     protected boolean canSupportFeature(@NotNull LSPClientFeatures clientFeatures, @NotNull PsiFile file) {
         return clientFeatures.getImplementationFeature().isImplementationSupported(file);
+    }
+
+    @Override
+    protected @NotNull String getProgressTitle(@NotNull PsiFile psiFile,
+                                               int offset) {
+        return LanguageServerBundle.message("lsp.goto.implementation.progress.title", psiFile.getName(), offset);
     }
 
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
@@ -66,4 +67,9 @@ public class LSPGoToReferenceAction extends AbstractLSPGoToAction {
         return clientFeatures.getReferencesFeature().isReferencesSupported(file);
     }
 
+    @Override
+    protected @NotNull String getProgressTitle(@NotNull PsiFile psiFile,
+                                               int offset) {
+        return LanguageServerBundle.message("lsp.goto.reference.progress.title", psiFile.getName(), offset);
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
@@ -66,4 +67,9 @@ public class LSPGoToTypeDefinitionAction extends AbstractLSPGoToAction {
         return clientFeatures.getTypeDefinitionFeature().isTypeDefinitionSupported(file);
     }
 
+    @Override
+    protected @NotNull String getProgressTitle(@NotNull PsiFile psiFile,
+                                               int offset) {
+        return LanguageServerBundle.message("lsp.goto.typeDefinition.progress.title", psiFile.getName(), offset);
+    }
 }

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -205,3 +205,9 @@ lsp.semantic.tokens.inspector.show.text.attributes=Show text attributes
 lsp.semantic.tokens.inspector.show.token.type=Show token type
 lsp.semantic.tokens.inspector.show.token.modifiers=Show token modifiers
 lsp.semantic.tokens.color.settings.name=Language Server
+
+# LSP GoTo actions
+lsp.goto.declaration.progress.title=Find declaration(s) of ''{0}'' at ''{1}''
+lsp.goto.implementation.progress.title=Find implementation(s) of ''{0}'' at ''{1}''
+lsp.goto.reference.progress.title=Find type reference(s) of ''{0}'' at ''{1}''
+lsp.goto.typeDefinition.progress.title=Find type definition(s) of ''{0}'' at ''{1}''


### PR DESCRIPTION
fix: IJ can freeze with execution of LSP References action

Fixes #634

The PR execute the LSP request (ex : textDocument/references) in an background task which avoids freezing IJ when request is called. Thebackground task should be cancellable.