### PR TITLE
feat: Allow disabling of editor templates when accepting method/function invocation completions (fixes #718)

### DIFF
--- a/docs/LSPApi.md
+++ b/docs/LSPApi.md
@@ -234,7 +234,7 @@ public class MyLSPCodeLensFeature extends LSPCodeLensFeature {
 | String getTailText(CompletionItem item)                                               | Returns the IntelliJ lookup tail text from the given LSP completion item and null otherwise.                                                                                                                                       | `item.getLabelDetails().getDetail()`                                                  |
 | boolean isItemTextBold(CompletionItem item)                                           | Returns the IntelliJ lookup item text bold from the given LSP completion item and null otherwise.                                                                                                                                  | `item.getKind() == CompletionItemKind.Keyword`                                        |
 | boolean useContextAwareSorting(PsiFile file)                                          | Returns `true` if client-side context-aware completion sorting should be used for the specified file and `false` otherwise.                                                                                                        | `false`                                                                               |
-|
+| boolean useTemplateForInvocationOnlySnippet(PsiFile file)                             | Returns `true` if an editor template should be used for invocation-only snippets and `false` otherwise.                                                                                                                            | `true`                                                                                |
 
 ## LSP Declaration Feature
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionFeature.java
@@ -306,4 +306,15 @@ public class LSPCompletionFeature extends AbstractLSPDocumentFeature {
         // Default to disabled
         return false;
     }
+
+    /**
+     * Whether or not an editor template should be used for invocation-only snippets.
+     *
+     * @param file the file
+     * @return true an editor template should be used for invocation-only snippets; otherwise false
+     */
+    public boolean useTemplateForInvocationOnlySnippet(@NotNull PsiFile file) {
+        // Default to enabled
+        return true;
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateFactory.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
+
 package com.redhat.devtools.lsp4ij.features.completion;
 
 import com.intellij.codeInsight.template.Template;
@@ -33,15 +34,25 @@ public class SnippetTemplateFactory {
     /**
      * Returns an Intellij Template instanced loaded from the given LSP snippet content.
      *
-     * @param snippetContent    the LSP snippet content
-     * @param project           the project.
-     * @param variableResolver the LSP variable resolvers (ex to resolve ${TM_SELECTED_TEXT}).
+     * @param snippetContent                      the LSP snippet content
+     * @param project                             the project.
+     * @param variableResolver                    the LSP variable resolvers (ex to resolve ${TM_SELECTED_TEXT}).
+     * @param useTemplateForInvocationOnlySnippet whether or not a template should be used for an invocation-only snippet
      * @return an Intellij Template instanced loaded from the given LSP snippet content.
      */
-    public static @NotNull Template createTemplate(@NotNull String snippetContent, @NotNull Project project, @NotNull Function<String, String> variableResolver, LspSnippetIndentOptions indentOptions) {
+    public static @NotNull Template createTemplate(@NotNull String snippetContent,
+                                                   @NotNull Project project,
+                                                   @NotNull Function<String, String> variableResolver,
+                                                   LspSnippetIndentOptions indentOptions,
+                                                   boolean useTemplateForInvocationOnlySnippet) {
         Template template = TemplateManager.getInstance(project).createTemplate("", "");
         template.setInline(true);
-        LspSnippetParser parser = new LspSnippetParser(new SnippetTemplateLoader(template, variableResolver, indentOptions));
+        LspSnippetParser parser = new LspSnippetParser(new SnippetTemplateLoader(
+                template,
+                variableResolver,
+                indentOptions,
+                useTemplateForInvocationOnlySnippet
+        ));
         parser.parse(snippetContent);
         return template;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateLoader.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateLoader.java
@@ -11,15 +11,20 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
+
 package com.redhat.devtools.lsp4ij.features.completion;
 
 import com.intellij.codeInsight.template.Template;
 import com.intellij.codeInsight.template.impl.ConstantNode;
+import com.intellij.openapi.util.text.StringUtil;
 import com.redhat.devtools.lsp4ij.features.completion.snippet.AbstractLspSnippetHandler;
 import com.redhat.devtools.lsp4ij.features.completion.snippet.LspSnippetHandler;
 import com.redhat.devtools.lsp4ij.features.completion.snippet.LspSnippetIndentOptions;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -32,20 +37,26 @@ import java.util.function.Function;
 public class SnippetTemplateLoader extends AbstractLspSnippetHandler {
 
     private final Template template;
+    private final boolean useTemplateForInvocationOnlySnippet;
 
-    private final List<String> existingVariables;
+    private final List<SnippetTemplateSegment> templateSegments = new LinkedList<>();
+    private final List<String> existingVariables = new LinkedList<>();
 
     /**
      * Load the given Intellij template from a LSP snippet content by using the given variable resolver.
      *
-     * @param template         the Intellij template to load.
-     * @param variableResolver the variable resolver (ex : resolve value of TM_SELECTED_TEXT when snippet declares ${TM_SELECTED_TEXT})
-     * @param indentOptions the LSP indent options to replace '\t' and '\n' characters according the code style settings of the language.
+     * @param template                            the Intellij template to load.
+     * @param variableResolver                    the variable resolver (ex : resolve value of TM_SELECTED_TEXT when snippet declares ${TM_SELECTED_TEXT})
+     * @param indentOptions                       the LSP indent options to replace '\t' and '\n' characters according the code style settings of the language.
+     * @param useTemplateForInvocationOnlySnippet whether or not a template should be used for an invocation-only snippet
      */
-    public SnippetTemplateLoader(Template template, Function<String, String> variableResolver, LspSnippetIndentOptions indentOptions) {
+    public SnippetTemplateLoader(@NotNull Template template,
+                                 @Nullable Function<String, String> variableResolver,
+                                 @Nullable LspSnippetIndentOptions indentOptions,
+                                 boolean useTemplateForInvocationOnlySnippet) {
         super(variableResolver, indentOptions);
         this.template = template;
-        this.existingVariables = new ArrayList<>();
+        this.useTemplateForInvocationOnlySnippet = useTemplateForInvocationOnlySnippet;
     }
 
     @Override
@@ -53,22 +64,99 @@ public class SnippetTemplateLoader extends AbstractLspSnippetHandler {
 
     }
 
+    @SuppressWarnings("DataFlowIssue")
     @Override
     public void endSnippet() {
+        List<SnippetTemplateSegment> effectiveTemplateSegments = templateSegments;
 
+        // If we should not use a template for an invocation-only snippet, see whether this fits the pattern
+        if (!useTemplateForInvocationOnlySnippet) {
+            boolean hasInvocation = false;
+            boolean inInvocation = false;
+            boolean hasVariablesOutsideInvocation = false;
+            List<SnippetTemplateSegment> simplifiedTemplateSegments = new ArrayList<>(templateSegments.size());
+            for (SnippetTemplateSegment templateSegment : templateSegments) {
+                // Keep track of invocations
+                if (templateSegment.isTextSegment()) {
+                    String textSegment = templateSegment.getTextSegment();
+                    if (!inInvocation && isInvocationStart(textSegment)) {
+                        // Mark us as having an invocation and being in it now
+                        hasInvocation = true;
+                        inInvocation = true;
+
+                        // Add the invocation start text segment and an end variable inside the invocation
+                        simplifiedTemplateSegments.add(templateSegment);
+                        simplifiedTemplateSegments.add(SnippetTemplateSegment.endVariable());
+                    } else if (inInvocation && isInvocationEnd(textSegment)) {
+                        // Mark us as no longer being in an invocation
+                        inInvocation = false;
+                        // Add the invocation end text segment
+                        simplifiedTemplateSegments.add(templateSegment);
+                    }
+                    // Otherwise only add text segments outside the invocation as the invocation should only contain the end variable
+                    else if (!inInvocation) {
+                        simplifiedTemplateSegments.add(templateSegment);
+                    }
+                }
+                // If we find a variable not in an invocation, we can't simplify this template
+                else if ((templateSegment.isVariable() || templateSegment.isNamedVariable()) && !inInvocation) {
+                    hasVariablesOutsideInvocation = true;
+                    break;
+                }
+            }
+
+            // If we found an invocation and all variables were inside of it, use the simplified template segments
+            if (hasInvocation && !hasVariablesOutsideInvocation) {
+                effectiveTemplateSegments = simplifiedTemplateSegments;
+            }
+        }
+
+        // Build the template
+        for (SnippetTemplateSegment templateSegment : effectiveTemplateSegments) {
+            if (templateSegment.isTextSegment()) {
+                template.addTextSegment(templateSegment.getTextSegment());
+            } else if (templateSegment.isVariableSegment()) {
+                template.addVariableSegment(templateSegment.getVariableSegment());
+            } else if (templateSegment.isVariable()) {
+                template.addVariable(templateSegment.getVariable(), templateSegment.isAlwaysStopAt());
+            } else if (templateSegment.isNamedVariable()) {
+                template.addVariable(
+                        templateSegment.getVariableName(),
+                        templateSegment.getVariable(),
+                        templateSegment.getDefaultValueExpression(),
+                        templateSegment.isAlwaysStopAt(),
+                        templateSegment.isSkipOnStart()
+                );
+            } else if (templateSegment.isEndVariable()) {
+                template.addEndVariable();
+            }
+        }
+    }
+
+    // NOTE: These are quite simple now and basically look for a segment that ends with "(" (ignoring trailing white
+    // space) to determine that an invocation has started and one that begins with ")" (again, ignore leading white
+    // space) to determine that an invocation has ended. If LSP languages with more complex invocation patterns are
+    // found these will need to be updated accordingly.
+
+    private static boolean isInvocationStart(@NotNull String text) {
+        return StringUtil.trimTrailing(text).endsWith("(");
+    }
+
+    private static boolean isInvocationEnd(@NotNull String text) {
+        return StringUtil.trimLeading(text).startsWith(")");
     }
 
     @Override
     public void text(String text) {
-        template.addTextSegment(formatText(text));
+        templateSegments.add(SnippetTemplateSegment.textSegment(formatText(text)));
     }
 
     @Override
     public void tabstop(int index) {
         if (index == 0) {
-            template.addEndVariable();
+            templateSegments.add(SnippetTemplateSegment.endVariable());
         } else {
-            template.addVariable(new ConstantNode(""), true);
+            templateSegments.add(SnippetTemplateSegment.variable(new ConstantNode(""), true));
         }
     }
 
@@ -80,7 +168,7 @@ public class SnippetTemplateLoader extends AbstractLspSnippetHandler {
 
     @Override
     public void choice(String name, List<String> choices) {
-        template.addVariable(new ConstantNode(name).withLookupStrings(choices), true);
+        templateSegments.add(SnippetTemplateSegment.variable(new ConstantNode(name).withLookupStrings(choices), true));
     }
 
     @Override
@@ -99,19 +187,18 @@ public class SnippetTemplateLoader extends AbstractLspSnippetHandler {
         if (resolvedValue != null) {
             // ex : ${TM_SELECTED_TEXT}
             // the TM_SELECTED_TEXT is resolved, we do a simple replacement
-            template.addVariable(new ConstantNode(resolvedValue), false);
+            templateSegments.add(SnippetTemplateSegment.variable(new ConstantNode(resolvedValue), false));
         } else {
             if (existingVariables.contains(name)) {
                 // The variable (ex : ${name}) has already been declared, add a simple variable segment
                 // which will be updated by the previous add variable
-                template.addVariableSegment(name);
+                templateSegments.add(SnippetTemplateSegment.variableSegment(name));
             } else {
                 // The variable doesn't exist, add a variable which can be updated
                 // and which will replace other variables with the same name.
                 existingVariables.add(name);
-                template.addVariable(name, new ConstantNode(name), null, true, false);
+                templateSegments.add(SnippetTemplateSegment.namedVariable(name, new ConstantNode(name), null, true, false));
             }
         }
     }
-
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateSegment.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateSegment.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.intellij.codeInsight.template.Expression;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This is a simple wrapper for a {@link com.intellij.codeInsight.template.Template} segment that allows deferred
+ * creation of the corresponding template with all segment information retained.
+ */
+class SnippetTemplateSegment {
+    private String textSegment;
+    private String variableSegment;
+    private Expression variable;
+    private boolean alwaysStopAt;
+    private String variableName;
+    private Expression defaultValueExpression;
+    private boolean skipOnStart;
+    private boolean endVariable;
+
+    @NotNull
+    static SnippetTemplateSegment textSegment(@NotNull String text) {
+        SnippetTemplateSegment snippetTemplateSegment = new SnippetTemplateSegment();
+        snippetTemplateSegment.textSegment = text;
+        return snippetTemplateSegment;
+    }
+
+    @NotNull
+    static SnippetTemplateSegment variableSegment(@NotNull String text) {
+        SnippetTemplateSegment snippetTemplateSegment = new SnippetTemplateSegment();
+        snippetTemplateSegment.variableSegment = text;
+        return snippetTemplateSegment;
+    }
+
+    @NotNull
+    static SnippetTemplateSegment variable(@NotNull Expression variable, boolean alwaysStopAt) {
+        SnippetTemplateSegment snippetTemplateSegment = new SnippetTemplateSegment();
+        snippetTemplateSegment.variable = variable;
+        snippetTemplateSegment.alwaysStopAt = alwaysStopAt;
+        return snippetTemplateSegment;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    @NotNull
+    static SnippetTemplateSegment namedVariable(@NotNull String variableName,
+                                                @NotNull Expression variable,
+                                                @Nullable Expression defaultValueExpression,
+                                                boolean alwaysStopAt,
+                                                boolean skipOnStart) {
+        SnippetTemplateSegment snippetTemplateSegment = new SnippetTemplateSegment();
+        snippetTemplateSegment.variableName = variableName;
+        snippetTemplateSegment.variable = variable;
+        snippetTemplateSegment.defaultValueExpression = defaultValueExpression;
+        snippetTemplateSegment.alwaysStopAt = alwaysStopAt;
+        snippetTemplateSegment.skipOnStart = skipOnStart;
+        return snippetTemplateSegment;
+    }
+
+    @NotNull
+    static SnippetTemplateSegment endVariable() {
+        SnippetTemplateSegment snippetTemplateSegment = new SnippetTemplateSegment();
+        snippetTemplateSegment.endVariable = true;
+        return snippetTemplateSegment;
+    }
+
+    boolean isTextSegment() {
+        return textSegment != null;
+    }
+
+    @Nullable
+    String getTextSegment() {
+        return textSegment;
+    }
+
+    boolean isVariableSegment() {
+        return variableSegment != null;
+    }
+
+    @Nullable
+    String getVariableSegment() {
+        return variableSegment;
+    }
+
+    boolean isVariable() {
+        return (variable != null) && (variableName == null);
+    }
+
+    @Nullable
+    Expression getVariable() {
+        return variable;
+    }
+
+    boolean isAlwaysStopAt() {
+        return alwaysStopAt;
+    }
+
+    boolean isNamedVariable() {
+        return (variable != null) && (variableName != null);
+    }
+
+    @Nullable
+    String getVariableName() {
+        return variableName;
+    }
+
+    @Nullable
+    Expression getDefaultValueExpression() {
+        return defaultValueExpression;
+    }
+
+    boolean isSkipOnStart() {
+        return skipOnStart;
+    }
+
+    boolean isEndVariable() {
+        return endVariable;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ClientConfigurableLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/ClientConfigurableLanguageServerDefinition.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.server.definition;
+
+import com.redhat.devtools.lsp4ij.server.definition.launching.ClientConfigurationSettings;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Common interface for language server definitions that support client configuration.
+ */
+public interface ClientConfigurableLanguageServerDefinition {
+    /**
+     * Returns the language server client configuration settings if available.
+     *
+     * @return the client configuration settings, or <code>null</code> if settings are not found/supported
+     */
+    @Nullable
+    ClientConfigurationSettings getLanguageServerClientConfiguration();
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
@@ -27,6 +27,10 @@ public class ClientConfigurationSettings {
          * Whether or not client-side context-aware completion sorting should be used. Defaults to false.
          */
         public boolean useContextAwareSorting = false;
+        /**
+         * Whether or not an editor template should be used for invocation-only snippets. Defaults to true.
+         */
+        public boolean useTemplateForInvocationOnlySnippet = true;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedCompletionFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedCompletionFeature.java
@@ -15,6 +15,7 @@ package com.redhat.devtools.lsp4ij.server.definition.launching;
 
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.client.features.LSPCompletionFeature;
+import com.redhat.devtools.lsp4ij.server.definition.ClientConfigurableLanguageServerDefinition;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -24,8 +25,15 @@ public class UserDefinedCompletionFeature extends LSPCompletionFeature {
 
     @Override
     public boolean useContextAwareSorting(@NotNull PsiFile file) {
-        UserDefinedLanguageServerDefinition serverDefinition = (UserDefinedLanguageServerDefinition) getClientFeatures().getServerDefinition();
+        ClientConfigurableLanguageServerDefinition serverDefinition = (ClientConfigurableLanguageServerDefinition) getClientFeatures().getServerDefinition();
         ClientConfigurationSettings clientConfiguration = serverDefinition.getLanguageServerClientConfiguration();
         return clientConfiguration != null ? clientConfiguration.completion.useContextAwareSorting : super.useContextAwareSorting(file);
+    }
+
+    @Override
+    public boolean useTemplateForInvocationOnlySnippet(@NotNull PsiFile file) {
+        ClientConfigurableLanguageServerDefinition serverDefinition = (ClientConfigurableLanguageServerDefinition) getClientFeatures().getServerDefinition();
+        ClientConfigurationSettings clientConfiguration = serverDefinition.getLanguageServerClientConfiguration();
+        return clientConfiguration != null ? clientConfiguration.completion.useTemplateForInvocationOnlySnippet : super.useTemplateForInvocationOnlySnippet(file);
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedLanguageServerDefinition.java
@@ -21,6 +21,7 @@ import com.redhat.devtools.lsp4ij.JSONUtils;
 import com.redhat.devtools.lsp4ij.client.LanguageClientImpl;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
+import com.redhat.devtools.lsp4ij.server.definition.ClientConfigurableLanguageServerDefinition;
 import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,7 +35,7 @@ import java.util.Map;
  * {@link com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition} implementation to start a
  * language server with a process command defined by the user.
  */
-public class UserDefinedLanguageServerDefinition extends LanguageServerDefinition {
+public class UserDefinedLanguageServerDefinition extends LanguageServerDefinition implements ClientConfigurableLanguageServerDefinition {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserDefinedLanguageServerDefinition.class);//$NON-NLS-1$
 
@@ -209,6 +210,8 @@ public class UserDefinedLanguageServerDefinition extends LanguageServerDefinitio
         return initializationOptions;
     }
 
+    @Override
+    @Nullable
     public ClientConfigurationSettings getLanguageServerClientConfiguration() {
         if ((clientConfiguration == null) && (clientConfigurationContent != null) && !clientConfigurationContent.isBlank()) {
             try {

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedWorkspaceSymbolFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedWorkspaceSymbolFeature.java
@@ -14,6 +14,7 @@
 package com.redhat.devtools.lsp4ij.server.definition.launching;
 
 import com.redhat.devtools.lsp4ij.client.features.LSPWorkspaceSymbolFeature;
+import com.redhat.devtools.lsp4ij.server.definition.ClientConfigurableLanguageServerDefinition;
 
 /**
  * Adds client-side workspace symbol configuration features.
@@ -22,7 +23,7 @@ public class UserDefinedWorkspaceSymbolFeature extends LSPWorkspaceSymbolFeature
 
     @Override
     public boolean supportsGotoClass() {
-        UserDefinedLanguageServerDefinition serverDefinition = (UserDefinedLanguageServerDefinition) getClientFeatures().getServerDefinition();
+        ClientConfigurableLanguageServerDefinition serverDefinition = (ClientConfigurableLanguageServerDefinition) getClientFeatures().getServerDefinition();
         ClientConfigurationSettings clientConfiguration = serverDefinition.getLanguageServerClientConfiguration();
         return clientConfiguration != null ? clientConfiguration.workspaceSymbol.supportsGotoClass : super.supportsGotoClass();
     }

--- a/src/main/resources/jsonSchema/clientSettings.schema.json
+++ b/src/main/resources/jsonSchema/clientSettings.schema.json
@@ -21,6 +21,12 @@
           "title": "Use context-aware completion sorting",
           "description": "Whether or not client-side context-aware completion sorting should be used.",
           "default": false
+        },
+        "useTemplateForInvocationOnlySnippet": {
+          "type": "boolean",
+          "title": "Use editor template for invocation-only snippets",
+          "description": "Whether or not an editor template should be used for invocation-only snippets.",
+          "default": true
         }
       }
     },

--- a/src/main/resources/templates/clojure-lsp/clientSettings.json
+++ b/src/main/resources/templates/clojure-lsp/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": true

--- a/src/main/resources/templates/gopls/clientSettings.json
+++ b/src/main/resources/templates/gopls/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": true

--- a/src/main/resources/templates/jdtls/clientSettings.json
+++ b/src/main/resources/templates/jdtls/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": true

--- a/src/main/resources/templates/lemminx/clientSettings.json
+++ b/src/main/resources/templates/lemminx/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": false

--- a/src/main/resources/templates/metals/clientSettings.json
+++ b/src/main/resources/templates/metals/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": true

--- a/src/main/resources/templates/rust-analyzer/clientSettings.json
+++ b/src/main/resources/templates/rust-analyzer/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": true

--- a/src/main/resources/templates/sourcekit-lsp/clientSettings.json
+++ b/src/main/resources/templates/sourcekit-lsp/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": true

--- a/src/main/resources/templates/typescript-language-server/clientSettings.json
+++ b/src/main/resources/templates/typescript-language-server/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": true

--- a/src/main/resources/templates/vscode-css-language-server/clientSettings.json
+++ b/src/main/resources/templates/vscode-css-language-server/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": true,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": false

--- a/src/main/resources/templates/vscode-html-language-server/clientSettings.json
+++ b/src/main/resources/templates/vscode-html-language-server/clientSettings.json
@@ -1,7 +1,8 @@
 {
   "caseSensitive": false,
   "completion": {
-    "useContextAwareSorting": true
+    "useContextAwareSorting": true,
+    "useTemplateForInvocationOnlySnippet": false
   },
   "workspaceSymbol": {
     "supportsGotoClass": false

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/CssCompletionClientConfigTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/CssCompletionClientConfigTest.java
@@ -1,0 +1,445 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionClientConfigFixtureTestCase;
+
+/**
+ * Tests code completion client configuration settings using a mock CSS language server.
+ */
+public class CssCompletionClientConfigTest extends LSPCompletionClientConfigFixtureTestCase {
+
+    private static final String TEST_FILE_NAME = "test.css";
+    private static final String TEST_FILE_BODY_BEFORE = """
+            .selector {
+                background-color: <caret>;
+            }
+            """;
+
+    // language=json
+    private static final String MOCK_TEXT_COMPLETION_JSON = """
+            {
+              "isIncomplete": true,
+              "items": [
+                {
+                  "label": "rgb",
+                  "kind": 3,
+                  "detail": "rgb($red, $green, $blue)",
+                  "documentation": "Creates a Color from red, green, and blue values.",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 1,
+                        "character": 22
+                      },
+                      "end": {
+                        "line": 1,
+                        "character": 22
+                      }
+                    },
+                    "newText": "rgb(${1:red}, ${2:green}, ${3:blue})"
+                  }
+                },
+                {
+                  "label": "rgb relative",
+                  "kind": 3,
+                  "detail": "rgb(from $color $red $green $blue)",
+                  "documentation": "Creates a Color from the red, green, and blue values of another Color.",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 1,
+                        "character": 22
+                      },
+                      "end": {
+                        "line": 1,
+                        "character": 22
+                      }
+                    },
+                    "newText": "rgb(from ${1:color} ${2:r} ${3:g} ${4:b})"
+                  }
+                },
+                {
+                  "label": "hwb",
+                  "kind": 3,
+                  "detail": "hwb($hue $white $black)",
+                  "documentation": "Creates a Color from hue, white, and black values.",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 1,
+                        "character": 22
+                      },
+                      "end": {
+                        "line": 1,
+                        "character": 22
+                      }
+                    },
+                    "newText": "hwb(${1:hue} ${2:white} ${3:black})"
+                  }
+                },
+                {
+                  "label": "color",
+                  "kind": 3,
+                  "detail": "color($color-space $red $green $blue)",
+                  "documentation": "Creates a Color in a specific color space from red, green, and blue values.",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 1,
+                        "character": 22
+                      },
+                      "end": {
+                        "line": 1,
+                        "character": 22
+                      }
+                    },
+                    "newText": "color(${1|srgb,srgb-linear,display-p3,a98-rgb,prophoto-rgb,rec2020,xyx,xyz-d50,xyz-d65|} ${2:red} ${3:green} ${4:blue})"
+                  }
+                },
+                {
+                  "label": "var()",
+                  "kind": 3,
+                  "documentation": "Evaluates the value of a custom variable.",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 1,
+                        "character": 22
+                      },
+                      "end": {
+                        "line": 1,
+                        "character": 22
+                      }
+                    },
+                    "newText": "var($1)"
+                  },
+                  "command": {
+                    "title": "Suggest",
+                    "command": "editor.action.triggerSuggest"
+                  }
+                }
+              ],
+              "itemDefaults": {
+                "editRange": {
+                  "start": {
+                    "line": 1,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 22
+                  }
+                }
+              }
+            }
+            """;
+
+    public CssCompletionClientConfigTest() {
+        super("*.css");
+    }
+
+    // SINGLE ARGUMENT TESTS
+
+    // language=json
+    private static final String VAR_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "var()",
+              "kind": 3,
+              "documentation": "Evaluates the value of a custom variable.",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 22
+                  }
+                },
+                "newText": "var($1)"
+              },
+              "command": {
+                "title": "Suggest",
+                "command": "editor.action.triggerSuggest"
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_singleArg() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                // This one doesn't have a variable value, so it'll be placed within the parens
+                """
+                        .selector {
+                            background-color: var(<caret>);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                VAR_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_singleArg() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: var(<caret>);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                VAR_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // MULTIPLE COMMA-DELIMITED ARGUMENTS TESTS
+
+    // language=json
+    private static final String RGB_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "rgb",
+              "kind": 3,
+              "detail": "rgb($red, $green, $blue)",
+              "documentation": "Creates a Color from red, green, and blue values.",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 22
+                  }
+                },
+                "newText": "rgb(${1:red}, ${2:green}, ${3:blue})"
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_multipleArgs_commaDelimited() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: rgb(red, green, blue);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                RGB_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_multipleArgs_commaDelimited() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: rgb(<caret>);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                RGB_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // MULTIPLE SPACE-DELIMITED ARGUMENTS TESTS
+
+    // language=json
+    private static final String HWB_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "hwb",
+              "kind": 3,
+              "detail": "hwb($hue $white $black)",
+              "documentation": "Creates a Color from hue, white, and black values.",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 22
+                  }
+                },
+                "newText": "hwb(${1:hue} ${2:white} ${3:black})"
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_multipleArgs_spaceDelimited() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: hwb(hue white black);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                HWB_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_multipleArgs_spaceDelimited() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: hwb(<caret>);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                HWB_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // COMPLEX ARGUMENT TESTS
+
+    // language=json
+    private static final String COMPLEX_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "color",
+              "kind": 3,
+              "detail": "color($color-space $red $green $blue)",
+              "documentation": "Creates a Color in a specific color space from red, green, and blue values.",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 22
+                  }
+                },
+                "newText": "color(${1|srgb,srgb-linear,display-p3,a98-rgb,prophoto-rgb,rec2020,xyx,xyz-d50,xyz-d65|} ${2:red} ${3:green} ${4:blue})"
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_complex() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: color(srgb red green blue);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                COMPLEX_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_complex() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: color(<caret>);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                COMPLEX_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // NON-ARGUMENT TAB STOP TESTS
+
+    // language=json
+    private static final String NON_ARGUMENT_TAB_STOPS_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "rgb relative",
+              "kind": 3,
+              "detail": "rgb(from $color $red $green $blue)",
+              "documentation": "Creates a Color from the red, green, and blue values of another Color.",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 22
+                  }
+                },
+                "newText": "rgb(from ${1:color} ${2:r} ${3:g} ${4:b})"
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_nonArgumentTabStops() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                """
+                        .selector {
+                            background-color: rgb(from color r g b);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                NON_ARGUMENT_TAB_STOPS_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_nonArgumentTabStops() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                // Because there are arguments outside of the invocation args, the template will be used
+                """
+                        .selector {
+                            background-color: rgb(from color r g b);
+                        }
+                        """,
+                MOCK_TEXT_COMPLETION_JSON,
+                NON_ARGUMENT_TAB_STOPS_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateLoaderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/SnippetTemplateLoaderTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.intellij.codeInsight.template.Template;
+import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionFixtureTestCase;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Tests behavior of {@link SnippetTemplateLoader} via {@link SnippetTemplateFactory}.
+ */
+public class SnippetTemplateLoaderTest extends LSPCompletionFixtureTestCase {
+
+    private static final String END_PLACEHOLDER = "<end>";
+
+    public SnippetTemplateLoaderTest() {
+        super("*.ts");
+    }
+
+    private void assertUseTemplateForInvocationOnlyTemplate(boolean useTemplateForInvocationOnlySnippet,
+                                                            @NotNull String snippet,
+                                                            @NotNull String expectedTemplateText,
+                                                            int expectedVariableCount,
+                                                            int expectedSegmentsCount) {
+        Template template = SnippetTemplateFactory.createTemplate(
+                snippet,
+                myFixture.getProject(),
+                variableName -> variableName,
+                null,
+                useTemplateForInvocationOnlySnippet
+        );
+
+        assertEquals(expectedTemplateText.replace(END_PLACEHOLDER, ""), template.getTemplateText());
+        assertEquals(expectedVariableCount, template.getVariables().size());
+        int segmentsCount = template.getSegmentsCount();
+        assertEquals(expectedSegmentsCount, segmentsCount);
+        assertEquals(Template.END, template.getSegmentName(segmentsCount - 1));
+        assertEquals(expectedTemplateText.indexOf(END_PLACEHOLDER), template.getSegmentOffset(segmentsCount - 1));
+    }
+
+    public void testUseTemplateForInvocationOnlyTemplate_enabled_invocation() {
+        assertUseTemplateForInvocationOnlyTemplate(
+                true,
+                ".pow(${1:x}, ${2:y})$0",
+                ".pow(, )<end>",
+                2,
+                3
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlyTemplate_disabled_invocation() {
+        assertUseTemplateForInvocationOnlyTemplate(
+                false,
+                ".pow(${1:x}, ${2:y})$0",
+                ".pow(<end>)",
+                0,
+                1
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlyTemplate_disabled_invocation_balancedNestedParens() {
+        assertUseTemplateForInvocationOnlyTemplate(
+                false,
+                ".pow(${1:x}, Math.abs(${2:y}))$0",
+                ".pow(<end>)",
+                0,
+                1
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlyTemplate_disabled_invocation_unbalancedNestedParens() {
+        assertUseTemplateForInvocationOnlyTemplate(
+                false,
+                ".pow(${1:x}, Math.abs(${2:y})$0",
+                ".pow(, Math.abs()<end>",
+                2,
+                3
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlyTemplate_disabled_notInvocation() {
+        assertUseTemplateForInvocationOnlyTemplate(
+                false,
+                ".PI$0",
+                ".PI<end>",
+                0,
+                1
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlyTemplate_disabled_invocation_extraVariables() {
+        assertUseTemplateForInvocationOnlyTemplate(
+                false,
+                ".pow(${1:x}, ${2:y}) /* ${3:z} */$0",
+                ".pow(, ) /*  */<end>",
+                3,
+                4
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionClientConfigTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/completion/TypeScriptCompletionClientConfigTest.java
@@ -1,0 +1,379 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.completion;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPCompletionClientConfigFixtureTestCase;
+
+/**
+ * Tests code completion client configuration settings using a mock TypeScript language server.
+ */
+public class TypeScriptCompletionClientConfigTest extends LSPCompletionClientConfigFixtureTestCase {
+
+    private static final String TEST_FILE_NAME = "test.ts";
+    private static final String TEST_FILE_BODY_BEFORE = "Math.<caret>";
+
+    // language=json
+    private static final String MOCK_TEXT_COMPLETION_JSON = """
+            {
+              "isIncomplete": false,
+              "items": [
+                {
+                  "label": "abs",
+                  "kind": 2,
+                  "sortText": "11",
+                  "filterText": ".abs",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 0,
+                        "character": 4
+                      },
+                      "end": {
+                        "line": 0,
+                        "character": 5
+                      }
+                    },
+                    "newText": ".abs"
+                  },
+                  "data": {
+                    "cacheId": 1
+                  }
+                },
+                {
+                  "label": "pow",
+                  "kind": 2,
+                  "sortText": "11",
+                  "filterText": ".pow",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 0,
+                        "character": 4
+                      },
+                      "end": {
+                        "line": 0,
+                        "character": 5
+                      }
+                    },
+                    "newText": ".pow"
+                  },
+                  "data": {
+                    "cacheId": 32
+                  }
+                },
+                {
+                  "label": "random",
+                  "kind": 2,
+                  "sortText": "11",
+                  "filterText": ".random",
+                  "insertTextFormat": 2,
+                  "textEdit": {
+                    "range": {
+                      "start": {
+                        "line": 0,
+                        "character": 4
+                      },
+                      "end": {
+                        "line": 0,
+                        "character": 5
+                      }
+                    },
+                    "newText": ".random"
+                  },
+                  "data": {
+                    "cacheId": 33
+                  }
+                }
+              ]
+            }
+            """;
+
+    public TypeScriptCompletionClientConfigTest() {
+        super("*.ts");
+    }
+
+    // SINGLE ARGUMENT TESTS
+
+    // language=json
+    private static final String ABS_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "abs",
+              "kind": 2,
+              "detail": "(method) Math.abs(x: number): number",
+              "documentation": {
+                "kind": "markdown",
+                "value": "Returns the absolute value of a number (the value without regard to whether it is positive or negative).\\nFor example, the absolute value of -5 is the same as the absolute value of 5.\\n\\n*@param* `x` — A numeric expression for which the absolute value is needed."
+              },
+              "sortText": "11",
+              "filterText": ".abs",
+              "insertText": ".abs(${1:x})$0",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 5
+                  }
+                },
+                "newText": ".abs(${1:x})$0"
+              },
+              "data": {
+                "file": "test.ts",
+                "line": 1,
+                "offset": 6,
+                "entryNames": [
+                  "abs"
+                ]
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_singleArg() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.abs(x)<caret>",
+                MOCK_TEXT_COMPLETION_JSON,
+                ABS_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_singleArg() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.abs(<caret>)",
+                MOCK_TEXT_COMPLETION_JSON,
+                ABS_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // SINGLE ARGUMENT TESTS WITH NO VARIABLE VALUES
+
+    private static final String ABS_NO_VARIABLE_VALUE_MOCK_COMPLETION_ITEM_RESOLVE_JSON = ABS_MOCK_COMPLETION_ITEM_RESOLVE_JSON.replace("${1:x}", "$1");
+
+    public void testUseTemplateForInvocationOnlySnippet_default_singleArg_noVariableValue() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                // Even when disabled, the caret should be placed in the parens because there's no variable value
+                "Math.abs(<caret>)",
+                MOCK_TEXT_COMPLETION_JSON,
+                ABS_NO_VARIABLE_VALUE_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_singleArg_noVariableValue() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.abs(<caret>)",
+                MOCK_TEXT_COMPLETION_JSON,
+                ABS_NO_VARIABLE_VALUE_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // OPTIONAL ARGUMENT TESTS
+
+    private static final String OPTIONAL_ARG_MOCK_COMPLETION_ITEM_RESOLVE_JSON = ABS_MOCK_COMPLETION_ITEM_RESOLVE_JSON.replace("${1:x}", "${1:x}$2");
+
+    public void testUseTemplateForInvocationOnlySnippet_default_optionalArg() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.abs(x)<caret>",
+                MOCK_TEXT_COMPLETION_JSON,
+                OPTIONAL_ARG_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_optionalArg() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.abs(<caret>)",
+                MOCK_TEXT_COMPLETION_JSON,
+                OPTIONAL_ARG_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // MULTIPLE ARGUMENTS TESTS
+
+    // language=json
+    private static final String POW_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "pow",
+              "kind": 2,
+              "detail": "(method) Math.pow(x: number, y: number): number",
+              "documentation": {
+                "kind": "markdown",
+                "value": "Returns the value of a base expression taken to a specified power.\\n\\n*@param* `x` — The base value of the expression.  \\n\\n*@param* `y` — The exponent value of the expression."
+              },
+              "sortText": "11",
+              "filterText": ".pow",
+              "insertText": ".pow(${1:x}, ${2:y})$0",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 5
+                  }
+                },
+                "newText": ".pow(${1:x}, ${2:y})$0"
+              },
+              "data": {
+                "file": "test.ts",
+                "line": 1,
+                "offset": 6,
+                "entryNames": [
+                  "pow"
+                ]
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_multipleArgs() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.pow(x, y)<caret>",
+                MOCK_TEXT_COMPLETION_JSON,
+                POW_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_multipleArgs() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.pow(<caret>)",
+                MOCK_TEXT_COMPLETION_JSON,
+                POW_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // NO ARGUMENTS TESTS
+
+    // language=json
+    private static final String RANDOM_MOCK_COMPLETION_ITEM_RESOLVE_JSON = """
+            {
+              "label": "random",
+              "kind": 2,
+              "detail": "(method) Math.random(): number",
+              "documentation": {
+                "kind": "markdown",
+                "value": "Returns a pseudorandom number between 0 and 1."
+              },
+              "sortText": "11",
+              "filterText": ".random",
+              "insertText": ".random()$0",
+              "insertTextFormat": 2,
+              "textEdit": {
+                "range": {
+                  "start": {
+                    "line": 0,
+                    "character": 4
+                  },
+                  "end": {
+                    "line": 0,
+                    "character": 5
+                  }
+                },
+                "newText": ".random()$0"
+              },
+              "data": {
+                "file": "test.ts",
+                "line": 1,
+                "offset": 6,
+                "entryNames": [
+                  "random"
+                ]
+              }
+            }
+            """;
+
+    public void testUseTemplateForInvocationOnlySnippet_default_noArgs() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                // Because this has no arguments, no template will be used and the caret will be placed outside of the argument list
+                "Math.random()<caret>",
+                MOCK_TEXT_COMPLETION_JSON,
+                RANDOM_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_noArgs() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                // Because this has no arguments, no template will be used and the caret will be placed outside of the argument list
+                "Math.random()<caret>",
+                MOCK_TEXT_COMPLETION_JSON,
+                RANDOM_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+
+    // NON-ARGUMENT TAB STOP TESTS
+
+    private static final String NON_ARGUMENT_TAB_STOPS_MOCK_COMPLETION_ITEM_RESOLVE_JSON = POW_MOCK_COMPLETION_ITEM_RESOLVE_JSON.replace("$0", " /* Enter text ${3:here} */$0");
+
+    public void testUseTemplateForInvocationOnlySnippet_default_nonArgumentTabStops() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                "Math.pow(x, y) /* Enter text here */<caret>",
+                MOCK_TEXT_COMPLETION_JSON,
+                NON_ARGUMENT_TAB_STOPS_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                // Default config
+                null
+        );
+    }
+
+    public void testUseTemplateForInvocationOnlySnippet_disabled_nonArgumentTabStops() {
+        assertTemplateForArguments(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY_BEFORE,
+                // Because there are arguments outside of the invocation args, the template will be used
+                "Math.pow(x, y) /* Enter text here */<caret>",
+                MOCK_TEXT_COMPLETION_JSON,
+                NON_ARGUMENT_TAB_STOPS_MOCK_COMPLETION_ITEM_RESOLVE_JSON,
+                clientConfig -> clientConfig.completion.useTemplateForInvocationOnlySnippet = false
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionClientConfigFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionClientConfigFixtureTestCase.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.fixtures;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.editor.CaretModel;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.ArrayUtil;
+import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
+import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+import com.redhat.devtools.lsp4ij.server.definition.ClientConfigurableLanguageServerDefinition;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
+import com.redhat.devtools.lsp4ij.server.definition.launching.ClientConfigurationSettings;
+import com.redhat.devtools.lsp4ij.server.definition.launching.UserDefinedCompletionFeature;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionOptions;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Base class test case for client-side on-type formatting tests by emulating LSP 'textDocument/selectionRange',
+ * 'textDocument/foldingRange', and 'textDocument/rangeFormatting' responses from the typescript-language-server.
+ */
+public abstract class LSPCompletionClientConfigFixtureTestCase extends LSPCodeInsightFixtureTestCase {
+
+    private static final String CARET = "<caret>";
+
+    public LSPCompletionClientConfigFixtureTestCase(String... fileNamePatterns) {
+        super(fileNamePatterns);
+    }
+
+    /**
+     * Asserts that <code>fileBodyBefore</code> is transformed into <code>fileBodyAfter</code> when triggering and
+     * accepting the first completion. <code>fileBodyBefore</code> should include a <code>&lt;caret&gt;</code>
+     * placeholder for where completion should be triggered, and <code>fileBodyAfter</code> should include either
+     * a <code>&lt;template&gt;</code> placeholder or a <code>&lt;caret&gt;</code> placeholder based on whether or
+     * not a template or just the caret is expected at the offset corresponding to that placeholder.
+     *
+     * @param fileName                      the file name
+     * @param fileBodyBefore                the file body before including the embedded typing imperative comment
+     * @param fileBodyAfter                 the file body after the character has been typed and formatting applied
+     * @param mockTextCompletionJson        the mock text/completion JSON response
+     * @param mockCompletionItemResolveJson the mock completionItem/resolve JSON response
+     * @param clientConfigCustomizer        a function that allows the caller to customize the client configuration as
+     *                                      needed for the test scenario
+     */
+    protected void assertTemplateForArguments(@NotNull String fileName,
+                                              @NotNull String fileBodyBefore,
+                                              @NotNull String fileBodyAfter,
+                                              @NotNull String mockTextCompletionJson,
+                                              @NotNull String mockCompletionItemResolveJson,
+                                              @Nullable Consumer<ClientConfigurationSettings> clientConfigCustomizer) {
+        MockLanguageServer.INSTANCE.setTimeToProceedQueries(200);
+
+        CompletionList mockCompletionList = JSONUtils.getLsp4jGson().fromJson(mockTextCompletionJson, CompletionList.class);
+        MockLanguageServer.INSTANCE.setCompletionList(mockCompletionList);
+
+        CompletionItem mockCompletionItem = JSONUtils.getLsp4jGson().fromJson(mockCompletionItemResolveJson, CompletionItem.class);
+        MockLanguageServer.INSTANCE.setCompletionItem(mockCompletionItem);
+
+        Project project = myFixture.getProject();
+        PsiFile file = myFixture.configureByText(fileName, removeCaret(fileBodyBefore));
+        Editor editor = myFixture.getEditor();
+        CaretModel caretModel = editor.getCaretModel();
+
+        // Initialize the language server
+        List<LanguageServerItem> languageServers = new LinkedList<>();
+        try {
+            ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
+                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .get(5000, TimeUnit.MILLISECONDS));
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        // Configure the language server's completion client configuration
+        LanguageServerItem languageServer = ContainerUtil.getFirstItem(languageServers);
+        assertNotNull(languageServer);
+
+        // Use a configurable completion feature
+        LSPClientFeatures clientFeatures = languageServer.getClientFeatures();
+        clientFeatures.setCompletionFeature(new UserDefinedCompletionFeature());
+
+        // Enable completion item resolution
+        languageServer.getServerCapabilities().setCompletionProvider(new CompletionOptions(true, null));
+
+        // Update client configuration as required for this test scenario
+        if (clientConfigCustomizer != null) {
+            LanguageServerDefinition languageServerDefinition = languageServer.getServerDefinition();
+            assertInstanceOf(languageServerDefinition, ClientConfigurableLanguageServerDefinition.class);
+            ClientConfigurableLanguageServerDefinition configurableLanguageServerDefinition = (ClientConfigurableLanguageServerDefinition) languageServerDefinition;
+            ClientConfigurationSettings clientConfiguration = configurableLanguageServerDefinition.getLanguageServerClientConfiguration();
+            assertNotNull(clientConfiguration);
+            clientConfigCustomizer.accept(clientConfiguration);
+        }
+
+        // Move to the offset at which completion should be triggered
+        int completionTriggerOffset = caretOffset(fileBodyBefore);
+        assertTrue(completionTriggerOffset > -1);
+        caretModel.moveToOffset(completionTriggerOffset);
+
+        // Trigger completion
+        LookupElement[] lookupElements = myFixture.completeBasic();
+        assertFalse(ArrayUtil.isEmpty(lookupElements));
+
+        // Find the completion which should be selected
+        LookupElement lookupElement = ContainerUtil.find(
+                lookupElements,
+                lookupElementCandidate -> mockCompletionItem.getLabel().equals(lookupElementCandidate.getLookupString())
+        );
+        assertNotNull(lookupElement);
+
+        // Select the completion
+        myFixture.selectItem(lookupElement);
+
+        // Confirm that the file body has been reformatted as expected
+        assertEquals(removeCaret(fileBodyAfter), editor.getDocument().getText());
+
+        // And if a final caret was specified, confirm it
+        int caretOffset = caretOffset(fileBodyAfter);
+        if (caretOffset > -1) {
+            assertEquals(caretOffset, caretModel.getOffset());
+        }
+    }
+
+    @NotNull
+    private static String removeCaret(@NotNull String fileBody) {
+        return fileBody.replace(CARET, "");
+    }
+
+    private static int caretOffset(@NotNull String fileBody) {
+        return fileBody.indexOf(CARET);
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
@@ -162,6 +162,10 @@ public final class MockLanguageServer implements LanguageServer {
 		this.textDocumentService.setMockCompletionList(completionList);
 	}
 
+	public void setCompletionItem(CompletionItem completionItem) {
+		this.textDocumentService.setMockCompletionItem(completionItem);
+	}
+
 	public void setSemanticTokens(SemanticTokens semanticTokens) {
 		this.textDocumentService.setSemanticTokens(semanticTokens);
 	}

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServerDefinition.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServerDefinition.java
@@ -12,15 +12,20 @@ package com.redhat.devtools.lsp4ij.mock;
 
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
+import com.redhat.devtools.lsp4ij.server.definition.ClientConfigurableLanguageServerDefinition;
 import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
+import com.redhat.devtools.lsp4ij.server.definition.launching.ClientConfigurationSettings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link LanguageServerDefinition} implementation to register the mock language server.
  */
-public class MockLanguageServerDefinition extends LanguageServerDefinition {
+public class MockLanguageServerDefinition extends LanguageServerDefinition implements ClientConfigurableLanguageServerDefinition {
 
     private static final String SERVER_ID = "mock-server-id";
+
+    private final ClientConfigurationSettings clientConfigurationSettings = new ClientConfigurationSettings();
 
     public MockLanguageServerDefinition() {
         this(SERVER_ID);
@@ -33,5 +38,11 @@ public class MockLanguageServerDefinition extends LanguageServerDefinition {
     @Override
     public @NotNull StreamConnectionProvider createConnectionProvider(@NotNull Project project) {
         return new MockConnectionProvider();
+    }
+
+    @Override
+    @Nullable
+    public ClientConfigurationSettings getLanguageServerClientConfiguration() {
+        return clientConfigurationSettings;
     }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
 public class MockTextDocumentService implements TextDocumentService {
 
     private CompletionList mockCompletionList;
+    private CompletionItem mockCompletionItem;
     private Hover mockHover;
     private List<? extends Location> mockDefinitionLocations;
     private List<? extends LocationLink> mockTypeDefinitions;
@@ -67,10 +68,11 @@ public class MockTextDocumentService implements TextDocumentService {
 
     public <U> MockTextDocumentService(Function<U, CompletableFuture<U>> futureFactory) {
         this._futureFactory = futureFactory;
-        // Some default values for mocks, can be overriden
+        // Some default values for mocks, can be overridden
         CompletionItem item = new CompletionItem();
         item.setLabel("Mock completion item");
         mockCompletionList = new CompletionList(false, Collections.singletonList(item));
+        mockCompletionItem = null;
         mockHover = new Hover(Collections.singletonList(Either.forLeft("Mock hover")), null);
         this.remoteProxies = new ArrayList<>();
         this.documentSymbols = Collections.emptyList();
@@ -88,7 +90,7 @@ public class MockTextDocumentService implements TextDocumentService {
 
     @Override
     public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
-        return CompletableFuture.completedFuture(null);
+        return CompletableFuture.completedFuture(mockCompletionItem);
     }
 
     @Override
@@ -267,6 +269,10 @@ public class MockTextDocumentService implements TextDocumentService {
         this.mockCompletionList = completionList;
     }
 
+    public void setMockCompletionItem(CompletionItem mockCompletionItem) {
+        this.mockCompletionItem = mockCompletionItem;
+    }
+
     public void setDidOpenCallback(CompletableFuture<DidOpenTextDocumentParams> didOpenExpectation) {
         this.didOpenCallback = didOpenExpectation;
     }
@@ -309,6 +315,7 @@ public class MockTextDocumentService implements TextDocumentService {
 
     public void reset() {
         this.mockCompletionList = new CompletionList();
+        this.mockCompletionItem = null;
         this.mockDefinitionLocations = Collections.emptyList();
         this.mockTypeDefinitions = Collections.emptyList();
         this.mockHover = null;


### PR DESCRIPTION
This is a fresh branch-based PR as a replacmeent for #738.

As stated/shown in #718, the editor template that is currently started when accepting a code completion that is a method/function invocation ~~with a single argument~~ is quite disruptive to the standard editor flow. ~~This PR adds a new client configuration option, `completion.useTemplateForSingleArgument`, that, when disabled (enabled by default for backward-compatibility), instead just places the caret into the invocation arguments so that the user can populate them as they would in any of JetBrains' natively-supported language editors. I've also updated all existing language server definition templates to disable editor templates in this case so that the "default" behavior for newly-created language server definitions is the smoother/more natural editor flow, but existing language server definitions will not see a change in behavior.~~

**UPDATE:** This has now been generalized to allow disabling editor templates for _any_ invocation-only snippet. An invocation-only snippet is one where all non-end (`$0`) variables are found as a comma-/whitespace-delimited list in invocation parentheses. If other invocation patterns are found in LSP languages, recognition support can be added for them as well.

The configuration option is now `completion.useTemplateForInvocationOnlySnippet` to reflect this more general behavior. As before, it is disabled by default in code but enabled by default in the bundled language server templates.

This also properly handles the situation of a single no-value variable snippet by forgoing an editor template and moving to the correct caret position for that variable with no need for any client config change.