### PR TITLE
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'file' of com/intellij/psi/search/GlobalSearchScope.accept must not be null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/AbstractLSPWorkspaceSymbolContributor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/AbstractLSPWorkspaceSymbolContributor.java
@@ -55,7 +55,7 @@ abstract class AbstractLSPWorkspaceSymbolContributor implements ChooseByNameCont
         List<WorkspaceSymbolData> items = getWorkspaceSymbols(queryString, true, project);
         if (items != null) {
             items.stream()
-                    .filter(data -> scope.accept(data.getFile()))
+                    .filter(data -> data.getFile() != null && scope.accept(data.getFile()))
                     .map(NavigationItem::getName)
                     .forEach(processor::process);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/WorkspaceSymbolData.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/WorkspaceSymbolData.java
@@ -90,6 +90,7 @@ public class WorkspaceSymbolData implements NavigationItem {
         this.presentation = new LSPItemPresentation(name, symbolKind, locationString);
     }
 
+    @Nullable
     public VirtualFile getFile() {
         return file;
     }


### PR DESCRIPTION
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'file' of com/intellij/psi/search/GlobalSearchScope.accept must not be null

Fixes #721