### PR TITLE
test: provide code action cancellation tests

### DIFF
--- a/src/test/java/com/redhat/devtools/lsp4ij/features/codeAction/CancelledCodeActionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/codeAction/CancelledCodeActionTest.java
@@ -1,0 +1,39 @@
+package com.redhat.devtools.lsp4ij.features.codeAction;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPCodeInsightFixtureTestCase;
+import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Test class for simulating the cancellation of a 'jakarta/java/codeAction' request.
+ * Includes a test case where the language server cancels the request
+ */
+public final class CancelledCodeActionTest extends LSPCodeInsightFixtureTestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        MockLanguageServer.reset();
+    }
+
+    /**
+     * Test case that simulates the cancellation of the 'jakarta/java/codeAction' request
+     * and checks that no quick fix is available as a result.
+     */
+    public void testQuickFixCancellation() {
+        MockLanguageServer.INSTANCE.getTextDocumentService().setCodeActionProvider((CodeActionParams params) -> {
+            CompletableFuture<List<Either<Command, CodeAction>>> future = new CompletableFuture<>();
+            future.completeExceptionally(new CancellationException("Request was canceled"));
+            return future;
+        });
+        CompletableFuture<List<Either<Command, CodeAction>>> actions = MockLanguageServer.INSTANCE.getTextDocumentService().getCodeActions(new CodeActionParams());
+        assertTrue("Code action should be cancelled", actions.isCompletedExceptionally());
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/codeAction/CancelledCodeActionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/codeAction/CancelledCodeActionTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ ******************************************************************************/
 package com.redhat.devtools.lsp4ij.features.codeAction;
 
 import com.redhat.devtools.lsp4ij.fixtures.LSPCodeInsightFixtureTestCase;

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/codeAction/CancelledCodeActionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/codeAction/CancelledCodeActionTest.java
@@ -9,14 +9,17 @@ package com.redhat.devtools.lsp4ij.features.codeAction;
 
 import com.redhat.devtools.lsp4ij.fixtures.LSPCodeInsightFixtureTestCase;
 import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+import com.redhat.devtools.lsp4ij.mock.MockTextDocumentService;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Test class for simulating the cancellation of a 'jakarta/java/codeAction' request.
@@ -30,17 +33,28 @@ public final class CancelledCodeActionTest extends LSPCodeInsightFixtureTestCase
         MockLanguageServer.reset();
     }
 
-    /**
-     * Test case that simulates the cancellation of the 'jakarta/java/codeAction' request
-     * and checks that no quick fix is available as a result.
-     */
-    public void testQuickFixCancellation() {
-        MockLanguageServer.INSTANCE.getTextDocumentService().setCodeActionProvider((CodeActionParams params) -> {
-            CompletableFuture<List<Either<Command, CodeAction>>> future = new CompletableFuture<>();
-            future.completeExceptionally(new CancellationException("Request was canceled"));
-            return future;
-        });
-        CompletableFuture<List<Either<Command, CodeAction>>> actions = MockLanguageServer.INSTANCE.getTextDocumentService().getCodeActions(new CodeActionParams());
-        assertTrue("Code action should be cancelled", actions.isCompletedExceptionally());
+    public void testCodeActionCancellation() {
+        Function<List<Either<Command, CodeAction>>, CompletableFuture<List<Either<Command, CodeAction>>>> futureFactory = (input) -> {
+            if (input == null) {
+                CompletableFuture<List<Either<Command, CodeAction>>> future = new CompletableFuture<>();
+                future.cancel(true);
+                return future;
+            }
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        };
+
+        MockTextDocumentService service = new MockTextDocumentService(futureFactory);
+
+        CompletableFuture<List<Either<Command, CodeAction>>> firstRequest = service.codeAction(new CodeActionParams());
+        CompletableFuture<List<Either<Command, CodeAction>>> secondRequest = service.codeAction(new CodeActionParams());
+
+        assertTrue("First request should be cancelled", firstRequest.isCancelled());
+
+        try {
+            List<Either<Command, CodeAction>> result = secondRequest.get(6, TimeUnit.SECONDS);
+            assertNotNull("Second request should return a result", result);
+        } catch (Exception e) {
+            fail("Second request should not fail: " + e.getMessage());
+        }
     }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2025 Rogue Wave Software Inc. and others.
+ * Copyright (c) 2016, 2022 Rogue Wave Software Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Rogue Wave Software Inc. and others.
+ * Copyright (c) 2016, 2025 Rogue Wave Software Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
@@ -64,7 +64,6 @@ public class MockTextDocumentService implements TextDocumentService {
     private SemanticTokens mockSemanticTokens;
     private List<FoldingRange> foldingRanges;
     public int codeActionRequests = 0;
-    private Function<CodeActionParams, CompletableFuture<List<Either<Command, CodeAction>>>> codeActionProvider;
 
     private volatile CompletableFuture<List<Either<Command, CodeAction>>> currentCodeActionFuture;
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
@@ -447,11 +446,4 @@ public class MockTextDocumentService implements TextDocumentService {
         return CompletableFuture.completedFuture(this.foldingRanges);
     }
 
-    public void setCodeActionProvider(Function<CodeActionParams, CompletableFuture<List<Either<Command, CodeAction>>>> provider) {
-        this.codeActionProvider = provider;
-    }
-
-    public CompletableFuture<List<Either<Command, CodeAction>>> getCodeActions(CodeActionParams params) {
-        return codeAction(params);
-    }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Rogue Wave Software Inc. and others.
+ * Copyright (c) 2017, 2025 Rogue Wave Software Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
@@ -65,6 +65,7 @@ public class MockTextDocumentService implements TextDocumentService {
     private SemanticTokens mockSemanticTokens;
     private List<FoldingRange> foldingRanges;
     public int codeActionRequests = 0;
+    private Function<CodeActionParams, CompletableFuture<List<Either<Command, CodeAction>>>> codeActionProvider;
 
     public <U> MockTextDocumentService(Function<U, CompletableFuture<U>> futureFactory) {
         this._futureFactory = futureFactory;
@@ -144,6 +145,9 @@ public class MockTextDocumentService implements TextDocumentService {
     @Override
     public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
         codeActionRequests++;
+        if (codeActionProvider != null) {
+            return (CompletableFuture<List<Either<Command, CodeAction>>>) codeActionProvider.apply(params);
+        }
         return futureFactory(this.mockCodeActions);
     }
 
@@ -428,4 +432,11 @@ public class MockTextDocumentService implements TextDocumentService {
         return CompletableFuture.completedFuture(this.foldingRanges);
     }
 
+    public void setCodeActionProvider(Function<CodeActionParams, CompletableFuture<List<Either<Command, CodeAction>>>> provider) {
+        this.codeActionProvider = provider;
+    }
+
+    public CompletableFuture<List<Either<Command, CodeAction>>> getCodeActions(CodeActionParams params) {
+        return codeAction(params);
+    }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
@@ -68,7 +68,6 @@ public class MockTextDocumentService implements TextDocumentService {
     private volatile CompletableFuture<List<Either<Command, CodeAction>>> currentCodeActionFuture;
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
-
     public <U> MockTextDocumentService(Function<U, CompletableFuture<U>> futureFactory) {
         this._futureFactory = futureFactory;
         // Some default values for mocks, can be overridden


### PR DESCRIPTION
This test emulates the language server and cancels the request. 

This PR corresponds to the ticket https://github.com/OpenLiberty/liberty-tools-intellij/issues/1072