### PR TITLE
feat: Made the LSP `typeDeclarationProvider` specify `order="last"` to help ensure that it will be invoked after other implementations

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -404,7 +404,8 @@
 
         <!-- LSP textDocument/typeDefinition support -->
         <typeDeclarationProvider
-                implementation="com.redhat.devtools.lsp4ij.features.workspaceSymbol.LSPWorkspaceTypeDeclarationProvider"/>
+                implementation="com.redhat.devtools.lsp4ij.features.workspaceSymbol.LSPWorkspaceTypeDeclarationProvider"
+                order="last"/>
 
         <!-- LSP textDocument/rename request support -->
         <renameHandler


### PR DESCRIPTION
Testing with a local pre-release build of LSP4IJ, I noticed that it was interfering with the same EP implementation in another language, and debugging a bit, I could see that LSP4IJ's was slotted in before that other one. By explicitly specifying `order="last"`, it is guaranteed to execute after all other EPs that don't also register themselves as `last` (at which point it's just about the plugin loading order).