### PR TITLE
feat: Omit word completions (by default) when there are completions from the language server (issue 638)

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -246,7 +246,7 @@
                 id="LSPCompletionContributor"
                 language="any"
                 implementationClass="com.redhat.devtools.lsp4ij.features.completion.LSPCompletionContributor"
-                order="first"/>
+                order="first, before wordCompletion"/>
 
         <!-- LSP textDocument/definition request support -->
         <gotoDeclarationHandler


### PR DESCRIPTION
This is a reissue of PR #639 which ran into issues with rebase/merge against main. The same comments in that PR apply here. The only differences are additional comments added to describe behavior in relatively recent vs. older IDE version and to be more clear about what's happening when `result.stopHere()` is called.