### PR TITLE
feat: Allow **Ctrl+Space** to toggle whether or not word completions are displayed

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
@@ -140,12 +140,13 @@ public class LSPCompletionContributor extends CompletionContributor {
             }
         }
 
-        // If completions were added from LSP and this is auto-completion or the explicit completion trigger was typed
-        // only once, add completions from other all other contributors except for the word completion contributor.
+        // If completions were added from LSP and this is auto-completion or the explicit completion was triggered an
+        // odd number of times (acts as a toggle), add completions from other all other contributors except for the
+        // word completion contributor.
         // Note that the word completion contributor only really kicks in when LSP completions are added in the context
         // of a TextMate file (see TextMateCompletionContributor), but that's going to be very common for LSP usage
         // since it's often adding (pseudo-)language support when not already present in the host JetBrains IDE.
-        if ((size > 0) && (parameters.getInvocationCount() < 2)) {
+        if ((size > 0) && ((parameters.getInvocationCount() == 0) || ((parameters.getInvocationCount() % 2) > 0))) {
             // Don't allow automatic execution of the remaining completion contributors; we'll execute them ourselves below
             result.stopHere();
 


### PR DESCRIPTION
Minor enhancement to the earlier LSP code completion enhancement such that word completions are not shown on auto-completion or odd completion trigger counts. This means that pressing **Ctrl+Space** repeatedly will now toggle word completions on and off but they won't be shown when there are LSP-based completions on auto-complete or initial explicit completion trigger.

Here's an example of the behavior with this change where you can see that there are not word completions by default, but pressing **Ctrl+Space** will toggle them on and off:

![LSP_Word_Completions_Toggle](https://github.com/user-attachments/assets/26ff7723-d580-4c70-a3b9-9fa859c4a669)
