### PR TITLE
fix: Fixed an issue with the JSON text editors caused by them being in scroll panes

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
@@ -251,14 +251,12 @@ public class LanguageServerPanel {
 
     private void createConfigurationField(FormBuilder builder) {
         configurationWidget = new LanguageServerConfigurationWidget(project);
-        JBScrollPane scrollPane = new JBScrollPane(configurationWidget);
-        builder.addLabeledComponent(LanguageServerBundle.message("language.server.configuration"), scrollPane, true);
+        builder.addLabeledComponentFillVertically(LanguageServerBundle.message("language.server.configuration"), configurationWidget);
     }
 
     private void createInitializationOptionsTabField(FormBuilder builder) {
         initializationOptionsWidget = new LanguageServerInitializationOptionsWidget(project);
-        JBScrollPane scrollPane = new JBScrollPane(initializationOptionsWidget);
-        builder.addLabeledComponent(LanguageServerBundle.message("language.server.initializationOptions"), scrollPane, true);
+        builder.addLabeledComponentFillVertically(LanguageServerBundle.message("language.server.initializationOptions"), initializationOptionsWidget);
     }
 
     public JBTextField getServerName() {


### PR DESCRIPTION
Those components have their own scrolling, and the nested scrolling mechanisms were causing issues with keyboard navigation, e.g., page up/down, etc., and other features such a Find (Ctrl+F). Without the surrounding scroll panes, it was also important that they be added so that they fill their available space vertically.