### PR TITLE
fix: Show progress messages in detail

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/progress/LSPProgressManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/progress/LSPProgressManager.java
@@ -139,7 +139,7 @@ public class LSPProgressManager implements Disposable {
                                          @Nullable Integer percentage,
                                          @NotNull ProgressIndicator progressIndicator) {
         if (message != null && !message.isBlank()) {
-            progressIndicator.setText(message);
+            progressIndicator.setText2(message);
         }
         if (percentage != null) {
             progressIndicator.setFraction(percentage.doubleValue() / 100);


### PR DESCRIPTION
Hello. When I use `$/progress`, the detailed message is displayed on the front.
<img width="924" alt="スクリーンショット 2024-12-01 9 23 13" src="https://github.com/user-attachments/assets/92307386-b80f-4f1b-b2d5-5216a01abb32">

The detailed message is displayed as `text2` in the [IntelliJ ProgressIndicator API](https://github.com/JetBrains/intellij-community/blob/56c38a555ee36467a9ac171f074d4d15d89a83a4/platform/core-api/src/com/intellij/openapi/progress/ProgressIndicator.java#L149).
The LSP title and message seem to correspond to the following:
| LSP | IntelliJ API |
|--------|--------|
| title | ProgressIndicator.text() |
| message | ProgressIndicator.text2() | 

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workDoneProgress

