### PR TITLE
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'future' of com/redhat/devtools/lsp4ij/internal/CompletableFutures.waitUntilDone must not be null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
@@ -38,8 +38,10 @@ public abstract class AbstractLSPFeatureSupport<Params, Result> {
      * Returns the (cached or not) LSP requests for all language servers applying to a given Psi file or project.
      *
      * @param params the LSP parameters expected to execute LSP requests.
-     * @return the (cached or not) LSP requests for all language servers applying to a given Psi file or project.
+     * @return the (cached or not) LSP requests for all language servers applying to a given Psi file or project and null otherwise
+     * (rare case when the future is loaded and cancel is occurred in the same time which set the future to null).
      */
+    @Nullable
     public CompletableFuture<Result> getFeatureData(Params params) {
         if (!isValidLSPFuture()) {
             // - the LSP requests have never been executed

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyTreeStructureBase.java
@@ -79,7 +79,7 @@ public abstract class LSPCallHierarchyTreeStructureBase extends LSPHierarchyTree
     }
 
     protected void fillChildren(@NotNull HierarchyNodeDescriptor descriptor,
-                                @NotNull CompletableFuture<List<CallHierarchyItemData>> callHierarchyFuture,
+                                @Nullable CompletableFuture<List<CallHierarchyItemData>> callHierarchyFuture,
                                 @NotNull List<LSPHierarchyNodeDescriptor> descriptors) {
         if (isDoneNormally(callHierarchyFuture)) {
             List<CallHierarchyItemData> items = callHierarchyFuture.getNow(null);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
@@ -63,7 +63,7 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
             return;
         }
         try {
-            List<? extends TextEdit> edits = formatFuture.getNow(null);
+            List<? extends TextEdit> edits = formatFuture != null ? formatFuture.getNow(null) : null;
             String formatted = edits != null ? applyEdits(editor.getDocument(), edits) : formattingRequest.getDocumentText();
             formattingRequest.onTextReady(formatted);
         } catch (Exception e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
@@ -79,7 +79,7 @@ public abstract class LSPTypeHierarchyTreeStructureBase extends LSPHierarchyTree
     }
 
     protected void fillChildren(@NotNull HierarchyNodeDescriptor descriptor,
-                                @NotNull CompletableFuture<List<TypeHierarchyItemData>> typeHierarchyFuture,
+                                @Nullable CompletableFuture<List<TypeHierarchyItemData>> typeHierarchyFuture,
                                 @NotNull List<LSPHierarchyNodeDescriptor> descriptors) {
         if (isDoneNormally(typeHierarchyFuture)) {
             List<TypeHierarchyItemData> items = typeHierarchyFuture.getNow(null);

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
@@ -103,8 +103,11 @@ public class CompletableFutures {
      * @param future the future to wait.
      * @param file   the Psi file.
      */
-    public static void waitUntilDone(@NotNull CompletableFuture<?> future,
+    public static void waitUntilDone(@Nullable CompletableFuture<?> future,
                                      @Nullable PsiFile file) throws ExecutionException, ProcessCanceledException {
+        if (future == null) {
+            return;
+        }
         long start = System.currentTimeMillis();
         final long modificationStamp = file != null ? file.getModificationStamp() : -1;
         while (!future.isDone()) {
@@ -151,10 +154,13 @@ public class CompletableFutures {
      * @param title  the task title.
      * @param file   the Psi file.
      */
-    public static void waitUntilDoneAsync(@NotNull CompletableFuture<?> future,
+    public static void waitUntilDoneAsync(@Nullable CompletableFuture<?> future,
                                           @NotNull String title,
                                           @NotNull PsiFile file) {
 
+        if (future == null) {
+            return;
+        }
         ProgressManager.getInstance().run(new Task.Backgroundable(file.getProject(), title, true) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {


### PR DESCRIPTION
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'future' of com/redhat/devtools/lsp4ij/internal/CompletableFutures.waitUntilDone must not be null

Fixes #719