### PR TITLE
fix: register ProjectIndexingActivityHistoryListener on appFrameCreated

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/indexing/ProjectIndexingAppLifecycleListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/indexing/ProjectIndexingAppLifecycleListener.java
@@ -12,6 +12,9 @@ package com.redhat.devtools.lsp4ij.client.indexing;
 
 import com.intellij.ide.AppLifecycleListener;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 /**
  * <p>The proxy that implements ProjectIndexingActivityHistoryListener is registered via topic subscribe
@@ -32,7 +35,8 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public class ProjectIndexingAppLifecycleListener implements AppLifecycleListener {
 
-    ProjectIndexingAppLifecycleListener() {
+    @Override
+    public  void appFrameCreated(@NotNull List<String> commandLineArgs) {
         ProjectIndexingDumbAndScanningStrategy.getInstance();
     }
 }


### PR DESCRIPTION
This PR tries to fix https://github.com/redhat-developer/lsp4ij/issues/660 (I cannot reproduce it).

The same error has been reported here https://github.com/EmmyLua/Intellij-EmmyLua2/issues/11

 * 