### PR TITLE
fix: Addressed issues with LSP Find Usages implementation (issue 708)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Here are some projects that use LSP4IJ:
  * [Intellij Gleam](https://github.com/themartdev/intellij-gleam)
  * [Liberty Tools for IntelliJ](https://github.com/OpenLiberty/liberty-tools-intellij)
  * [Vespa Schema Language Support](https://github.com/vespa-engine/vespa/tree/master/integration/schema-language-server/clients/intellij)
+ * [Jimmer DTO LSP](https://github.com/Enaium/jimmer-dto-lsp)
 
 ## Requirements
 

--- a/docs/LSPApi.md
+++ b/docs/LSPApi.md
@@ -53,15 +53,18 @@ public class MyLanguageServerFactory implements LanguageServerFactory {
 
 | API                                                          | Description                                                                                                                        | Default Behaviour |
 |--------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| boolean isEnabled(VirtualFile)                               | Returns `true` if the language server is enabled for the given file and `false` otherwise.                                         | `true`            |
+| boolean isEnabled(VirtualFile)                               | Returns `true` if the language server is enabled for the given file and `false` otherwise.                                         | `true`            |
+| URI getFileUri(VirtualFile file)                             | Returns the file Uri from the given virtual file and null otherwise (to use default `FileUriSupport.DEFAULT.getFileUri`).          | `null`            |
+| VirtualFile findFileByUri(String fileUri)                    | Returns the virtual file found by the given file Uri and null otherwise (to use default `FileUriSupport.DEFAULT.findFileByUri`).   | `null`            |
+| boolean isCaseSensitive(PsiFile file)                        | Returns `true` if the language grammar for the given file is case-sensitive and `false` otherwise.                                 | `false`           | 
+| boolean keepServerAlive()                                    | Returns `true` if the server is kept alive even if all files associated with the language server are closed and `false` otherwise. | `false`           |
+| boolean canStopServerByUser()                                | Returns `true` if the user can stop the language server in LSP console from the context menu and `false` otherwise.                | `true`            |
 | Project getProject()                                         | Returns the project.                                                                                                               |                   |
 | LanguageServerDefinition getServerDefinition()               | Returns the language server definition.                                                                                            |                   |
 | boolean isServerDefinition(@NotNull String languageServerId) | Returns `true` if the given language server id matches the server definition and `false` otherwise.                                |                   |
 | ServerStatus getServerStatus()                               | Returns the server status.                                                                                                         |                   |
 | LanguageServer getLanguageServer()                           | Returns the LSP4J language server.                                                                                                 |                   |
-| boolean keepServerAlive()                                    | Returns `true` if the server is kept alive even if all files associated with the language server are closed and `false` otherwise. | `false`           |
-| boolean canStopServerByUser()                                | Returns `true` if the user can stop the language server in LSP console from the context menu and `false` otherwise.                | `true`            |
-| boolean isEnabled(VirtualFile)                               | Returns `true` if the language server is enabled for the given file and `false` otherwise.                                         | `true`            |
-| boolean isCaseSensitive(PsiFile file)                        | Returns `true` if the language grammar for the given file is case-sensitive and `false` otherwise.                                 | `false`           | 
 
 ```java
 package my.language.server;

--- a/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
@@ -22,7 +22,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -46,12 +45,12 @@ public class DocumentContentSynchronizer implements DocumentListener {
     @NotNull final CompletableFuture<Void> didOpenFuture;
 
     public DocumentContentSynchronizer(@NotNull LanguageServerWrapper languageServerWrapper,
-                                       @NotNull URI fileUri,
+                                       @NotNull String fileUri,
                                        @NotNull VirtualFile file,
                                        @NotNull Document document,
                                        @Nullable TextDocumentSyncKind syncKind) {
         this.languageServerWrapper = languageServerWrapper;
-        this.fileUri = fileUri.toASCIIString();
+        this.fileUri = fileUri;
         this.syncKind = syncKind != null ? syncKind : TextDocumentSyncKind.Full;
 
         this.document = document;

--- a/src/main/java/com/redhat/devtools/lsp4ij/ServerMessageHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ServerMessageHandler.java
@@ -26,12 +26,14 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.JBPopupListener;
 import com.intellij.openapi.ui.popup.LightweightWindowEvent;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.console.LSPConsoleToolWindowPanel;
 import com.redhat.devtools.lsp4ij.features.documentation.MarkdownConverter;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.eclipse.lsp4j.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.concurrent.CompletableFuture;
@@ -157,6 +159,7 @@ public class ServerMessageHandler {
     }
 
     public static CompletableFuture<ShowDocumentResult> showDocument(@NotNull ShowDocumentParams params,
+                                                                     @Nullable FileUriSupport fileUriSupport,
                                                                      @NotNull Project project) {
         String uri = params.getUri();
         if (StringUtils.isEmpty(uri)) {
@@ -180,7 +183,7 @@ public class ServerMessageHandler {
         CompletableFuture<ShowDocumentResult> future = new CompletableFuture<>();
         ApplicationManager.getApplication()
                 .executeOnPooledThread(() -> {
-                    if (LSPIJUtils.openInEditor(uri, position, focusEditor, project)) {
+                    if (LSPIJUtils.openInEditor(uri, position, focusEditor, false, fileUriSupport, project)) {
                         future.complete(SHOW_DOCUMENT_RESULT_WITH_SUCCESS);
                     }
                     future.complete(SHOW_DOCUMENT_RESULT_WITH_FAILURE);

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/IndexAwareLanguageClient.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/IndexAwareLanguageClient.java
@@ -17,16 +17,14 @@ import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 public class IndexAwareLanguageClient extends LanguageClientImpl {
-    private static final Logger LOGGER = LoggerFactory.getLogger(IndexAwareLanguageClient.class);
 
     public IndexAwareLanguageClient(Project project) {
         super(project);
@@ -68,7 +66,7 @@ public class IndexAwareLanguageClient extends LanguageClientImpl {
      * @return the file path to display in the progress bar.
      */
     protected String getFilePath(String fileUri) {
-        VirtualFile file = LSPIJUtils.findResourceFor(fileUri);
+        VirtualFile file = FileUriSupport.findFileByUri(fileUri, getClientFeatures());
         if (file != null) {
             Module module = LSPIJUtils.getModule(file, getProject());
             if (module != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.client;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.Disposable;
@@ -21,6 +20,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.redhat.devtools.lsp4ij.*;
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.diagnostics.LSPDiagnosticHandler;
 import com.redhat.devtools.lsp4ij.features.progress.LSPProgressManager;
 import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager;
@@ -79,6 +79,10 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
         return wrapper.getServerDefinition();
     }
 
+    public LSPClientFeatures getClientFeatures() {
+        return wrapper.getClientFeatures();
+    }
+
     @Override
     public void telemetryEvent(Object object) {
         // TODO
@@ -96,7 +100,7 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
 
     @Override
     public CompletableFuture<ShowDocumentResult> showDocument(ShowDocumentParams params) {
-        return ServerMessageHandler.showDocument(params, getProject());
+        return ServerMessageHandler.showDocument(params, getClientFeatures(), getProject());
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/FileUriSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/FileUriSupport.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and declaration
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.client.features;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+
+/**
+ * File Uri support.
+ */
+public interface FileUriSupport {
+
+    public static final FileUriSupport DEFAULT = new FileUriSupport() {
+
+        @Override
+        public @Nullable URI getFileUri(@NotNull VirtualFile file) {
+            return LSPIJUtils.toUri(file);
+        }
+
+        @Override
+        public @Nullable VirtualFile findFileByUri(@NotNull String fileUri) {
+            return LSPIJUtils.findResourceFor(fileUri);
+        }
+    };
+
+    /**
+     * Returns the file Uri from the given virtual file and null otherwise.
+     * @param file the virtual file.
+     * @return the file Uri from the given virtual file and null otherwise.
+     */
+    @Nullable
+    URI getFileUri(@NotNull VirtualFile file);
+
+    /**
+     * Returns the virtual file found by the given file Uri and null otherwise.
+     * @param fileUri the file Uri.
+     * @return the virtual file found by the given file Uri and null otherwise.
+     */
+    @Nullable
+    VirtualFile findFileByUri(@NotNull String fileUri);
+
+    @Nullable
+    public static URI getFileUri(@NotNull VirtualFile file,
+                                 @Nullable FileUriSupport fileUriSupport) {
+        URI fileUri = fileUriSupport != null ? fileUriSupport.getFileUri(file) : null;
+        if (fileUri != null) {
+            return fileUri;
+        }
+        return DEFAULT.getFileUri(file);
+    }
+
+    @Nullable
+    public static VirtualFile findFileByUri(@NotNull String fileUri,
+                                            @Nullable FileUriSupport fileUriSupport) {
+        VirtualFile file = fileUriSupport != null ? fileUriSupport.findFileByUri(fileUri) : null;
+        if (file != null) {
+            return file;
+        }
+        return DEFAULT.findFileByUri(fileUri);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
@@ -26,11 +26,13 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.net.URI;
+
 /**
  * LSP  client features.
  */
 @ApiStatus.Experimental
-public class LSPClientFeatures implements Disposable {
+public class LSPClientFeatures implements Disposable, FileUriSupport {
 
     private LanguageServerWrapper serverWrapper;
 
@@ -85,6 +87,71 @@ public class LSPClientFeatures implements Disposable {
     private LSPWorkspaceSymbolFeature workspaceSymbolFeature;
 
     /**
+     * Returns true if the language server is enabled for the given file and false otherwise. Default to true
+     *
+     * @param file the file for test
+     * @return true if the language server is enabled for the input and false otherwise. Default to true
+     */
+    public boolean isEnabled(@NotNull VirtualFile file) {
+        return true;
+    }
+
+    /**
+     * Overrides this method if you need to generate custom URI.
+     *
+     * @param file the virtual file.
+     *
+     * @return the file Uri and null otherwise.
+     */
+    @Override
+    public @Nullable URI getFileUri(@NotNull VirtualFile file) {
+        return null;
+    }
+
+    /**
+     * Overrides this method if you need to support custom file uri.
+     *
+     * @param fileUri the file Uri.
+     * @return the virtual file and null otherwise.
+     */
+    @Override
+    public @Nullable VirtualFile findFileByUri(@NotNull String fileUri) {
+        return null;
+    }
+
+    /**
+     * Determines whether or not the language grammar for the file is case-sensitive.
+     *
+     * @param file the file
+     * @return true if the file's language grammar is case-sensitive; otherwise false
+     */
+    public boolean isCaseSensitive(@NotNull PsiFile file) {
+        // Default to case-insensitive
+        return false;
+    }
+
+    /**
+     * Returns true if the server is kept alive even if all files associated with the language server are closed and false otherwise.
+     *
+     * @return true if the server is kept alive even if all files associated with the language server are closed and false otherwise.
+     */
+    public boolean keepServerAlive() {
+        return false;
+    }
+
+    /**
+     * Returns true if the user can stop the language server in LSP console from the context menu and false otherwise.
+     * <p>
+     * By default, user can stop the server.
+     * </p>
+     *
+     * @return true if the user can stop the language server in LSP console from the context menu and false otherwise.
+     */
+    public boolean canStopServerByUser() {
+        return true;
+    }
+
+    /**
      * Returns the project.
      *
      * @return the project.
@@ -132,27 +199,6 @@ public class LSPClientFeatures implements Disposable {
     @Nullable
     public final LanguageServer getLanguageServer() {
         return getServerWrapper().getLanguageServer();
-    }
-
-    /**
-     * Returns true if the server is kept alive even if all files associated with the language server are closed and false otherwise.
-     *
-     * @return true if the server is kept alive even if all files associated with the language server are closed and false otherwise.
-     */
-    public boolean keepServerAlive() {
-        return false;
-    }
-
-    /**
-     * Returns true if the user can stop the language server in LSP console from the context menu and false otherwise.
-     * <p>
-     * By default, user can stop the server.
-     * </p>
-     *
-     * @return true if the user can stop the language server in LSP console from the context menu and false otherwise.
-     */
-    public boolean canStopServerByUser() {
-        return true;
     }
 
     /**
@@ -953,27 +999,6 @@ public class LSPClientFeatures implements Disposable {
         workspaceSymbolFeature.setClientFeatures(this);
         this.workspaceSymbolFeature = workspaceSymbolFeature;
         return this;
-    }
-
-    /**
-     * Returns true if the language server is enabled for the given file and false otherwise. Default to true
-     *
-     * @param file the file for test
-     * @return true if the language server is enabled for the input and false otherwise. Default to true
-     */
-    public boolean isEnabled(@NotNull VirtualFile file) {
-        return true;
-    }
-
-    /**
-     * Determines whether or not the language grammar for the file is case-sensitive.
-     *
-     * @param file the file
-     * @return true if the file's language grammar is case-sensitive; otherwise false
-     */
-    public boolean isCaseSensitive(@NotNull PsiFile file) {
-        // Default to case-insensitive
-        return false;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/commands/editor/ShowReferencesAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/commands/editor/ShowReferencesAction.java
@@ -16,10 +16,13 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.commands.CommandExecutor;
 import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import com.redhat.devtools.lsp4ij.commands.LSPCommandAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
 import com.redhat.devtools.lsp4ij.usages.LSPUsagesManager;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 
@@ -79,14 +82,21 @@ public class ShowReferencesAction extends LSPCommandAction {
         if (array == null) {
             return;
         }
-        // Get LSP4J Location from the JSON locations array
-        final List<Location> locations = new ArrayList<>();
-        for (int i = 0; i < array.size(); i++) {
-            locations.add(JSONUtils.toModel(array.get(i), Location.class));
-        }
+
         DataContext dataContext = e.getDataContext();
+        LanguageServerItem languageServer = dataContext.getData(CommandExecutor.LSP_COMMAND_LANGUAGE_SERVER);
+
+        // Get LSP4J Location from the JSON locations array
+        final List<LocationData> locations = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            locations.add(new LocationData(JSONUtils.toModel(array.get(i), Location.class), languageServer));
+        }
+
         // Call "Find Usages" in popup mode.
-        LSPUsagesManager.getInstance(project).findShowUsagesInPopup(locations, LSPUsageType.References, dataContext, (MouseEvent) e.getInputEvent());
+        LSPUsagesManager.getInstance(project).findShowUsagesInPopup(locations,
+                LSPUsageType.References,
+                dataContext,
+                (MouseEvent) e.getInputEvent());
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPDocumentFeatureSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPDocumentFeatureSupport.java
@@ -13,7 +13,9 @@ package com.redhat.devtools.lsp4ij.features;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -81,5 +83,11 @@ public abstract class AbstractLSPDocumentFeatureSupport<Params, Result> extends 
                 .getLanguageServers(file.getVirtualFile(),
                         beforeStartingServerFilter,
                         afterStartingServerFilter);
+    }
+
+    protected static void updateTextDocumentUri(@NotNull TextDocumentIdentifier textDocument,
+                                                @NotNull PsiFile file,
+                                                @NotNull LanguageServerItem languageServer) {
+        textDocument.setUri(FileUriSupport.getFileUri(file.getVirtualFile(), languageServer.getClientFeatures()).toASCIIString());
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElementFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElementFactory.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Range;
@@ -50,8 +51,10 @@ public interface LSPPsiElementFactory<T extends LSPPsiElement> {
      * @return an instance of {@link LSPPsiElement} from the given LSP location and null otherwise.
      */
     @Nullable
-    public static LSPPsiElement toPsiElement(@NotNull Location location, @NotNull Project project) {
-        return toPsiElement(location, project, DEFAULT);
+    public static LSPPsiElement toPsiElement(@NotNull Location location,
+                                             @Nullable FileUriSupport fileUriSupport,
+                                             @NotNull Project project) {
+        return toPsiElement(location, fileUriSupport, project, DEFAULT);
     }
 
     /**
@@ -64,13 +67,14 @@ public interface LSPPsiElementFactory<T extends LSPPsiElement> {
      */
     @Nullable
     public static <T extends LSPPsiElement> T toPsiElement(@NotNull Location location,
+                                                           @Nullable FileUriSupport fileUriSupport,
                                                            @NotNull Project project,
                                                            @NotNull LSPPsiElementFactory<T> factory) {
         if (ApplicationManager.getApplication().isReadAccessAllowed()) {
-            return doToPsiElement(location.getUri(), location.getRange(), project, factory);
+            return doToPsiElement(location.getUri(), location.getRange(), fileUriSupport, project, factory);
         }
         return ReadAction.compute(() -> {
-            return doToPsiElement(location.getUri(), location.getRange(), project, factory);
+            return doToPsiElement(location.getUri(), location.getRange(), fileUriSupport, project, factory);
         });
     }
 
@@ -82,8 +86,9 @@ public interface LSPPsiElementFactory<T extends LSPPsiElement> {
      * @return an instance of {@link LSPPsiElement} from the given LSP location link and null otherwise.
      */
     public static LSPPsiElement toPsiElement(@NotNull LocationLink location,
+                                             @Nullable FileUriSupport fileUriSupport,
                                              @NotNull Project project) {
-        return toPsiElement(location, project, DEFAULT);
+        return toPsiElement(location, fileUriSupport, project, DEFAULT);
     }
 
     /**
@@ -96,25 +101,27 @@ public interface LSPPsiElementFactory<T extends LSPPsiElement> {
      */
     @Nullable
     public static <T extends LSPPsiElement> T toPsiElement(@NotNull LocationLink location,
+                                                           @Nullable FileUriSupport fileUriSupport,
                                                            @NotNull Project project,
                                                            @NotNull LSPPsiElementFactory<T> factory) {
         if (ApplicationManager.getApplication().isReadAccessAllowed()) {
-            return doToPsiElement(location.getTargetUri(), location.getTargetRange(), project, factory);
+            return doToPsiElement(location.getTargetUri(), location.getTargetRange(), fileUriSupport, project, factory);
         }
         return ReadAction.compute(() -> {
-            return doToPsiElement(location.getTargetUri(), location.getTargetRange(), project, factory);
+            return doToPsiElement(location.getTargetUri(), location.getTargetRange(), fileUriSupport, project, factory);
         });
     }
 
     @Nullable
     private static <T extends LSPPsiElement> T doToPsiElement(@Nullable String uri,
                                                               @Nullable Range range,
+                                                              @Nullable FileUriSupport fileUriSupport,
                                                               @NotNull Project project,
                                                               @NotNull LSPPsiElementFactory<T> factory) {
         if (uri == null || range == null) {
             return null;
         }
-        VirtualFile file = LSPIJUtils.findResourceFor(uri);
+        VirtualFile file = FileUriSupport.findFileByUri(uri, fileUriSupport);
         if (file == null) {
             return null;
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyIncomingCallsSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyIncomingCallsSupport.java
@@ -66,7 +66,7 @@ public class LSPCallHierarchyIncomingCallsSupport extends AbstractLSPDocumentFea
                     // Collect list of callHierarchy/incomingCalls future for each language servers
                     List<CompletableFuture<List<CallHierarchyItemData>>> callHierarchyPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getCallHierarchyIncomingCalls(params, languageServer, file, cancellationSupport))
+                            .map(languageServer -> getCallHierarchyIncomingCalls(params, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of callHierarchy/incomingCalls future in one future which return the list of call hierarchy items
@@ -76,7 +76,6 @@ public class LSPCallHierarchyIncomingCallsSupport extends AbstractLSPDocumentFea
 
     private static CompletableFuture<List<CallHierarchyItemData>> getCallHierarchyIncomingCalls(@NotNull CallHierarchyIncomingCallsParams params,
                                                                                                 @NotNull LanguageServerItem languageServer,
-                                                                                                @NotNull PsiFile file,
                                                                                                 @NotNull CancellationSupport cancellationSupport) {
 
         return cancellationSupport.execute(languageServer

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyOutgoingCallsSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyOutgoingCallsSupport.java
@@ -66,7 +66,7 @@ public class LSPCallHierarchyOutgoingCallsSupport extends AbstractLSPDocumentFea
                     // Collect list of callHierarchy/outgoingCalls future for each language servers
                     List<CompletableFuture<List<CallHierarchyItemData>>> callHierarchyPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getCallHierarchyOutgoingCalls(params, languageServer, file, cancellationSupport))
+                            .map(languageServer -> getCallHierarchyOutgoingCalls(params, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of callHierarchy/outgoingCalls future in one future which return the list of call hierarchy items
@@ -76,7 +76,6 @@ public class LSPCallHierarchyOutgoingCallsSupport extends AbstractLSPDocumentFea
 
     private static CompletableFuture<List<CallHierarchyItemData>> getCallHierarchyOutgoingCalls(@NotNull CallHierarchyOutgoingCallsParams params,
                                                                                                 @NotNull LanguageServerItem languageServer,
-                                                                                                @NotNull PsiFile file,
                                                                                                 @NotNull CancellationSupport cancellationSupport) {
 
         return cancellationSupport.execute(languageServer

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyTreeStructureBase.java
@@ -55,7 +55,11 @@ public abstract class LSPCallHierarchyTreeStructureBase extends LSPHierarchyTree
     }
 
     @Override
-    protected void buildRoot(@NotNull HierarchyNodeDescriptor descriptor, PsiFile psiFile, Document document, int offset, List<LSPHierarchyNodeDescriptor> descriptors) {
+    protected void buildRoot(@NotNull HierarchyNodeDescriptor descriptor,
+                             @NotNull PsiFile psiFile,
+                             @NotNull Document document,
+                             int offset,
+                             @NotNull List<LSPHierarchyNodeDescriptor> descriptors) {
         // Consume LSP 'textDocument/prepareCallHierarchy' request
         LSPPrepareCallHierarchySupport prepareCallHierarchySupport = LSPFileSupport.getSupport(psiFile).getPrepareCallHierarchySupport();
         var params = new LSPCallHierarchyPrepareParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
@@ -82,7 +86,10 @@ public abstract class LSPCallHierarchyTreeStructureBase extends LSPHierarchyTree
             if (items != null) {
                 for (var item : items) {
                     var callHierarchyItem = item.callHierarchyItem();
-                    PsiElement element = createPsiElement(callHierarchyItem.getUri(), callHierarchyItem.getRange(), callHierarchyItem.getName());
+                    PsiElement element = createPsiElement(callHierarchyItem.getUri(),
+                            callHierarchyItem.getRange(),
+                            callHierarchyItem.getName(),
+                            item.languageServer().getClientFeatures());
                     if (element != null) {
                         descriptors.add(createHierarchyNodeDescriptor(myProject, descriptor, element, callHierarchyItem));
                     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPPrepareCallHierarchySupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPPrepareCallHierarchySupport.java
@@ -86,6 +86,8 @@ public class LSPPrepareCallHierarchySupport extends AbstractLSPDocumentFeatureSu
                                                                                    @NotNull PsiFile file,
                                                                                    @NotNull CancellationSupport cancellationSupport) {
 
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .prepareCallHierarchy(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_PREPARE_CALL_HIERARCHY)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionCodeActionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionCodeActionSupport.java
@@ -78,7 +78,7 @@ public class LSPIntentionCodeActionSupport extends AbstractLSPDocumentFeatureSup
                     // Collect list of textDocument/codeAction future for each language servers
                     List<CompletableFuture<List<CodeActionData>>> codeActionPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getCodeActionsFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getCodeActionsFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/codeAction future in one future which return the list of code actions
@@ -87,8 +87,11 @@ public class LSPIntentionCodeActionSupport extends AbstractLSPDocumentFeatureSup
     }
 
     private static CompletableFuture<List<CodeActionData>> getCodeActionsFor(@NotNull CodeActionParams params,
+                                                                             @NotNull PsiFile file,
                                                                              @NotNull LanguageServerItem languageServer,
                                                                              @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .codeAction(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_CODE_ACTION)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
@@ -85,6 +85,8 @@ public class LSPCodeLensSupport extends AbstractLSPDocumentFeatureSupport<CodeLe
                                                                           @NotNull PsiFile file,
                                                                           @NotNull CancellationSupport cancellationSupport) {
 
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .codeLens(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_CODE_LENS)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorSupport.java
@@ -65,7 +65,7 @@ public class LSPColorSupport extends AbstractLSPDocumentFeatureSupport<DocumentC
                     // Collect list of textDocument/documentColor future for each language servers
                     List<CompletableFuture<List<ColorData>>> colorInformationPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getColorsFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getColorsFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/documentColor future in one future which return the list of color information
@@ -74,8 +74,12 @@ public class LSPColorSupport extends AbstractLSPDocumentFeatureSupport<DocumentC
     }
 
     private static CompletableFuture<List<ColorData>> getColorsFor(@NotNull DocumentColorParams params,
+                                                                   @NotNull PsiFile file,
                                                                    @NotNull LanguageServerItem languageServer,
                                                                    @NotNull CancellationSupport cancellationSupport) {
+
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .documentColor(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DOCUMENT_COLOR)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionSupport.java
@@ -85,6 +85,8 @@ public class LSPCompletionSupport extends AbstractLSPDocumentFeatureSupport<LSPC
                                                                              @NotNull LanguageServerItem languageServer,
                                                                              @NotNull CancellationSupport cancellationSupport) {
 
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         params.setContext(createCompletionContext(params, file, languageServer));
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
@@ -20,6 +20,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -44,13 +45,13 @@ public class LSPGoToDeclarationAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<Location>> getLocations(@NotNull PsiFile psiFile,
+    protected CompletableFuture<List<LocationData>> getLocations(@NotNull PsiFile psiFile,
                                                              @NotNull Document document,
                                                              @NotNull Editor editor,
                                                              int offset) {
         LSPDeclarationSupport declarationSupport = LSPFileSupport.getSupport(psiFile).getDeclarationSupport();
         var params = new LSPDeclarationParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
-        CompletableFuture<List<Location>> declarationsFuture = declarationSupport.getDeclarations(params);
+        CompletableFuture<List<LocationData>> declarationsFuture = declarationSupport.getDeclarations(params);
         try {
             waitUntilDone(declarationsFuture, psiFile);
         } catch (ProcessCanceledException ex) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticHandler.java
@@ -25,6 +25,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LSPVirtualFileData;
 import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
 import com.redhat.devtools.lsp4ij.client.CoalesceByKey;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.jetbrains.annotations.NotNull;
 
@@ -74,7 +75,7 @@ public class LSPDiagnosticHandler implements Consumer<PublishDiagnosticsParams> 
         if (project.isDisposed()) {
             return;
         }
-        VirtualFile file = LSPIJUtils.findResourceFor(params.getUri());
+        VirtualFile file = FileUriSupport.findFileByUri(params.getUri(), languageServerWrapper.getClientFeatures());
         if (file == null) {
             return;
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
@@ -26,6 +26,7 @@ import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.jetbrains.annotations.Nullable;
@@ -90,13 +91,14 @@ public class LSPDocumentLinkGotoDeclarationHandler implements GotoDeclarationHan
                         // The Ctrl+Click has been done in a LSP document link,try to open the document.
                         final String target = documentLink.getTarget();
                         if (target != null && !target.isEmpty()) {
-                            VirtualFile targetFile = LSPIJUtils.findResourceFor(target);
+                            FileUriSupport fileUriSupport = documentLinkData.languageServer().getClientFeatures();
+                            VirtualFile targetFile = FileUriSupport.findFileByUri(target, fileUriSupport );
                             if (targetFile == null) {
                                 // The LSP document link file doesn't exist, open a file dialog
                                 // which asks if user want to create the file.
                                 // At this step we cannot open a dialog directly, we need to open the dialog
                                 // with invoke later.
-                                LSPIJUtils.openInEditor(target, null, true, true, project);
+                                LSPIJUtils.openInEditor(target, null, true, true, fileUriSupport, project);
                                 // Return an empty response here.
                                 // If user accepts to create the file, the open is done after the creation of the file.
                                 return PsiElement.EMPTY_ARRAY;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkSupport.java
@@ -64,7 +64,7 @@ public class LSPDocumentLinkSupport extends AbstractLSPDocumentFeatureSupport<Do
                     // Collect list of textDocument/documentLink future for each language servers
                     List<CompletableFuture<List<DocumentLinkData>>> linkInformationPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getDocumentLinksFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getDocumentLinksFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/documentLink future in one future which return the list of document link
@@ -73,8 +73,11 @@ public class LSPDocumentLinkSupport extends AbstractLSPDocumentFeatureSupport<Do
     }
 
     private static CompletableFuture<List<DocumentLinkData>> getDocumentLinksFor(@NotNull DocumentLinkParams params,
+                                                                                 @NotNull PsiFile file,
                                                                                  @NotNull LanguageServerItem languageServer,
                                                                                  @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .documentLink(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DOCUMENT_LINK)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationLinkHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationLinkHandler.java
@@ -15,6 +15,7 @@ import com.intellij.platform.backend.documentation.DocumentationLinkHandler;
 import com.intellij.platform.backend.documentation.DocumentationTarget;
 import com.intellij.platform.backend.documentation.LinkResolveResult;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -33,7 +34,8 @@ public class LSPDocumentationLinkHandler implements DocumentationLinkHandler {
             ApplicationManager.getApplication()
                     .executeOnPooledThread(() -> {
                         var file = lspTarget.getFile();
-                        LSPIJUtils.openInEditor(url, null, true, true, file.getProject());
+                        FileUriSupport fileUriSupport = lspTarget.getLanguageServer().getClientFeatures();;
+                        LSPIJUtils.openInEditor(url, null, true, true, fileUriSupport, file.getProject());
                     });
             return LinkResolveResult.resolvedTarget(target);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTarget.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTarget.java
@@ -67,4 +67,8 @@ public class LSPDocumentationTarget implements DocumentationTarget {
     public PsiFile getFile() {
         return file;
     }
+
+    public LanguageServerItem getLanguageServer() {
+        return languageServer;
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPHoverSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPHoverSupport.java
@@ -70,7 +70,7 @@ public class LSPHoverSupport extends AbstractLSPDocumentFeatureSupport<HoverPara
                     // Collect list of textDocument/hover future for each language servers
                     List<CompletableFuture<HoverData>> hoverPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getHoverFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getHoverFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/hover future in one future which return the list of highlights
@@ -95,8 +95,11 @@ public class LSPHoverSupport extends AbstractLSPDocumentFeatureSupport<HoverPara
     }
 
     private static CompletableFuture<@Nullable HoverData> getHoverFor(@NotNull HoverParams params,
+                                                                      @NotNull PsiFile file,
                                                                       @NotNull LanguageServerItem languageServer,
                                                                       @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .hover(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_HOVER)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeSupport.java
@@ -65,7 +65,7 @@ public class LSPFoldingRangeSupport extends AbstractLSPDocumentFeatureSupport<Fo
                     // Collect list of textDocument/foldingRange future for each language servers
                     List<CompletableFuture<List<FoldingRange>>> foldingRangesPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getFoldingRangesFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getFoldingRangesFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/foldingRange future in one future which return the list of folding ranges
@@ -73,9 +73,12 @@ public class LSPFoldingRangeSupport extends AbstractLSPDocumentFeatureSupport<Fo
                 });
     }
 
-    private static CompletableFuture<List<FoldingRange>> getFoldingRangesFor(FoldingRangeRequestParams params,
-                                                                             LanguageServerItem languageServer,
-                                                                             CancellationSupport cancellationSupport) {
+    private static CompletableFuture<List<FoldingRange>> getFoldingRangesFor(@NotNull FoldingRangeRequestParams params,
+                                                                             @NotNull PsiFile file,
+                                                                             @NotNull LanguageServerItem languageServer,
+                                                                             @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .foldingRange(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_FOLDING_RANGE)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
@@ -19,6 +19,7 @@ import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
@@ -110,14 +111,14 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
 
                     if (isRangeFormatting && languageServer.isDocumentRangeFormattingSupported()) {
                         // Range formatting
-                        DocumentRangeFormattingParams lspParams = createDocumentRangeFormattingParams(params.tabSize(), params.insertSpaces(), params.textRange(), params.document());
+                        DocumentRangeFormattingParams lspParams = createDocumentRangeFormattingParams(params.tabSize(), params.insertSpaces(), params.textRange(), params.document(), languageServer);
                         return cancellationSupport.execute(languageServer
                                 .getTextDocumentService()
                                 .rangeFormatting(lspParams), languageServer, LSPRequestConstants.TEXT_DOCUMENT_RANGE_FORMATTING);
                     }
 
                     // Full document formatting
-                    DocumentFormattingParams lspParams = createDocumentFormattingParams(params.tabSize(), params.insertSpaces());
+                    DocumentFormattingParams lspParams = createDocumentFormattingParams(params.tabSize(), params.insertSpaces(), languageServer);
                     return cancellationSupport.execute(languageServer
                             .getTextDocumentService()
                             .formatting(lspParams), languageServer, LSPRequestConstants.TEXT_DOCUMENT_FORMATTING);
@@ -139,9 +140,11 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
         return languageServers.get(0);
     }
 
-    private @NotNull DocumentFormattingParams createDocumentFormattingParams(Integer tabSize, Boolean insertSpaces) {
+    private @NotNull DocumentFormattingParams createDocumentFormattingParams(@Nullable Integer tabSize,
+                                                                             @Nullable Boolean insertSpaces,
+                                                                             @NotNull LanguageServerItem languageServer) {
         DocumentFormattingParams params = new DocumentFormattingParams();
-        params.setTextDocument(LSPIJUtils.toTextDocumentIdentifier(getFile().getVirtualFile()));
+        params.setTextDocument(new TextDocumentIdentifier(FileUriSupport.getFileUri(getFile().getVirtualFile(), languageServer.getClientFeatures()).toASCIIString()));
         FormattingOptions options = new FormattingOptions();
         if (tabSize != null) {
             options.setTabSize(tabSize);
@@ -153,9 +156,12 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
         return params;
     }
 
-    private @NotNull DocumentRangeFormattingParams createDocumentRangeFormattingParams(Integer tabSize, Boolean insertSpaces, @NotNull TextRange textRange, Document document) {
+    private @NotNull DocumentRangeFormattingParams createDocumentRangeFormattingParams(@Nullable Integer tabSize,
+                                                                                       @Nullable Boolean insertSpaces,
+                                                                                       @NotNull TextRange textRange,
+                                                                                       @NotNull Document document, LanguageServerItem languageServer) {
         DocumentRangeFormattingParams params = new DocumentRangeFormattingParams();
-        params.setTextDocument(LSPIJUtils.toTextDocumentIdentifier(getFile().getVirtualFile()));
+        params.setTextDocument(new TextDocumentIdentifier(FileUriSupport.getFileUri(getFile().getVirtualFile(), languageServer.getClientFeatures()).toASCIIString()));
         FormattingOptions options = new FormattingOptions();
         if (tabSize != null) {
             options.setTabSize(tabSize);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyTreeStructureBase.java
@@ -21,6 +21,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.ArrayUtilRt;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import org.eclipse.lsp4j.Range;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -71,8 +72,9 @@ public abstract class LSPHierarchyTreeStructureBase<T> extends HierarchyTreeStru
     @Nullable
     protected PsiElement createPsiElement(@Nullable String uri,
                                           @Nullable Range range,
-                                          @NotNull String name) {
-        VirtualFile file = LSPIJUtils.findResourceFor(uri);
+                                          @NotNull String name,
+                                          @Nullable FileUriSupport fileUriSupport) {
+        VirtualFile file = FileUriSupport.findFileByUri(uri, fileUriSupport);
         if (file == null) {
             return null;
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightSupport.java
@@ -71,7 +71,7 @@ public class LSPHighlightSupport extends AbstractLSPDocumentFeatureSupport<Docum
                     // Collect list of textDocument/highlights future for each language servers
                     List<CompletableFuture<List<? extends org.eclipse.lsp4j.DocumentHighlight>>> highlightsPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getHighlightsFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getHighlightsFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/highlights future in one future which return the list of highlights
@@ -80,8 +80,11 @@ public class LSPHighlightSupport extends AbstractLSPDocumentFeatureSupport<Docum
     }
 
     private static CompletableFuture<List<? extends org.eclipse.lsp4j.DocumentHighlight>> getHighlightsFor(@NotNull DocumentHighlightParams params,
+                                                                                                           @NotNull PsiFile file,
                                                                                                            @NotNull LanguageServerItem languageServer,
                                                                                                            @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .documentHighlight(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DOCUMENT_HIGHLIGHT)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
@@ -20,7 +20,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
-import org.eclipse.lsp4j.Location;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +44,10 @@ public class LSPGoToImplementationAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<Location>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
+    protected CompletableFuture<List<LocationData>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
         LSPImplementationSupport implementationSupport = LSPFileSupport.getSupport(psiFile).getImplementationSupport();
         var params = new LSPImplementationParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
-        CompletableFuture<List<Location>> implementationsFuture = implementationSupport.getImplementations(params);
+        CompletableFuture<List<LocationData>> implementationsFuture = implementationSupport.getImplementations(params);
         try {
             waitUntilDone(implementationsFuture, psiFile);
         } catch (ProcessCanceledException ex) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsSupport.java
@@ -79,6 +79,8 @@ public class LSPInlayHintsSupport extends AbstractLSPDocumentFeatureSupport<Inla
                                                                            @NotNull PsiFile file,
                                                                            @NotNull LanguageServerItem languageServer,
                                                                            @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .inlayHint(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_INLAY_HINT)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
@@ -20,7 +20,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
-import org.eclipse.lsp4j.Location;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +44,10 @@ public class LSPGoToReferenceAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<Location>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
+    protected CompletableFuture<List<LocationData>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
         LSPReferenceSupport referenceSupport = LSPFileSupport.getSupport(psiFile).getReferenceSupport();
         var params = new LSPReferenceParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
-        CompletableFuture<List<Location>> referencesFuture = referenceSupport.getReferences(params);
+        CompletableFuture<List<LocationData>> referencesFuture = referenceSupport.getReferences(params);
         try {
             waitUntilDone(referencesFuture, psiFile);
         } catch (ProcessCanceledException ex) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPPrepareRenameSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPPrepareRenameSupport.java
@@ -78,7 +78,7 @@ public class LSPPrepareRenameSupport extends AbstractLSPDocumentFeatureSupport<L
                     for (var languageServer : languageServers) {
                         CompletableFuture<List<PrepareRenameResultData>> future = null;
                         if (languageServer.isPrepareRenameSupported()) {
-                            future = getPrepareRenamesFor(params, defaultPrepareRenameResult, languageServer, cancellationSupport);
+                            future = getPrepareRenamesFor(params, file, defaultPrepareRenameResult, languageServer, cancellationSupport);
                         } else {
                             var result = defaultPrepareRenameResult.apply(languageServer);
                             if (result != null) {
@@ -97,9 +97,12 @@ public class LSPPrepareRenameSupport extends AbstractLSPDocumentFeatureSupport<L
     }
 
     private static CompletableFuture<List<PrepareRenameResultData>> getPrepareRenamesFor(@NotNull PrepareRenameParams params,
+                                                                                         @NotNull PsiFile file,
                                                                                          @NotNull DefaultPrepareRenameResultProvider defaultPrepareRenameResultProvider,
                                                                                          @NotNull LanguageServerItem languageServer,
                                                                                          @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                                 .getTextDocumentService()
                                 .prepareRename(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_PREPARE_RENAME,

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPSelectionRangeSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPSelectionRangeSupport.java
@@ -71,7 +71,7 @@ public class LSPSelectionRangeSupport extends AbstractLSPDocumentFeatureSupport<
                     // Collect list of textDocument/selectionRange future for each language servers
                     List<CompletableFuture<List<SelectionRange>>> selectionRangesPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getSelectionRangesFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getSelectionRangesFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/selectionRange future in one future which return the list of selection ranges
@@ -79,9 +79,12 @@ public class LSPSelectionRangeSupport extends AbstractLSPDocumentFeatureSupport<
                 });
     }
 
-    private static CompletableFuture<List<SelectionRange>> getSelectionRangesFor(LSPSelectionRangeParams params,
-                                                                                 LanguageServerItem languageServer,
-                                                                                 CancellationSupport cancellationSupport) {
+    private static CompletableFuture<List<SelectionRange>> getSelectionRangesFor(@NotNull LSPSelectionRangeParams params,
+                                                                                 @NotNull PsiFile file,
+                                                                                 @NotNull LanguageServerItem languageServer,
+                                                                                 @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .selectionRange(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_SELECTION_RANGE)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensSupport.java
@@ -64,7 +64,7 @@ public class LSPSemanticTokensSupport extends AbstractLSPDocumentFeatureSupport<
                     // Collect list of textDocument/semanticTokens future for each language servers
                     List<CompletableFuture<SemanticTokensData>> semanticTokensPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getSemanticTokensFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getSemanticTokensFor(params, file, languageServer, cancellationSupport))
                             .filter(Objects::nonNull)
                             .toList();
 
@@ -73,9 +73,12 @@ public class LSPSemanticTokensSupport extends AbstractLSPDocumentFeatureSupport<
                 });
     }
 
-    private static CompletableFuture<SemanticTokensData> getSemanticTokensFor(SemanticTokensParams params,
-                                                                              LanguageServerItem languageServer,
-                                                                              CancellationSupport cancellationSupport) {
+    private static CompletableFuture<SemanticTokensData> getSemanticTokensFor(@NotNull SemanticTokensParams params,
+                                                                              @NotNull PsiFile file,
+                                                                              @NotNull LanguageServerItem languageServer,
+                                                                              @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .semanticTokensFull(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_SEMANTIC_TOKENS_FULL)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPSignatureHelpSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPSignatureHelpSupport.java
@@ -59,13 +59,16 @@ public class LSPSignatureHelpSupport extends AbstractLSPDocumentFeatureSupport<S
 
                     // Get signature help for the first language server
                     LanguageServerItem languageServer = languageServers.get(0);
-                    return getSignatureHelpFor(params, languageServer, cancellationSupport);
+                    return getSignatureHelpFor(params, file, languageServer, cancellationSupport);
                 });
     }
 
     private static CompletableFuture<SignatureHelp> getSignatureHelpFor(@NotNull SignatureHelpParams params,
+                                                                        @NotNull PsiFile file,
                                                                         @NotNull LanguageServerItem languageServer,
                                                                         @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                 .getTextDocumentService()
                 .signatureHelp(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_SIGNATURE_HELP);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
@@ -20,7 +20,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
-import org.eclipse.lsp4j.Location;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +44,10 @@ public class LSPGoToTypeDefinitionAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<Location>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
+    protected CompletableFuture<List<LocationData>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
         LSPTypeDefinitionSupport typeDefinitionSupport = LSPFileSupport.getSupport(psiFile).getTypeDefinitionSupport();
         var params = new LSPTypeDefinitionParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
-        CompletableFuture<List<Location>> typeDefinitionsFuture = typeDefinitionSupport.getTypeDefinitions(params);
+        CompletableFuture<List<LocationData>> typeDefinitionsFuture = typeDefinitionSupport.getTypeDefinitions(params);
         try {
             waitUntilDone(typeDefinitionsFuture, psiFile);
         } catch (ProcessCanceledException ex) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPTypeDefinitionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPTypeDefinitionSupport.java
@@ -17,7 +17,7 @@ import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
-import org.eclipse.lsp4j.Location;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
  *      <li>textDocument/typeDefinition</li>
  *  </ul>
  */
-public class LSPTypeDefinitionSupport extends AbstractLSPDocumentFeatureSupport<LSPTypeDefinitionParams, List<Location>> {
+public class LSPTypeDefinitionSupport extends AbstractLSPDocumentFeatureSupport<LSPTypeDefinitionParams, List<LocationData>> {
 
     private Integer previousOffset;
 
@@ -38,7 +38,7 @@ public class LSPTypeDefinitionSupport extends AbstractLSPDocumentFeatureSupport<
         super(file);
     }
 
-    public CompletableFuture<List<Location>> getTypeDefinitions(LSPTypeDefinitionParams params) {
+    public CompletableFuture<List<LocationData>> getTypeDefinitions(LSPTypeDefinitionParams params) {
         int offset = params.getOffset();
         if (previousOffset != null && !previousOffset.equals(offset)) {
             super.cancel();
@@ -48,12 +48,12 @@ public class LSPTypeDefinitionSupport extends AbstractLSPDocumentFeatureSupport<
     }
 
     @Override
-    protected CompletableFuture<List<Location>> doLoad(LSPTypeDefinitionParams params, CancellationSupport cancellationSupport) {
+    protected CompletableFuture<List<LocationData>> doLoad(LSPTypeDefinitionParams params, CancellationSupport cancellationSupport) {
         PsiFile file = super.getFile();
         return collectTypeDefinitions(file, params, cancellationSupport);
     }
 
-    private static @NotNull CompletableFuture<List<Location>> collectTypeDefinitions(@NotNull PsiFile file,
+    private static @NotNull CompletableFuture<List<LocationData>> collectTypeDefinitions(@NotNull PsiFile file,
                                                                                      @NotNull LSPTypeDefinitionParams params,
                                                                                      @NotNull CancellationSupport cancellationSupport) {
         return getLanguageServers(file,
@@ -67,9 +67,9 @@ public class LSPTypeDefinitionSupport extends AbstractLSPDocumentFeatureSupport<
                     }
 
                     // Collect list of textDocument/typeDefinition future for each language servers
-                    List<CompletableFuture<List<Location>>> typeDefinitionsPerServerFutures = languageServers
+                    List<CompletableFuture<List<LocationData>>> typeDefinitionsPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getTypeDefinitionFor(params, languageServer, cancellationSupport))
+                            .map(languageServer -> getTypeDefinitionFor(params, file, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of textDocument/typeDefinition future in one future which return the list of typeDefinition ranges
@@ -77,12 +77,15 @@ public class LSPTypeDefinitionSupport extends AbstractLSPDocumentFeatureSupport<
                 });
     }
 
-    private static CompletableFuture<List<Location>> getTypeDefinitionFor(LSPTypeDefinitionParams params,
-                                                                          LanguageServerItem languageServer,
-                                                                          CancellationSupport cancellationSupport) {
+    private static CompletableFuture<List<LocationData>> getTypeDefinitionFor(@NotNull LSPTypeDefinitionParams params,
+                                                                          @NotNull PsiFile file,
+                                                                          @NotNull LanguageServerItem languageServer,
+                                                                          @NotNull CancellationSupport cancellationSupport) {
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .typeDefinition(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_TYPE_DEFINITION)
-                .thenApplyAsync(LSPIJUtils::getLocations);
+                .thenApplyAsync(locations -> LSPIJUtils.getLocations(locations, languageServer));
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPPrepareTypeHierarchySupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPPrepareTypeHierarchySupport.java
@@ -61,8 +61,8 @@ public class LSPPrepareTypeHierarchySupport extends AbstractLSPDocumentFeatureSu
                                                                                                      @NotNull CancellationSupport cancellationSupport) {
 
         return getLanguageServers(file,
-                        f -> f.getTypeHierarchyFeature().isEnabled(file),
-                        f -> f.getTypeHierarchyFeature().isSupported(file))
+                f -> f.getTypeHierarchyFeature().isEnabled(file),
+                f -> f.getTypeHierarchyFeature().isSupported(file))
                 .thenComposeAsync(languageServers -> {
                     // Here languageServers is the list of language servers which matches the given file
                     // and which have type hierarchy capability
@@ -86,6 +86,8 @@ public class LSPPrepareTypeHierarchySupport extends AbstractLSPDocumentFeatureSu
                                                                                         @NotNull PsiFile file,
                                                                                         @NotNull CancellationSupport cancellationSupport) {
 
+        // Update textDocument Uri with custom file Uri if needed
+        updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
                         .prepareTypeHierarchy(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_PREPARE_TYPE_HIERARCHY)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySubtypesSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySubtypesSupport.java
@@ -54,8 +54,8 @@ public class LSPTypeHierarchySubtypesSupport extends AbstractLSPDocumentFeatureS
                                                                                                     @NotNull CancellationSupport cancellationSupport) {
 
         return getLanguageServers(file,
-                        f -> f.getTypeHierarchyFeature().isEnabled(file),
-                        f -> f.getTypeHierarchyFeature().isSupported(file))
+                f -> f.getTypeHierarchyFeature().isEnabled(file),
+                f -> f.getTypeHierarchyFeature().isSupported(file))
                 .thenComposeAsync(languageServers -> {
                     // Here languageServers is the list of language servers which matches the given file
                     // and which have type hierarchy capability
@@ -66,7 +66,7 @@ public class LSPTypeHierarchySubtypesSupport extends AbstractLSPDocumentFeatureS
                     // Collect list of typeHierarchy/subtypes future for each language servers
                     List<CompletableFuture<List<TypeHierarchyItemData>>> typeHierarchyPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getTypeHierarchiesFor(params, languageServer, file, cancellationSupport))
+                            .map(languageServer -> getTypeHierarchiesFor(params, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of typeHierarchy/subtypes future in one future which return the list of type hierarchy items
@@ -76,7 +76,6 @@ public class LSPTypeHierarchySubtypesSupport extends AbstractLSPDocumentFeatureS
 
     private static CompletableFuture<List<TypeHierarchyItemData>> getTypeHierarchiesFor(@NotNull TypeHierarchySubtypesParams params,
                                                                                         @NotNull LanguageServerItem languageServer,
-                                                                                        @NotNull PsiFile file,
                                                                                         @NotNull CancellationSupport cancellationSupport) {
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySupertypesSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySupertypesSupport.java
@@ -50,12 +50,12 @@ public class LSPTypeHierarchySupertypesSupport extends AbstractLSPDocumentFeatur
     }
 
     private static @NotNull CompletableFuture<List<TypeHierarchyItemData>> getTypeHierarchySupertypes(@NotNull PsiFile file,
-                                                                                                    @NotNull TypeHierarchySupertypesParams params,
-                                                                                                    @NotNull CancellationSupport cancellationSupport) {
+                                                                                                      @NotNull TypeHierarchySupertypesParams params,
+                                                                                                      @NotNull CancellationSupport cancellationSupport) {
 
         return getLanguageServers(file,
-                        f -> f.getTypeHierarchyFeature().isEnabled(file),
-                        f -> f.getTypeHierarchyFeature().isSupported(file))
+                f -> f.getTypeHierarchyFeature().isEnabled(file),
+                f -> f.getTypeHierarchyFeature().isSupported(file))
                 .thenComposeAsync(languageServers -> {
                     // Here languageServers is the list of language servers which matches the given file
                     // and which have type hierarchy capability
@@ -66,7 +66,7 @@ public class LSPTypeHierarchySupertypesSupport extends AbstractLSPDocumentFeatur
                     // Collect list of typeHierarchy/supertypes future for each language servers
                     List<CompletableFuture<List<TypeHierarchyItemData>>> typeHierarchyPerServerFutures = languageServers
                             .stream()
-                            .map(languageServer -> getTypeHierarchiesFor(params, languageServer, file, cancellationSupport))
+                            .map(languageServer -> getTypeHierarchiesFor(params, languageServer, cancellationSupport))
                             .toList();
 
                     // Merge list of typeHierarchy/supertypes future in one future which return the list of type hierarchy items
@@ -76,7 +76,6 @@ public class LSPTypeHierarchySupertypesSupport extends AbstractLSPDocumentFeatur
 
     private static CompletableFuture<List<TypeHierarchyItemData>> getTypeHierarchiesFor(@NotNull TypeHierarchySupertypesParams params,
                                                                                         @NotNull LanguageServerItem languageServer,
-                                                                                        @NotNull PsiFile file,
                                                                                         @NotNull CancellationSupport cancellationSupport) {
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
@@ -86,7 +86,7 @@ public abstract class LSPTypeHierarchyTreeStructureBase extends LSPHierarchyTree
             if (items != null) {
                 for (var item : items) {
                     var typeHierarchyItem = item.typeHierarchyItem();
-                    PsiElement element = createPsiElement(typeHierarchyItem.getUri(), typeHierarchyItem.getRange(), typeHierarchyItem.getName());
+                    PsiElement element = createPsiElement(typeHierarchyItem.getUri(), typeHierarchyItem.getRange(), typeHierarchyItem.getName(), item.languageServer().getClientFeatures());
                     if (element != null) {
                         descriptors.add(createHierarchyNodeDescriptor(myProject, descriptor, element, typeHierarchyItem));
                     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
@@ -29,7 +29,7 @@ import com.redhat.devtools.lsp4ij.features.LSPPsiElementFactory;
 import com.redhat.devtools.lsp4ij.features.implementation.LSPImplementationParams;
 import com.redhat.devtools.lsp4ij.features.implementation.LSPImplementationSupport;
 import com.redhat.devtools.lsp4ij.ui.LSP4IJUiUtils;
-import org.eclipse.lsp4j.Location;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +95,7 @@ public class LSPWorkspaceImplementationsSearch extends QueryExecutorBase<PsiElem
                 offset
         );
         LSPImplementationSupport implementationSupport = LSPFileSupport.getSupport(file).getImplementationSupport();
-        CompletableFuture<List<Location>> implementationsFuture = implementationSupport.getImplementations(params);
+        CompletableFuture<List<LocationData>> implementationsFuture = implementationSupport.getImplementations(params);
         try {
             waitUntilDone(implementationsFuture, file);
         } catch (ProcessCanceledException ex) {
@@ -109,14 +109,14 @@ public class LSPWorkspaceImplementationsSearch extends QueryExecutorBase<PsiElem
         }
 
         if (isDoneNormally(implementationsFuture)) {
-            List<Location> implementations = implementationsFuture.getNow(null);
+            List<LocationData> implementations = implementationsFuture.getNow(null);
             if (ContainerUtil.isEmpty(implementations)) {
                 // No implementations found
                 LSP4IJUiUtils.showErrorHint(file, CodeInsightBundle.message("goto.implementation.notFound"));
             } else {
                 // textDocument/implementations has been collected correctly
-                for (Location implementation : implementations) {
-                    if (!consumer.process(LSPPsiElementFactory.toPsiElement(implementation, project))) {
+                for (LocationData implementation : implementations) {
+                    if (!consumer.process(LSPPsiElementFactory.toPsiElement(implementation.location(), implementation.languageServer().getClientFeatures(), project))) {
                         return;
                     }
                 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceSymbolSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceSymbolSupport.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.lsp4ij.features.workspaceSymbol;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPWorkspaceFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
@@ -91,14 +92,14 @@ public class LSPWorkspaceSymbolSupport extends AbstractLSPWorkspaceFeatureSuppor
                         for (var si : s) {
                             if (params.accept(si)) {
                                 items.add(new WorkspaceSymbolData(
-                                        si.getName(), si.getKind(), si.getLocation(), project));
+                                        si.getName(), si.getKind(), si.getLocation(), languageServer.getClientFeatures(), project));
                             }
                         }
                     } else if (symbols.isRight()) {
                         List<? extends WorkspaceSymbol> ws = symbols.getRight();
                         for (var si : ws) {
                             if (params.accept(si)) {
-                                WorkspaceSymbolData item = createItem(si, project);
+                                WorkspaceSymbolData item = createItem(si, languageServer.getClientFeatures(),project);
                                 items.add(item);
                             }
                         }
@@ -107,14 +108,16 @@ public class LSPWorkspaceSymbolSupport extends AbstractLSPWorkspaceFeatureSuppor
                 });
     }
 
-    private static WorkspaceSymbolData createItem(WorkspaceSymbol si, Project project) {
+    private static WorkspaceSymbolData createItem(WorkspaceSymbol si,
+                                                  FileUriSupport fileUriSupport,
+                                                  Project project) {
         String name = si.getName();
         SymbolKind symbolKind = si.getKind();
         if (si.getLocation().isLeft()) {
             return new WorkspaceSymbolData(
-                    name, symbolKind, si.getLocation().getLeft(), project);
+                    name, symbolKind, si.getLocation().getLeft(), fileUriSupport, project);
         }
         return new WorkspaceSymbolData(
-                name, symbolKind, si.getLocation().getRight().getUri(), null, project);
+                name, symbolKind, si.getLocation().getRight().getUri(), null, fileUriSupport, project);
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/WorkspaceSymbolData.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/WorkspaceSymbolData.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.ui.IconMapper;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -40,6 +41,7 @@ public class WorkspaceSymbolData implements NavigationItem {
     private final Project project;
     private final VirtualFile file;
     private final LSPItemPresentation presentation;
+    private final FileUriSupport fileUriSupport;
 
     private record LSPItemPresentation(String name, SymbolKind symbolKind, String locationString) implements ItemPresentation {
 
@@ -64,16 +66,26 @@ public class WorkspaceSymbolData implements NavigationItem {
 
     }
 
-    public WorkspaceSymbolData(String name, SymbolKind symbolKind, Location location, Project project) {
-        this(name, symbolKind, location.getUri(), location.getRange().getStart(), project);
+    public WorkspaceSymbolData(String name,
+                               SymbolKind symbolKind,
+                               Location location,
+                               FileUriSupport fileUriSupport,
+                               Project project) {
+        this(name, symbolKind, location.getUri(), location.getRange().getStart(), fileUriSupport, project);
     }
 
-    public WorkspaceSymbolData(String name, SymbolKind symbolKind, String fileUri, Position position, Project project) {
+    public WorkspaceSymbolData(String name,
+                               SymbolKind symbolKind,
+                               String fileUri,
+                               Position position,
+                               FileUriSupport fileUriSupport,
+                               Project project) {
         this.symbolKind = symbolKind;
         this.fileUri = fileUri;
         this.position = position;
         this.project = project;
-        this.file = LSPIJUtils.findResourceFor(fileUri);
+        this.file = FileUriSupport.findFileByUri(fileUri, fileUriSupport);
+        this.fileUriSupport = fileUriSupport;
         String locationString = file != null ? getLocationString(project, file) : fileUri;
         this.presentation = new LSPItemPresentation(name, symbolKind, locationString);
     }
@@ -98,7 +110,7 @@ public class WorkspaceSymbolData implements NavigationItem {
 
     @Override
     public void navigate(boolean requestFocus) {
-        LSPIJUtils.openInEditor(fileUri, position, requestFocus, project);
+        LSPIJUtils.openInEditor(fileUri, position, requestFocus, false, fileUriSupport, project);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/hint/LSPNavigationLinkHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/hint/LSPNavigationLinkHandler.java
@@ -41,7 +41,7 @@ public class LSPNavigationLinkHandler extends TooltipLinkHandler {
     @Override
     public boolean handleLink(@NotNull String fileUrl,
                               @NotNull Editor editor) {
-        return LSPIJUtils.openInEditor(fileUrl, null, true, true, editor.getProject());
+        return LSPIJUtils.openInEditor(fileUrl, null, true, true, null, editor.getProject());
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
@@ -119,7 +119,7 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
                 file,
                 ReadAction.compute(element::getTextOffset),
                 options.searchScope,
-                reference -> processor.process(new UsageInfo2UsageAdapter(new UsageInfo(reference)))
+                reference -> processor.process(ReadAction.compute(() -> new UsageInfo2UsageAdapter(new UsageInfo(reference))))
         );
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
@@ -57,7 +57,7 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
             if (elt.getLSPReferences() != null) {
                 elt.getLSPReferences()
                         .forEach(ref -> {
-                            var psiElement = LSPUsagesManager.toPsiElement(ref, LSPUsagePsiElement.UsageKind.references, element.getProject());
+                            var psiElement = LSPUsagesManager.toPsiElement(ref.location(), ref.languageServer().getClientFeatures(), LSPUsagePsiElement.UsageKind.references, element.getProject());
                             if (psiElement != null) {
                                 processor.process(ReadAction.compute(() -> new UsageInfo2UsageAdapter(new UsageInfo(psiElement))));
                             }

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
@@ -98,7 +98,11 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
         }
 
         // For completeness' sake, also collect external usages to LSP (pseudo-)elements
-        LSPExternalReferencesFinder.processExternalReferences(file, element.getTextOffset(), reference -> processor.process(new UsageInfo2UsageAdapter(new UsageInfo(reference))));
+        ReadAction.run(() -> LSPExternalReferencesFinder.processExternalReferences(
+                file,
+                element.getTextOffset(),
+                reference -> processor.process(new UsageInfo2UsageAdapter(new UsageInfo(reference)))
+        ));
     }
 
     @Nullable

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTriggeredPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTriggeredPsiElement.java
@@ -13,7 +13,6 @@ package com.redhat.devtools.lsp4ij.usages;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.features.LSPPsiElement;
-import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,18 +25,18 @@ import java.util.List;
  */
 public class LSPUsageTriggeredPsiElement extends LSPPsiElement {
 
-    private List<Location> references;
+    private List<LocationData> references;
 
     public LSPUsageTriggeredPsiElement(@NotNull PsiFile file, @NotNull TextRange textRange) {
         super(file, textRange);
     }
 
     @Nullable
-    public List<Location> getLSPReferences() {
+    public List<LocationData> getLSPReferences() {
         return references;
     }
 
-    public void setLSPReferences(List<Location> references) {
+    public void setLSPReferences(List<LocationData> references) {
         this.references = references;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LocationData.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LocationData.java
@@ -1,0 +1,7 @@
+package com.redhat.devtools.lsp4ij.usages;
+
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import org.eclipse.lsp4j.Location;
+
+public record LocationData(Location location, LanguageServerItem languageServer) {
+}


### PR DESCRIPTION
I'm unfortunately unable to reproduce the actual error seen by the reporting user in both 2023.2 or 2024.3, but wrapping the entire call in a read action should resolve all downstream requirements for the read lock.