### PR TITLE
fix: Restoring VFS refresh of bundled JSON schema file

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileSystemProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileSystemProvider.java
@@ -42,7 +42,7 @@ abstract class AbstractLSPJsonSchemaFileSystemProvider extends AbstractLSPJsonSc
             jsonSchemaFile = jsonSchemaFileUrl != null ? VirtualFileManager.getInstance().findFileByUrl(jsonSchemaFileUrl) : null;
             // Make sure that the IDE is using the absolute latest version of the JSON schema
             if (jsonSchemaFile != null) {
-                jsonSchemaFile.refresh(true, false);
+                jsonSchemaFile.refresh(true, false, () -> jsonSchemaFile.refresh(false, false));
             }
         }
         return jsonSchemaFile;


### PR DESCRIPTION
Unfortunately I can't use `reloadPsi()` for two reasons:
1. There's not guaranteed to be a non-null `Project` when the JSON schema is loaded because it's loaded via a project-independent extension point.
2. `reloadPsi()` uses `FileManagerImpl` which is annotated as `@ApiStatus.Internal` and therefore almost certainly won't be accepted by JetBrains in a new plugin version submission. That likely needs to change to do something different, perhaps just what I'm doing here with a two-phase VFS refresh.
