### PR TITLE
fix: Allow requesting scalar values in workspace/configuration

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.client;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.Disposable;
@@ -250,15 +251,7 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     }
 
     protected static Object findSettings(String[] sections, JsonObject jsonObject) {
-        JsonObject current = jsonObject;
-        for (String section : sections) {
-            Object result = current.get(section);
-            if (!(result instanceof JsonObject json)) {
-                return null;
-            }
-            current = json;
-        }
-        return current;
+        return SettingsHelper.findSettings(sections, jsonObject);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/SettingsHelper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/SettingsHelper.java
@@ -1,18 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
 package com.redhat.devtools.lsp4ij.client;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+/**
+ * Helpers for extracting nested settings from json
+ */
 public class SettingsHelper {
 
     private SettingsHelper() {
     }
 
-    public static JsonElement findSettings(String[] sections, JsonObject jsonObject) {
-        JsonElement current = jsonObject;
+    /**
+     * Extract nested settings from json.
+     * @param sections path to the json element to retrieve
+     * @param parent Json to look for settings in
+     * @return the settings retrieved in the specified section and null if the section was not found.
+     */
+    public static @Nullable JsonElement findSettings(@NotNull String[] sections, @Nullable JsonObject parent) {
+        JsonElement current = parent;
         for (String section : sections) {
-            if (current instanceof JsonObject object) {
-                current = object.get(section);
+            if (current instanceof JsonObject currentObject) {
+                current = currentObject.get(section);
                 if (current == null) {
                     return null;
                 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/SettingsHelper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/SettingsHelper.java
@@ -1,0 +1,23 @@
+package com.redhat.devtools.lsp4ij.client;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class SettingsHelper {
+
+    private SettingsHelper() {
+    }
+
+    public static JsonElement findSettings(String[] sections, JsonObject jsonObject) {
+        JsonElement current = jsonObject;
+        for (String section : sections) {
+            if (current instanceof JsonObject object) {
+                current = object.get(section);
+                if (current == null) {
+                    return null;
+                }
+            }
+        }
+        return current;
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/client/SettingsHelperTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/client/SettingsHelperTest.java
@@ -1,0 +1,73 @@
+package com.redhat.devtools.lsp4ij.client;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.io.StringReader;
+
+public class SettingsHelperTest extends BasePlatformTestCase {
+    // language=json
+    private final String testJson = """
+            {
+                "mylsp": {
+                    "myscalarsetting": "value",
+                    "myobjectsettings": {
+                        "subsettingA": 1,
+                        "subsettingB": 2
+                    }
+                }
+            }
+            """;
+
+    public void testGetSettingsPrimitiveValue() {
+        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
+        String[] requestedPath = new String[]{"mylsp", "myscalarsetting"};
+
+        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
+
+        assertNotNull(result);
+        assertTrue(result.isJsonPrimitive());
+        assertEquals("value", result.getAsString());
+    }
+
+    public void testGetSettingsObjectValue() {
+        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
+        String[] requestedPath = new String[]{"mylsp", "myobjectsettings"};
+
+        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
+
+        assertNotNull(result);
+        assertTrue(result.isJsonObject());
+        assertEquals(1, result.getAsJsonObject().get("subsettingA").getAsInt());
+        assertEquals(2, result.getAsJsonObject().get("subsettingB").getAsInt());
+    }
+
+    public void testGetSettingsNonExistingValue() {
+        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
+        String[] requestedPath = new String[]{"mylsp", "nonexistant"};
+
+        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
+
+        assertNull(result);
+    }
+
+    public void testGetSettingsEmptyJson() {
+        JsonObject jsonObject = JsonParser.parseReader(new StringReader("{}")).getAsJsonObject();
+        String[] requestedPath = new String[]{"mylsp", "myobjectsettings"};
+
+        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
+
+        assertNull(result);
+    }
+
+    public void testGetSettingsIdentityOnEmptySections() {
+        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
+        String[] requestedPath = new String[0];
+
+        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
+
+        assertEquals(jsonObject, result);
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/client/SettingsHelperTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/client/SettingsHelperTest.java
@@ -1,12 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
 package com.redhat.devtools.lsp4ij.client;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.StringReader;
 
+/**
+ * Tests for LSP {@link SettingsHelper}.
+ */
 public class SettingsHelperTest extends BasePlatformTestCase {
     // language=json
     private final String testJson = """
@@ -21,53 +39,50 @@ public class SettingsHelperTest extends BasePlatformTestCase {
             }
             """;
 
-    public void testGetSettingsPrimitiveValue() {
-        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
-        String[] requestedPath = new String[]{"mylsp", "myscalarsetting"};
+    private static void assertFindSettings(@NotNull String json, @NotNull String[] sections, @Nullable String expectedJsonText) {
+        JsonObject jsonObject = JsonParser.parseReader(new StringReader(json)).getAsJsonObject();
+        JsonElement expectedJson = expectedJsonText == null ? null : JsonParser.parseReader(new StringReader(expectedJsonText));
 
-        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
+        JsonElement result = SettingsHelper.findSettings(sections, jsonObject);
 
-        assertNotNull(result);
-        assertTrue(result.isJsonPrimitive());
-        assertEquals("value", result.getAsString());
-    }
-
-    public void testGetSettingsObjectValue() {
-        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
-        String[] requestedPath = new String[]{"mylsp", "myobjectsettings"};
-
-        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
-
-        assertNotNull(result);
-        assertTrue(result.isJsonObject());
-        assertEquals(1, result.getAsJsonObject().get("subsettingA").getAsInt());
-        assertEquals(2, result.getAsJsonObject().get("subsettingB").getAsInt());
-    }
-
-    public void testGetSettingsNonExistingValue() {
-        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
-        String[] requestedPath = new String[]{"mylsp", "nonexistant"};
-
-        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
-
-        assertNull(result);
-    }
-
-    public void testGetSettingsEmptyJson() {
-        JsonObject jsonObject = JsonParser.parseReader(new StringReader("{}")).getAsJsonObject();
-        String[] requestedPath = new String[]{"mylsp", "myobjectsettings"};
-
-        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
-
-        assertNull(result);
+        assertEquals(result, expectedJson);
     }
 
     public void testGetSettingsIdentityOnEmptySections() {
-        JsonObject jsonObject = JsonParser.parseReader(new StringReader(testJson)).getAsJsonObject();
         String[] requestedPath = new String[0];
+        assertFindSettings(testJson, requestedPath, testJson);
+    }
 
-        JsonElement result = SettingsHelper.findSettings(requestedPath, jsonObject);
+    public void testGetSettingsObjectValue() {
+        String[] requestedPath = new String[]{"mylsp"};
+        assertFindSettings(testJson, requestedPath, """
+                {
+                    "myscalarsetting": "value",
+                    "myobjectsettings": {
+                        "subsettingA": 1,
+                        "subsettingB": 2
+                    }
+                }
+                """);
+    }
 
-        assertEquals(jsonObject, result);
+    public void testGetSettingsPrimitiveValue() {
+        String[] requestedPath = new String[]{"mylsp", "myscalarsetting"};
+        assertFindSettings(testJson, requestedPath, "\"value\"");
+    }
+
+    public void testGetSettingsDeepPrimitiveValue() {
+        String[] requestedPath = new String[]{"mylsp", "myobjectsettings", "subsettingA"};
+        assertFindSettings(testJson, requestedPath, "1");
+    }
+
+    public void testGetSettingsNonExistingValue() {
+        String[] requestedPath = new String[]{"mylsp", "nonexistant"};
+        assertFindSettings(testJson, requestedPath, null);
+    }
+
+    public void testGetSettingsEmptyJson() {
+        String[] requestedPath = new String[]{"mylsp", "myobjectsettings", "subsettingA"};
+        assertFindSettings("{}", requestedPath, null);
     }
 }


### PR DESCRIPTION
This is my attempt to fix #648 

My knowledge about LSP and its different language servers is very limited. Atleast for the faulty request shown in the issue and the configuration listed there this will now return the correct values.