### PR TITLE
feat: provide UI to define DAP descriptor factory

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
@@ -348,8 +348,8 @@ public class LanguageServersRegistry {
         }
     }
 
-
-    private void addServerDefinitionWithoutNotification(@NotNull LanguageServerDefinition serverDefinition, @NotNull List<ServerMapping> mappings) {
+    private void addServerDefinitionWithoutNotification(@NotNull LanguageServerDefinition serverDefinition,
+                                                        @NotNull List<ServerMapping> mappings) {
         String languageServerId = serverDefinition.getId();
         serverDefinitions.put(languageServerId, serverDefinition);
         // Update associations

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPServerMappingsPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPServerMappingsPanel.java
@@ -14,7 +14,6 @@ import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.util.ui.FormBuilder;
 import com.redhat.devtools.lsp4ij.dap.DAPBundle;
-import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAdapterDescriptorFactory;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
 import com.redhat.devtools.lsp4ij.settings.ui.FileNamePatternServerMappingTablePanel;
@@ -81,11 +80,13 @@ public class DAPServerMappingsPanel {
     /**
      * Refresh the language, file type, file name pattern mappings defined by the DAP factory.
      *
-     * @param dapFactory the DAP factory.
+     * @param languageMappings language mappings.
+     * @param allFileTypeMappings file type and pattern mappings.
      */
-    public void refreshMappings(UserDefinedDebugAdapterDescriptorFactory dapFactory) {
+    public void refreshMappings(@NotNull List<ServerMappingSettings> languageMappings,
+                                @NotNull List<ServerMappingSettings> allFileTypeMappings) {
         // refresh language mappings list
-        setLanguageMappings(dapFactory.getLanguageMappings());
+        setLanguageMappings(languageMappings);
 
         // refresh file type mappings
         List<ServerMappingSettings> fileTypeMappings = new ArrayList<>();
@@ -104,7 +105,7 @@ public class DAPServerMappingsPanel {
         // Collect them by following this strategy:
         // - case 1: if fileType can be retrieved by the name, create a fileType mapping.
         // - case 2: if fileType cannot be retrieved, create file name pattern mapping.
-        for (var mapping : dapFactory.getFileTypeMappings()) {
+        for (var mapping : allFileTypeMappings) {
             boolean add = false;
             String fileType = mapping.getFileType();
             if (!StringUtils.isEmpty(fileType)) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPSettingsEditor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPSettingsEditor.java
@@ -10,33 +10,14 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.dap.configurations;
 
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.ComboBox;
-import com.intellij.openapi.ui.TextFieldWithBrowseButton;
-import com.intellij.ui.SimpleListCellRenderer;
-import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.util.ui.FormBuilder;
-import com.intellij.util.ui.components.BorderLayoutPanel;
-import com.redhat.devtools.lsp4ij.dap.DAPBundle;
-import com.redhat.devtools.lsp4ij.dap.DebuggingType;
-import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory;
-import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterManager;
-import com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplate;
-import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAdapterDescriptorFactory;
-import com.redhat.devtools.lsp4ij.internal.StringUtils;
-import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
-import com.redhat.devtools.lsp4ij.settings.ServerTrace;
-import com.redhat.devtools.lsp4ij.settings.ui.JsonTextField;
+import com.redhat.devtools.lsp4ij.dap.settings.ui.DebugAdapterDescriptorFactoryPanel;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Debug Adapter Protocol (DAP) settings editor.
@@ -45,285 +26,64 @@ public class DAPSettingsEditor extends SettingsEditor<DAPRunConfiguration> {
 
     private final JPanel myPanel;
     private final @NotNull Project project;
-
-    private final JBTabbedPane mainTabbedPane;
-
-    // Program settings
-    private TextFieldWithBrowseButton workingDirectoryField;
-    private TextFieldWithBrowseButton fileField;
-
-    // DAP server settings
-    private ComboBox<DebugAdapterDescriptorFactory> serverFactoryCombo;
-    private JTextField serverNameField;
-    private TextFieldWithBrowseButton commandField;
-    private DAPConnectingServerConfigurationPanel connectingServerConfigurationPanel;
-    private ComboBox<ServerTrace> serverTraceComboBox;
-
-    private JBTabbedPane parametersTabbedPane;
-    private JRadioButton launchRadioButton;
-    private JRadioButton attachRadioButton;
-    private JsonTextField launchParametersField;
-    private JsonTextField attachParametersField;
-
-    // DAP file mappings
-    private DAPServerMappingsPanel mappingsPanel;
-
-    private DAPTemplate currentTemplate;
-    private DebugAdapterDescriptorFactory currentServerFactory;
-    private boolean initialized;
+    private final DebugAdapterDescriptorFactoryPanel dapPanel;
 
     public DAPSettingsEditor(@NotNull Project project) {
         this.project = project;
         FormBuilder builder = FormBuilder
                 .createFormBuilder();
-
-        mainTabbedPane = new JBTabbedPane();
-        builder.addComponentFillVertically(mainTabbedPane, 0);
-
-        // Configuration tab
-        addConfigurationTab(mainTabbedPane);
-        // Mappings tab
-        addMappingsTab(mainTabbedPane, builder);
-        // Server tab
-        addServerTab(mainTabbedPane, builder);
-
+        dapPanel = new DebugAdapterDescriptorFactoryPanel(builder,
+                null,
+                DebugAdapterDescriptorFactoryPanel.EditionMode.EDIT_USER_DEFINED,
+                true,
+                project);
         myPanel = new JPanel(new BorderLayout());
         myPanel.add(builder.getPanel(), BorderLayout.CENTER);
     }
 
-    private void addConfigurationTab(JBTabbedPane tabbedPane) {
-        FormBuilder configurationTab = addTab(tabbedPane, DAPBundle.message("dap.settings.editor.configuration.tab"));
-
-        workingDirectoryField = new TextFieldWithBrowseButton();
-        workingDirectoryField.addBrowseFolderListener(null, null, getProject(), FileChooserDescriptorFactory.createSingleFolderDescriptor());
-        configurationTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.configuration.cwd.field"), workingDirectoryField);
-
-        fileField = new TextFieldWithBrowseButton();
-        fileField.addBrowseFolderListener(null, null, getProject(), FileChooserDescriptorFactory.createSingleFileDescriptor());
-        configurationTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.configuration.file.field"), fileField);
-
-        ButtonGroup buttonGroup = new ButtonGroup();
-        launchRadioButton = new JRadioButton(DAPBundle.message("dap.settings.editor.configuration.debugging.launch.type"));
-        buttonGroup.add(launchRadioButton);
-        attachRadioButton = new JRadioButton(DAPBundle.message("dap.settings.editor.configuration.debugging.attach.type"));
-        buttonGroup.add(attachRadioButton);
-
-        JPanel radioPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
-        radioPanel.add(launchRadioButton);
-        radioPanel.add(attachRadioButton);
-        configurationTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.configuration.debugging.type.field"), radioPanel);
-
-        parametersTabbedPane = new JBTabbedPane();
-        launchRadioButton.addActionListener(event -> {
-            selectLaunchDebuggingType();
-        });
-        attachRadioButton.addActionListener(event -> {
-            selectAttachDebuggingType();
-        });
-
-        // Launch / Attach DAP parameters
-        configurationTab.addComponentFillVertically(parametersTabbedPane, 0);
-
-        FormBuilder launchTab = addTab(parametersTabbedPane, DAPBundle.message("dap.settings.editor.configuration.parameters.launch.tab"));
-        launchParametersField = new JsonTextField(project);
-        launchTab.addLabeledComponentFillVertically(DAPBundle.message("dap.settings.editor.configuration.parameters.field"), launchParametersField);
-        FormBuilder attachTab = addTab(parametersTabbedPane, DAPBundle.message("dap.settings.editor.configuration.parameters.attach.tab"));
-        attachParametersField = new JsonTextField(project);
-        attachTab.addLabeledComponentFillVertically(DAPBundle.message("dap.settings.editor.configuration.parameters.field"), attachParametersField);
-
-    }
-
-    private void addMappingsTab(JBTabbedPane tabbedPane, FormBuilder builder) {
-        FormBuilder mappingsTab = addTab(tabbedPane, DAPBundle.message("dap.settings.editor.mappings.tab"));
-        this.mappingsPanel = new DAPServerMappingsPanel(mappingsTab, true);
-    }
-
-    private void addServerTab(@NotNull JBTabbedPane tabbedPane,
-                              @NotNull FormBuilder builder) {
-        FormBuilder serverTab = addTab(tabbedPane, DAPBundle.message("dap.settings.editor.server.tab"));
-
-        serverFactoryCombo = new ComboBox<>(new DefaultComboBoxModel<>(getDapServerFactories()));
-        serverFactoryCombo.setRenderer(new SimpleListCellRenderer<>() {
-            @Override
-            public void customize(@NotNull JList list,
-                                  @Nullable DebugAdapterDescriptorFactory serverFactory,
-                                  int index,
-                                  boolean selected,
-                                  boolean hasFocus) {
-                if (serverFactory == null) {
-                    setText("");
-                } else {
-                    setText(serverFactory.getName());
-                }
-            }
-        });
-
-        serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.factory.field"), serverFactoryCombo);
-
-        serverNameField = new JTextField();
-        serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.name.field"), serverNameField);
-
-        commandField = new TextFieldWithBrowseButton();
-        commandField.addBrowseFolderListener(null, null, getProject(),
-                FileChooserDescriptorFactory.createSingleFileDescriptor());
-        serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.command.field"), commandField);
-
-        // Connecting server configuration
-        connectingServerConfigurationPanel = new DAPConnectingServerConfigurationPanel();
-        serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.connecting.strategy.label"), connectingServerConfigurationPanel, true);
-
-        serverTraceComboBox = new ComboBox<>(new DefaultComboBoxModel<>(ServerTrace.values()));
-        serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.serverTrace.field"), serverTraceComboBox);
-    }
-
-    private static DebugAdapterDescriptorFactory[] getDapServerFactories() {
-        List<DebugAdapterDescriptorFactory> templates = new ArrayList<>();
-        templates.add(DebugAdapterDescriptorFactory.NONE);
-        templates.addAll(DebugAdapterManager.getInstance().getFactories());
-        return templates.toArray(new DebugAdapterDescriptorFactory[0]);
-    }
-
-    private void selectAttachDebuggingType() {
-        attachRadioButton.setSelected(true);
-        parametersTabbedPane.setSelectedIndex(1);
-    }
-
-    private void selectLaunchDebuggingType() {
-        launchRadioButton.setSelected(true);
-        parametersTabbedPane.setSelectedIndex(0);
-    }
-
-    private void loadFromDapFactory(@NotNull UserDefinedDebugAdapterDescriptorFactory dapFactory) {
-        // Update name
-        serverNameField.setText(dapFactory.getName() != null ? dapFactory.getName() : "");
-
-        // Update wait for trace
-        connectingServerConfigurationPanel.update(null,
-                getInt(dapFactory.getWaitForTimeout()),
-                dapFactory.getWaitForTrace());
-
-        // Update command
-        String command = getCommandLine(dapFactory);
-        commandField.setText(command);
-
-        // Update mappings
-        mappingsPanel.refreshMappings(dapFactory);
-
-        // Update DAP parameters
-        launchParametersField.setText(dapFactory.getLaunchConfiguration() != null ? dapFactory.getLaunchConfiguration() : "");
-        launchParametersField.setCaretPosition(0);
-        attachParametersField.setText(dapFactory.getAttachConfiguration() != null ? dapFactory.getAttachConfiguration() : "");
-        attachParametersField.setCaretPosition(0);
-    }
-
-    private static String getCommandLine(UserDefinedDebugAdapterDescriptorFactory entry) {
-        StringBuilder command = new StringBuilder();
-        if (entry.getCommandLine() != null) {
-            if (!command.isEmpty()) {
-                command.append(' ');
-            }
-            command.append(entry.getCommandLine());
-        }
-        return command.toString();
-    }
-
-
     @Override
     protected void resetEditorFrom(DAPRunConfiguration runConfiguration) {
-        // Configuration settings
-        workingDirectoryField.setText(runConfiguration.getWorkingDirectory());
-        fileField.setText(runConfiguration.getFile());
-        boolean launchType = runConfiguration.getDebuggingType() == DebuggingType.LAUNCH;
-        if (launchType) {
-            selectLaunchDebuggingType();
-        } else {
-            selectAttachDebuggingType();
-        }
-        launchParametersField.setText(runConfiguration.getLaunchParameters());
-        attachParametersField.setText(runConfiguration.getAttachParameters());
-
-        // Mappings settings
-        List<ServerMappingSettings> languageMappings = runConfiguration.getServerMappings()
-                .stream()
-                .filter(mapping -> !StringUtils.isEmpty(mapping.getLanguage()))
-                .collect(Collectors.toList());
-        mappingsPanel.setLanguageMappings(languageMappings);
-
-        List<ServerMappingSettings> fileTypeMappings = runConfiguration.getServerMappings()
-                .stream()
-                .filter(mapping -> !StringUtils.isEmpty(mapping.getFileType()))
-                .collect(Collectors.toList());
-        mappingsPanel.setFileTypeMappings(fileTypeMappings);
-
-        List<ServerMappingSettings> fileNamePatternMappings = runConfiguration.getServerMappings()
-                .stream()
-                .filter(mapping -> mapping.getFileNamePatterns() != null)
-                .collect(Collectors.toList());
-        mappingsPanel.setFileNamePatternMappings(fileNamePatternMappings);
-
         // Sever settings
-        String serverId = runConfiguration.getServerId();
-        if (StringUtils.isNotBlank(serverId)) {
-            DebugAdapterDescriptorFactory factory = DebugAdapterManager.getInstance().getFactoryById(serverId);
-            if (factory != null) {
-                currentServerFactory = factory;
-                serverFactoryCombo.setSelectedItem(factory);
-            }
-        }
-        serverNameField.setText(runConfiguration.getServerName());
-        commandField.setText(runConfiguration.getCommand());
-        connectingServerConfigurationPanel.update(runConfiguration.getConnectingServerStrategy(),
+        dapPanel.setServerName(runConfiguration.getServerName());
+        dapPanel.setCommandLine(runConfiguration.getCommand());
+        dapPanel.updateConnectingStrategy(runConfiguration.getConnectingServerStrategy(),
                 runConfiguration.getWaitForTimeout(),
                 runConfiguration.getWaitForTrace());
-        serverTraceComboBox.setSelectedItem(runConfiguration.getServerTrace());
+        dapPanel.setServerTrace(runConfiguration.getServerTrace());
 
-        // If DAP server is not configured, select 'Server' tab
-        if (!initialized) {
-            initializeEditor(runConfiguration);
-        }
-        initialized = true;
-    }
+        // Mappings settings
+        dapPanel.setMappings(runConfiguration.getServerMappings());
 
-    private void initializeEditor(DAPRunConfiguration runConfiguration) {
-        // Add Listener when server is selected, it must update Configuration / Mappings and Server tabs
-        serverFactoryCombo.addItemListener(e -> {
-            currentServerFactory = (DebugAdapterDescriptorFactory) e.getItem();
-            if (currentServerFactory instanceof UserDefinedDebugAdapterDescriptorFactory dapFactory) {
-                if (dapFactory != UserDefinedDebugAdapterDescriptorFactory.NONE) {
-                    loadFromDapFactory(dapFactory);
-                }
-            }
-        });
-        // If DAP server is not configured, the Server tab must be selected
-        String serverId = runConfiguration.getServerId();
-        if (StringUtils.isEmpty(serverId) && commandField.getText().isEmpty()) {
-            mainTabbedPane.setSelectedIndex(2);
-        }
+        // Configuration settings
+        dapPanel.setWorkingDirectory(runConfiguration.getWorkingDirectory());
+        dapPanel.setFile(runConfiguration.getFile());
+        dapPanel.setDebuggingType(runConfiguration.getDebuggingType());
+        dapPanel.setLaunchConfiguration(runConfiguration.getLaunchParameters());
+        dapPanel.setAttachConfiguration(runConfiguration.getAttachParameters());
+
+        // Update server if at and to update tabs if needed
+        dapPanel.setServerId(runConfiguration.getServerId());
     }
 
     @Override
     protected void applyEditorTo(@NotNull DAPRunConfiguration runConfiguration) {
-        // Configuration settings
-        runConfiguration.setWorkingDirectory(workingDirectoryField.getText());
-        runConfiguration.setFile(fileField.getText());
-        runConfiguration.setDebuggingType(attachRadioButton.isSelected() ? DebuggingType.ATTACH : DebuggingType.LAUNCH);
-        runConfiguration.setLaunchParameters(launchParametersField.getText());
-        runConfiguration.setAttachParameters(attachParametersField.getText());
+        // Sever settings
+        runConfiguration.setServerName(dapPanel.getServerName());
+        runConfiguration.setCommand(dapPanel.getCommandLine());
+        runConfiguration.setConnectingServerStrategy(dapPanel.getConnectingServerConfigurationPanel().getConnectingServerStrategy());
+        runConfiguration.setWaitForTimeout(getInt(dapPanel.getConnectingServerConfigurationPanel().getTimeout()));
+        runConfiguration.setWaitForTrace(dapPanel.getConnectingServerConfigurationPanel().getTrace());
+        runConfiguration.setServerTrace(dapPanel.getServerTrace());
 
         // Mappings settings
-        runConfiguration.setServerMappings(mappingsPanel.getAllMappings());
+        runConfiguration.setServerMappings(dapPanel.getMappings());
 
-        // Sever settings
-        runConfiguration.setServerName(serverNameField.getText());
-        runConfiguration.setCommand(commandField.getText());
-        runConfiguration.setConnectingServerStrategy(connectingServerConfigurationPanel.getConnectingServerStrategy());
-        runConfiguration.setWaitForTimeout(getInt(connectingServerConfigurationPanel.getTimeout()));
-        runConfiguration.setWaitForTrace(connectingServerConfigurationPanel.getTrace());
-        runConfiguration.setServerTrace((ServerTrace) serverTraceComboBox.getSelectedItem());
-
-        if (currentServerFactory != null) {
-            runConfiguration.setServerId(currentServerFactory.getId());
-        }
+        // Configuration settings
+        runConfiguration.setWorkingDirectory(dapPanel.getWorkingDirectory());
+        runConfiguration.setFile(dapPanel.getFile());
+        runConfiguration.setDebuggingType(dapPanel.getDebuggingType());
+        runConfiguration.setLaunchParameters(dapPanel.getLaunchConfiguration());
+        runConfiguration.setAttachParameters(dapPanel.getAttachConfiguration());
     }
 
     private static int getInt(String text) {
@@ -338,23 +98,6 @@ public class DAPSettingsEditor extends SettingsEditor<DAPRunConfiguration> {
     @Override
     protected JComponent createEditor() {
         return myPanel;
-    }
-
-    private static FormBuilder addTab(JBTabbedPane tabbedPane, String tabTitle) {
-        return addTab(tabbedPane, tabTitle, true);
-    }
-
-    @NotNull
-    private static FormBuilder addTab(JBTabbedPane tabbedPane, String tabTitle, boolean addToTop) {
-        FormBuilder builder = FormBuilder.createFormBuilder();
-        var tabPanel = new BorderLayoutPanel();
-        if (addToTop) {
-            tabPanel.addToTop(builder.getPanel());
-        } else {
-            tabPanel.addToCenter(builder.getPanel());
-        }
-        tabbedPane.add(tabTitle, tabPanel);
-        return builder;
     }
 
     public @NotNull Project getProject() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactory.java
@@ -23,7 +23,9 @@ import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAd
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import javax.swing.*;
 import java.util.Collections;
 
 import static com.redhat.devtools.lsp4ij.dap.DAPIJUtils.getFilePath;
@@ -102,5 +104,19 @@ public abstract class DebugAdapterDescriptorFactory {
             return true;
         }
         return false;
+    }
+
+    public @NotNull String getDisplayName() {
+        return getName();
+    }
+
+    @Nullable
+    public Icon getIcon() {
+        return null;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return null;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactoryListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactoryListener.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.descriptors;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+/**
+ * Debug Adapter Protocol (DAP) descriptor factory listener API.
+ */
+public interface DebugAdapterDescriptorFactoryListener {
+
+    abstract class DebugAdapterDescriptorFactoryEvent {
+        DebugAdapterDescriptorFactoryEvent() {
+
+        }
+    }
+
+    class DebugAdapterDescriptorFactoryAddedEvent extends DebugAdapterDescriptorFactoryEvent {
+
+        public final Collection<DebugAdapterDescriptorFactory> serverDescriptors;
+
+        public DebugAdapterDescriptorFactoryAddedEvent(@NotNull Collection<DebugAdapterDescriptorFactory> serverDefinitions) {
+            this.serverDescriptors = serverDefinitions;
+        }
+    }
+
+    class DebugAdapterDescriptorFactoryRemovedEvent extends DebugAdapterDescriptorFactoryEvent {
+
+        public final Collection<DebugAdapterDescriptorFactory> serverDefinitions;
+
+        public DebugAdapterDescriptorFactoryRemovedEvent(@NotNull Collection<DebugAdapterDescriptorFactory> serverDefinitions) {
+            this.serverDefinitions = serverDefinitions;
+        }
+    }
+
+    class DebugAdapterDescriptorFactoryChangedEvent extends DebugAdapterDescriptorFactoryEvent {
+
+        public final DebugAdapterDescriptorFactory descriptorFactory;
+
+        public final boolean nameChanged;
+        public final boolean commandChanged;
+        public final boolean userEnvironmentVariablesChanged;
+        public final boolean includeSystemEnvironmentVariablesChanged;
+        public final boolean waitForTimeoutChanged;
+        public final boolean waitForTraceChanged;
+        public final boolean mappingsChanged;
+        public final boolean configurationChanged;
+        public final boolean initializationOptionsContentChanged;
+
+        public DebugAdapterDescriptorFactoryChangedEvent(@NotNull DebugAdapterDescriptorFactory descriptorFactory,
+                                                         boolean nameChanged,
+                                                         boolean commandChanged,
+                                                         boolean userEnvironmentVariablesChanged,
+                                                         boolean includeSystemEnvironmentVariablesChanged,
+                                                         boolean waitForTimeoutChanged,
+                                                         boolean waitForTraceChanged,
+                                                         boolean mappingsChanged,
+                                                         boolean configurationContentChanged,
+                                                         boolean initializationOptionsContentChanged) {
+            this.descriptorFactory = descriptorFactory;
+            this.nameChanged = nameChanged;
+            this.commandChanged = commandChanged;
+            this.userEnvironmentVariablesChanged = userEnvironmentVariablesChanged;
+            this.includeSystemEnvironmentVariablesChanged = includeSystemEnvironmentVariablesChanged;
+            this.waitForTimeoutChanged = waitForTimeoutChanged;
+            this.waitForTraceChanged = waitForTraceChanged;
+            this.mappingsChanged = mappingsChanged;
+            this.configurationChanged = configurationContentChanged;
+            this.initializationOptionsContentChanged = initializationOptionsContentChanged;
+        }
+    }
+
+    void handleAdded(@NotNull DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryAddedEvent event);
+
+    void handleRemoved(@NotNull DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryRemovedEvent event);
+
+    void handleChanged(@NotNull DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryChangedEvent event);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterManager.java
@@ -12,16 +12,25 @@ package com.redhat.devtools.lsp4ij.dap.descriptors;
 
 import com.intellij.execution.RunManager;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.lang.Language;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPRunConfiguration;
-import com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplateManager;
-import com.redhat.devtools.lsp4ij.dap.descriptors.templates.TemplateDebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.dap.settings.UserDefinedDebugAdapterDescriptorFactorySettings;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
+import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
 
 import static com.redhat.devtools.lsp4ij.dap.DAPIJUtils.getFilePath;
 
@@ -30,24 +39,85 @@ import static com.redhat.devtools.lsp4ij.dap.DAPIJUtils.getFilePath;
  */
 public class DebugAdapterManager {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DebugAdapterManager.class);
+
     public static DebugAdapterManager getInstance() {
         return ApplicationManager.getApplication().getService(DebugAdapterManager.class);
     }
 
+    private final Collection<DebugAdapterDescriptorFactoryListener> listeners = new CopyOnWriteArrayList<>();
+
     private final Map<String, DebugAdapterDescriptorFactory> factories = new HashMap<>();
 
-    public DebugAdapterManager() {
-        DAPTemplateManager.getInstance()
+    /*public DebugAdapterManager() {
+        /*DAPTemplateManager.getInstance()
                 .getTemplates()
-                .forEach(template -> addDebugAdapterDescriptorFactory(new TemplateDebugAdapterDescriptorFactory(template)));
+                .forEach(template -> addDebugAdapterDescriptorFactory(new TemplateDebugAdapterDescriptorFactory(template)));*/
+    //}*/
+
+   public DebugAdapterManager() {
+        initialize();
+    }
+
+    public void addDebugAdapterDescriptorFactoryListener(@NotNull DebugAdapterDescriptorFactoryListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeDebugAdapterDescriptorFactoryListener(@NotNull DebugAdapterDescriptorFactoryListener listener) {
+        listeners.remove(listener);
     }
 
     public void addDebugAdapterDescriptorFactory(@NotNull DebugAdapterDescriptorFactory factory) {
-        factories.put(factory.getId(), factory);
+        addDebugAdapterDescriptorFactoryWithoutNotification(factory);
+        // Notifications
+        var event = new DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryAddedEvent(Collections.singleton(factory));
+        for (var listener : this.listeners) {
+            try {
+                listener.handleAdded(event);
+            } catch (Exception e) {
+                LOGGER.error("Error while adding Debug Adapter Descriptor Factory with id='" + factory.getId() + "'", e);
+            }
+        }
+    }
+
+    public void addDebugAdapterDescriptorFactoryWithoutNotification(@NotNull DebugAdapterDescriptorFactory factory) {
+        String factoryId = factory.getId();
+        factories.put(factoryId, factory);
+        if (factory instanceof UserDefinedDebugAdapterDescriptorFactory userDefinedFactory) {
+            // Update settings
+            UserDefinedDebugAdapterDescriptorFactorySettings.ItemSettings settings = new UserDefinedDebugAdapterDescriptorFactorySettings.ItemSettings();
+            settings.setServerId(userDefinedFactory.getId());
+            settings.setServerName(userDefinedFactory.getDisplayName());
+            settings.setUserEnvironmentVariables(userDefinedFactory.getUserEnvironmentVariables());
+            settings.setIncludeSystemEnvironmentVariables(userDefinedFactory.isIncludeSystemEnvironmentVariables());
+            settings.setCommandLine(userDefinedFactory.getCommandLine());
+            settings.setWaitForTimeout(userDefinedFactory.getWaitForTimeout());
+            settings.setWaitForTrace(userDefinedFactory.getWaitForTrace());
+            List<ServerMappingSettings> mappings = Stream.concat(userDefinedFactory.getLanguageMappings().stream(),
+                    userDefinedFactory.getFileTypeMappings().stream())
+                    .toList();
+            settings.setMappings(mappings);
+            settings.setLaunchConfiguration(userDefinedFactory.getLaunchConfiguration());
+            settings.setAttachConfiguration(userDefinedFactory.getAttachConfiguration());
+
+            UserDefinedDebugAdapterDescriptorFactorySettings.getInstance().setSettings(factoryId, settings);
+        }
     }
 
     public void removeDebugAdapterDescriptorFactory(@NotNull DebugAdapterDescriptorFactory factory) {
-        factories.remove(factory.getId());
+        String factoryId = factory.getId();
+        factories.remove(factoryId);
+        // Update settings
+        UserDefinedDebugAdapterDescriptorFactorySettings.getInstance().removeSettings(factoryId);
+        // Notifications
+        var event = new DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryRemovedEvent(Collections.singleton(factory));
+        for (var listener : this.listeners) {
+            try {
+                listener.handleRemoved(event);
+            } catch (Exception e) {
+                LOGGER.error("Error while DAP server descriptor is added with id='" + factory.getId() + "'", e);
+            }
+        }
     }
 
     @Nullable
@@ -57,6 +127,97 @@ public class DebugAdapterManager {
 
     public Collection<DebugAdapterDescriptorFactory> getFactories() {
         return Collections.unmodifiableCollection(factories.values());
+    }
+
+    public record UpdateDebugAdapterDescriptorFactoryRequest(@NotNull UserDefinedDebugAdapterDescriptorFactory descriptorFactory,
+                                                             @Nullable String name,
+                                                             @Nullable Map<String, String> userEnvironmentVariables,
+                                                             boolean includeSystemEnvironmentVariables,
+                                                             @Nullable String commandLine,
+                                                             @Nullable String  waitForTimeout,
+                                                             @Nullable String  waitForTrace,
+                                                             @NotNull List<ServerMappingSettings> languageMappings,
+                                                             @NotNull List<ServerMappingSettings> fileTypeMappings,
+                                                             @Nullable String launchConfiguration,
+                                                             @Nullable String launchConfigurationSchema,
+                                                             @Nullable String attachConfiguration,
+                                                             @Nullable String attachConfigurationSchema) {
+    }
+
+    @Nullable
+    public DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryChangedEvent updateDescriptorFactory(@NotNull DebugAdapterManager.UpdateDebugAdapterDescriptorFactoryRequest request,
+                                                                                                                   boolean notify) {
+        var descriptorFactory = request.descriptorFactory();
+        String descriptorFactoryId = request.descriptorFactory().getId();
+        descriptorFactory.setName(request.name());
+        descriptorFactory.setCommandLine(request.commandLine());
+        descriptorFactory.setWaitForTimeout(request.waitForTimeout());
+        descriptorFactory.setWaitForTrace(request.waitForTrace());
+        descriptorFactory.setUserEnvironmentVariables(request.userEnvironmentVariables());
+        descriptorFactory.setIncludeSystemEnvironmentVariables(request.includeSystemEnvironmentVariables());
+
+        descriptorFactory.setLanguageMappings(request.languageMappings());
+        descriptorFactory.setFileTypeMappings(request.fileTypeMappings());
+
+        descriptorFactory.setLaunchConfiguration(request.launchConfiguration());
+        descriptorFactory.setLaunchConfigurationSchema(request.launchConfigurationSchema());
+        descriptorFactory.setAttachConfiguration(request.attachConfiguration());
+        descriptorFactory.setAttachConfigurationSchema(request.attachConfigurationSchema());
+
+        List<ServerMappingSettings> mappings = Stream.concat(request.languageMappings().stream(), request.fileTypeMappings().stream()).toList();
+        UserDefinedDebugAdapterDescriptorFactorySettings.ItemSettings settings = UserDefinedDebugAdapterDescriptorFactorySettings.getInstance().getSettings(descriptorFactoryId);
+        boolean nameChanged = !Objects.equals(settings.getServerName(), request.name());
+        boolean userEnvironmentVariablesChanged = !Objects.equals(settings.getUserEnvironmentVariables(), request.userEnvironmentVariables());
+        boolean includeSystemEnvironmentVariablesChanged = settings.isIncludeSystemEnvironmentVariables() != request.includeSystemEnvironmentVariables();
+        boolean commandChanged = !Objects.equals(settings.getCommandLine(), request.commandLine());
+        boolean waitForTimeoutChanged = !Objects.equals(settings.getWaitForTimeout(), request.waitForTimeout());
+        boolean waitForTraceChanged = !Objects.equals(settings.getWaitForTrace(), request.waitForTrace());
+        boolean mappingsChanged = !Objects.deepEquals(settings.getMappings(), mappings);
+        boolean launchConfigurationChanged = !Objects.equals(settings.getLaunchConfiguration(), request.launchConfiguration());
+        boolean attachConfigurationChanged = !Objects.equals(settings.getAttachConfiguration(), request.attachConfiguration());
+        // Not checking whether client config changed because that shouldn't result in a LanguageServerChangedEvent
+
+        settings.setServerName(request.name());
+        settings.setUserEnvironmentVariables(request.userEnvironmentVariables());
+        settings.setIncludeSystemEnvironmentVariables(request.includeSystemEnvironmentVariables());
+        settings.setCommandLine(request.commandLine());
+        settings.setWaitForTimeout(request.waitForTimeout);
+        settings.setWaitForTrace(request.waitForTrace);
+        settings.setMappings(mappings);
+        settings.setLaunchConfiguration(request.launchConfiguration());
+        settings.setAttachConfiguration(request.attachConfiguration());
+
+        if (nameChanged || userEnvironmentVariablesChanged || includeSystemEnvironmentVariablesChanged ||
+                commandChanged || waitForTimeoutChanged || waitForTraceChanged ||
+                mappingsChanged || launchConfigurationChanged || attachConfigurationChanged) {
+            // Notifications
+            DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryChangedEvent event = new DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryChangedEvent(
+                    descriptorFactory,
+                    nameChanged,
+                    commandChanged,
+                    userEnvironmentVariablesChanged,
+                    includeSystemEnvironmentVariablesChanged,
+                    waitForTimeoutChanged,
+                    waitForTraceChanged,
+                    mappingsChanged,
+                    launchConfigurationChanged,
+                    attachConfigurationChanged);
+            if (notify) {
+                handleChangeEvent(event);
+            }
+            return event;
+        }
+        return null;
+    }
+
+    public void handleChangeEvent(DebugAdapterDescriptorFactoryListener.DebugAdapterDescriptorFactoryChangedEvent event) {
+        for (DebugAdapterDescriptorFactoryListener listener : this.listeners) {
+            try {
+                listener.handleChanged(event);
+            } catch (Exception e) {
+                LOGGER.error("Error while updaing user defined debug adapter descriptor factory with id='" + event.descriptorFactory.getId() + "'", e);
+            }
+        }
     }
 
     public boolean canDebug(@NotNull VirtualFile file,
@@ -72,7 +233,8 @@ public class DebugAdapterManager {
 
     /**
      * Returns the existing run configuration for the given file and null otherwise.
-     * @param file the file.
+     *
+     * @param file    the file.
      * @param project the project.
      * @return the existing run configuration  for the given file and null otherwise.
      */
@@ -98,15 +260,16 @@ public class DebugAdapterManager {
 
     /**
      * Returns the DAP descriptor factory for the given file and null otherwise.
-     * @param file the file.
+     *
+     * @param file    the file.
      * @param project the project.
      * @return the DAP descriptor factory for the given file and null otherwise.
      */
     @Nullable
     private DebugAdapterDescriptorFactory findFactoryFor(@NotNull VirtualFile file,
                                                          @NotNull Project project) {
-        for(var factory : factories.values()) {
-            if(factory.canDebug(file, project)) {
+        for (var factory : factories.values()) {
+            if (factory.canDebug(file, project)) {
                 return factory;
             }
         }
@@ -117,7 +280,7 @@ public class DebugAdapterManager {
                                         @NotNull VirtualFile file,
                                         @NotNull Project project) {
         RunConfiguration existingConfiguration = findExistingConfigurationFor(file, project, true);
-        if(existingConfiguration != null
+        if (existingConfiguration != null
                 && existingConfiguration instanceof DAPRunConfiguration existingDapConfiguration
                 && configuration instanceof DAPRunConfiguration dapConfiguration) {
             existingDapConfiguration.copyTo(dapConfiguration);
@@ -129,4 +292,73 @@ public class DebugAdapterManager {
         }
         return false;
     }
+
+    private void initialize() {
+        // Load Debug Adapter descriptor factory from extension point
+        loadFromExtensionPoint();
+
+        // Load Debug Adapter descriptor factory from settings
+        loadFromSettings();
+    }
+
+    private void loadFromExtensionPoint() {
+        // TODO
+    }
+
+    private void loadFromSettings() {
+        try {
+            for (var setting : UserDefinedDebugAdapterDescriptorFactorySettings.getInstance().getSettings()) {
+                String factoryId = setting.getServerId();
+                List<ServerMappingSettings> languageMappings = new ArrayList<>();
+                List<ServerMappingSettings> fileTypeMappings = new ArrayList<>();
+                var mappingSettings = setting.getMappings();
+                if (mappingSettings != null && !mappingSettings.isEmpty()) {
+                    for (var mapping : mappingSettings) {
+                        String mappingLanguage = mapping.getLanguage();
+                        if (!StringUtils.isEmpty(mappingLanguage)) {
+                            Language language = Language.findLanguageByID(mappingLanguage);
+                            if (language != null) {
+                                languageMappings.add(mapping);
+                            }
+                        } else {
+                            boolean fileTypeMappingCreated = false;
+                            String mappingFileType = mapping.getFileType();
+                            if (!StringUtils.isEmpty(mappingFileType)) {
+                                FileType fileType = FileTypeManager.getInstance().findFileTypeByName(mappingFileType);
+                                if (fileType != null) {
+                                    // Register file type mapping from settings
+                                    fileTypeMappings.add(mapping);
+                                    fileTypeMappingCreated = true;
+                                }
+                            }
+                            if (!fileTypeMappingCreated) {
+                                List<String> patterns = mapping.getFileNamePatterns();
+                                if (patterns != null) {
+                                    // Register file name patterns mapping from settings
+                                    fileTypeMappings.add(mapping);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Register Debug Adapter descriptor factory from settings
+                var factory = new UserDefinedDebugAdapterDescriptorFactory(factoryId,
+                        setting.getServerName(),
+                        setting.getCommandLine(),
+                        languageMappings,
+                        fileTypeMappings);
+                factory.setUserEnvironmentVariables(setting.getUserEnvironmentVariables());
+                factory.setIncludeSystemEnvironmentVariables(setting.isIncludeSystemEnvironmentVariables());
+                factory.setWaitForTimeout(setting.getWaitForTimeout());
+                factory.setWaitForTrace(setting.getWaitForTrace());
+                factory.setLaunchConfiguration(setting.getLaunchConfiguration());
+                factory.setAttachConfiguration(setting.getAttachConfiguration());
+                addDebugAdapterDescriptorFactoryWithoutNotification(factory);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error while loading user defined debug adapter descriptor factory from settings", e);
+        }
+    }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/userdefined/UserDefinedDebugAdapterDescriptorFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/userdefined/UserDefinedDebugAdapterDescriptorFactory.java
@@ -23,7 +23,9 @@ import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jps.model.fileTypes.FileNameMatcherFactory;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -31,19 +33,24 @@ import java.util.stream.Stream;
  */
 public class UserDefinedDebugAdapterDescriptorFactory extends DebugAdapterDescriptorFactory {
 
-
+    // Server
     private final @NotNull String id;
     private @NotNull String name;
+    private Map<String, String> userEnvironmentVariables;
+    private boolean includeSystemEnvironmentVariables;
     private String commandLine;
+    private String waitForTimeout;
+    private String waitForTrace;
+
+    // Mappings
     private @NotNull List<ServerMappingSettings> languageMappings;
     private @NotNull List<ServerMappingSettings> fileTypeMappings;
 
+    // Configuration
     private String launchConfiguration;
     private String launchConfigurationSchema;
     private String attachConfiguration;
     private String attachConfigurationSchema;
-    private String waitForTimeout;
-    private String waitForTrace;
 
     public UserDefinedDebugAdapterDescriptorFactory(@NotNull String id,
                                                     @NotNull String name,
@@ -69,6 +76,43 @@ public class UserDefinedDebugAdapterDescriptorFactory extends DebugAdapterDescri
 
     public void setName(@NotNull String name) {
         this.name = name;
+    }
+
+    /**
+     * Returns the User environment variables used to start the language server process.
+     *
+     * @return the User environment variables used to start the language server process.
+     */
+    @NotNull
+    public Map<String, String> getUserEnvironmentVariables() {
+        return userEnvironmentVariables != null ? userEnvironmentVariables : Collections.emptyMap();
+    }
+
+    /**
+     * Set the User environment variables used to start the language server process.
+     *
+     * @param userEnvironmentVariables the User environment variables.
+     */
+    public void setUserEnvironmentVariables(Map<String, String> userEnvironmentVariables) {
+        this.userEnvironmentVariables = userEnvironmentVariables;
+    }
+
+    /**
+     * Returns true if System environment variables must be included when language server process starts and false otherwise.
+     *
+     * @return true if System environment variables must be included when language server process starts and false otherwise.
+     */
+    public boolean isIncludeSystemEnvironmentVariables() {
+        return includeSystemEnvironmentVariables;
+    }
+
+    /**
+     * Set true if System environment variables must be included when language server process starts and false otherwise.
+     *
+     * @param includeSystemEnvironmentVariables true if System environment variables must be included when language server process starts and false otherwise.
+     */
+    public void setIncludeSystemEnvironmentVariables(boolean includeSystemEnvironmentVariables) {
+        this.includeSystemEnvironmentVariables = includeSystemEnvironmentVariables;
     }
 
     public String getCommandLine() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/DebugAdapterDescriptorFactoryConfigurable.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/DebugAdapterDescriptorFactoryConfigurable.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.settings;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.NamedConfigurable;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.NlsContexts;
+import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.dap.settings.ui.DebugAdapterDescriptorFactoryView;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+/**
+ * UI settings to configure a given debug adapter descriptor factory
+ */
+public class DebugAdapterDescriptorFactoryConfigurable extends NamedConfigurable<DebugAdapterDescriptorFactory> implements DebugAdapterDescriptorFactoryView.DebugAdapterDescriptorFactoryNameProvider {
+
+    private final DebugAdapterDescriptorFactory descriptorFactory;
+    private final @NotNull Project project;
+
+    private DebugAdapterDescriptorFactoryView myView;
+
+    public DebugAdapterDescriptorFactoryConfigurable(@NotNull DebugAdapterDescriptorFactory descriptorFactory,
+                                                     @NotNull Runnable updater,
+                                                     @NotNull Project project) {
+        super(descriptorFactory instanceof UserDefinedDebugAdapterDescriptorFactory, updater);
+        this.project = project;
+        this.descriptorFactory = descriptorFactory;
+    }
+
+    @Override
+    public void setDisplayName(String name) {
+        // Do nothing: the descriptor name is not editable.
+        if (descriptorFactory instanceof UserDefinedDebugAdapterDescriptorFactory userDefinedFactory) {
+            userDefinedFactory.setName(name);
+        }
+    }
+
+    @Override
+    public DebugAdapterDescriptorFactory getEditableObject() {
+        return descriptorFactory;
+    }
+
+    @Override
+    public @NlsContexts.DetailedDescription String getBannerSlogan() {
+        return descriptorFactory.getDisplayName();
+    }
+
+    @Override
+    public JComponent createOptionsPanel() {
+        if (myView == null) {
+            myView = new DebugAdapterDescriptorFactoryView(descriptorFactory, this, project);
+        }
+        return myView.getComponent();
+    }
+
+    @Override
+    public @NlsContexts.ConfigurableName String getDisplayName() {
+        return descriptorFactory.getDisplayName();
+    }
+
+    @Override
+    public @Nullable Icon getIcon(boolean expanded) {
+        return descriptorFactory.getIcon();
+    }
+
+    @Override
+    public boolean isModified() {
+        return myView.isModified();
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        myView.apply();
+    }
+
+    @Override
+    public void reset() {
+        myView.reset();
+    }
+
+    @Override
+    public void disposeUIResources() {
+        if (myView != null) Disposer.dispose(myView);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/UserDefinedDebugAdapterDescriptorFactorySettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/UserDefinedDebugAdapterDescriptorFactorySettings.java
@@ -1,0 +1,269 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.settings;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.xmlb.annotations.Tag;
+import com.intellij.util.xmlb.annotations.XCollection;
+import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * User defined debug adapter descriptor factory settings.
+ */
+@State(
+        name = "debugAdapterDescriptorFactorySettingsState",
+        storages = @Storage("DebugAdapterDescriptorFactorySettings.xml")
+)
+public class UserDefinedDebugAdapterDescriptorFactorySettings implements PersistentStateComponent<UserDefinedDebugAdapterDescriptorFactorySettings.MyState> {
+
+    private final List<Runnable> myChangeHandlers = ContainerUtil.createConcurrentList();
+    private volatile MyState myState = new MyState();
+
+    public static UserDefinedDebugAdapterDescriptorFactorySettings getInstance() {
+        return ApplicationManager.getApplication().getService(UserDefinedDebugAdapterDescriptorFactorySettings.class);
+    }
+
+    @Nullable
+    @Override
+    public MyState getState() {
+        return myState;
+    }
+
+    @Override
+    public void loadState(@NotNull MyState state) {
+        myState = state;
+    }
+
+    /**
+     * Returns the Debug Adapter descriptor factory settings for the given factory Id and null otherwise.
+     *
+     * @param descriptorFactoryId the Debug Adapter descriptor factory id.
+     * @return the Debug Adapter descriptor factory settings for the given factory Id and null otherwise.
+     */
+    @Nullable
+    public ItemSettings getSettings(@NotNull String descriptorFactoryId) {
+        return myState.myState.get(descriptorFactoryId);
+    }
+
+    /**
+     * Register the Debug Adapter descriptor factory settings for the given factory Id.
+     * @param descriptorFactoryId the Debug Adapter descriptor factory id.
+     * @param settings the Debug Adapter descriptor factory settings.
+     */
+    public void setSettings(@NotNull String descriptorFactoryId, @NotNull ItemSettings settings) {
+        myState.myState.put(descriptorFactoryId, settings);
+        fireStateChanged();
+    }
+
+    public void removeSettings(String descriptorFactoryId) {
+        myState.myState.remove(descriptorFactoryId);
+        fireStateChanged();
+    }
+
+    public Collection<ItemSettings> getSettings() {
+        return myState.myState.values();
+    }
+
+    /**
+     * Adds the given changeHandler to the list of registered change handlers
+     *
+     * @param changeHandler the changeHandler to remove
+     */
+    public void addChangeHandler(@NotNull Runnable changeHandler) {
+        myChangeHandlers.add(changeHandler);
+    }
+
+    /**
+     * Removes the given changeHandler from the list of registered change handlers
+     *
+     * @param changeHandler the changeHandler to remove
+     */
+    public void removeChangeHandler(@NotNull Runnable changeHandler) {
+        myChangeHandlers.remove(changeHandler);
+    }
+
+    /**
+     * Notifies all registered change handlers when the state changed
+     */
+    private void fireStateChanged() {
+        for (Runnable handler : myChangeHandlers) {
+            handler.run();
+        }
+    }
+
+    public Object updateSettings(@NotNull String descriptorFactoryId,
+                                 @NotNull UserDefinedDebugAdapterDescriptorFactorySettings.ItemSettings settings,
+                                 boolean notify) {
+
+        return null;
+    }
+
+    public void handleChanged(Object settingsChangedEvent) {
+    }
+
+    public static class ItemSettings {
+
+        private String serverId;
+
+        private String serverName;
+
+        private Map<String, String> userEnvironmentVariables;
+        private boolean includeSystemEnvironmentVariables = true;
+        private String commandLine;
+        private String waitForTimeout;
+        private String waitForTrace;
+
+        @XCollection(elementTypes = ServerMappingSettings.class)
+        private List<ServerMappingSettings> mappings;
+
+        private String launchConfiguration;
+        private String launchConfigurationSchema;
+        private String attachConfiguration;
+        private String attachConfigurationSchema;
+
+        public String getServerId() {
+            return serverId;
+        }
+
+        public void setServerId(String serverId) {
+            this.serverId = serverId;
+        }
+
+        public String getServerName() {
+            return serverName;
+        }
+
+        public void setServerName(String serverName) {
+            this.serverName = serverName;
+        }
+
+        /**
+         * Returns the User environment variables used to start the language server process.
+         *
+         * @return the User environment variables used to start the language server process.
+         */
+        @NotNull
+        public Map<String, String> getUserEnvironmentVariables() {
+            return userEnvironmentVariables != null ? userEnvironmentVariables : Collections.emptyMap();
+        }
+
+        /**
+         * Set the User environment variables used to start the language server process.
+         *
+         * @param userEnvironmentVariables the User environment variables.
+         */
+        public void setUserEnvironmentVariables(Map<String, String> userEnvironmentVariables) {
+            this.userEnvironmentVariables = userEnvironmentVariables;
+        }
+
+        /**
+         * Returns true if System environment variables must be included when language server process starts and false otherwise.
+         *
+         * @return true if System environment variables must be included when language server process starts and false otherwise.
+         */
+        public boolean isIncludeSystemEnvironmentVariables() {
+            return includeSystemEnvironmentVariables;
+        }
+
+        /**
+         * Set true if System environment variables must be included when language server process starts and false otherwise.
+         *
+         * @param includeSystemEnvironmentVariables true if System environment variables must be included when language server process starts and false otherwise.
+         */
+        public void setIncludeSystemEnvironmentVariables(boolean includeSystemEnvironmentVariables) {
+            this.includeSystemEnvironmentVariables = includeSystemEnvironmentVariables;
+        }
+
+        public String getCommandLine() {
+            return commandLine;
+        }
+
+        public void setCommandLine(String commandLine) {
+            this.commandLine = commandLine;
+        }
+
+        public String getWaitForTimeout() {
+            return waitForTimeout;
+        }
+
+        public void setWaitForTimeout(String waitForTimeout) {
+            this.waitForTimeout = waitForTimeout;
+        }
+
+        public String getWaitForTrace() {
+            return waitForTrace;
+        }
+
+        public void setWaitForTrace(String waitForTrace) {
+            this.waitForTrace = waitForTrace;
+        }
+
+        public List<ServerMappingSettings> getMappings() {
+            return mappings != null ? mappings : Collections.emptyList();
+        }
+
+        public void setMappings(List<ServerMappingSettings> mappings) {
+            this.mappings = mappings;
+        }
+
+        public String getLaunchConfiguration() {
+            return launchConfiguration;
+        }
+
+        public void setLaunchConfiguration(String launchConfiguration) {
+            this.launchConfiguration = launchConfiguration;
+        }
+
+        public String getLaunchConfigurationSchema() {
+            return launchConfigurationSchema;
+        }
+
+        public void setLaunchConfigurationSchema(String launchConfigurationSchema) {
+            this.launchConfigurationSchema = launchConfigurationSchema;
+        }
+
+        public String getAttachConfiguration() {
+            return attachConfiguration;
+        }
+
+        public void setAttachConfiguration(String attachConfiguration) {
+            this.attachConfiguration = attachConfiguration;
+        }
+
+        public String getAttachConfigurationSchema() {
+            return attachConfigurationSchema;
+        }
+
+        public void setAttachConfigurationSchema(String attachConfigurationSchema) {
+            this.attachConfigurationSchema = attachConfigurationSchema;
+        }
+    }
+
+    public static class MyState {
+        @Tag("state")
+        @XCollection
+        public Map<String, ItemSettings> myState = new TreeMap<>();
+
+        MyState() {
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DAPConnectingServerConfigurationPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DAPConnectingServerConfigurationPanel.java
@@ -8,7 +8,7 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
-package com.redhat.devtools.lsp4ij.dap.configurations;
+package com.redhat.devtools.lsp4ij.dap.settings.ui;
 
 import com.redhat.devtools.lsp4ij.dap.ConnectingServerStrategy;
 import com.redhat.devtools.lsp4ij.dap.DAPBundle;
@@ -71,7 +71,7 @@ public class DAPConnectingServerConfigurationPanel extends JPanel {
         JPanel traceStrategyPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         traceRadio = new JRadioButton(DAPBundle.message("dap.settings.editor.server.connecting.strategy.trace"));
         buttonGroup.add(traceRadio);
-        traceField = new JTextField(50);
+        traceField = new JTextField(30);
         traceStrategyPanel.add(traceRadio);
         traceStrategyPanel.add(traceField);
         super.add(traceStrategyPanel);

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterDescriptorFactoryPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterDescriptorFactoryPanel.java
@@ -1,0 +1,553 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.settings.ui;
+
+import com.intellij.execution.configuration.EnvironmentVariablesComponent;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.NlsContexts;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.ui.HyperlinkLabel;
+import com.intellij.ui.SimpleListCellRenderer;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.components.JBTabbedPane;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.ui.scale.JBUIScale;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.UIUtil;
+import com.intellij.util.ui.components.BorderLayoutPanel;
+import com.redhat.devtools.lsp4ij.dap.ConnectingServerStrategy;
+import com.redhat.devtools.lsp4ij.dap.DAPBundle;
+import com.redhat.devtools.lsp4ij.dap.DebuggingType;
+import com.redhat.devtools.lsp4ij.dap.configurations.DAPServerMappingsPanel;
+import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterManager;
+import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
+import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
+import com.redhat.devtools.lsp4ij.server.definition.launching.UserDefinedLanguageServerDefinition;
+import com.redhat.devtools.lsp4ij.settings.ServerTrace;
+import com.redhat.devtools.lsp4ij.settings.ui.CommandLineWidget;
+import com.redhat.devtools.lsp4ij.settings.ui.SchemaBackedJsonTextField;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * UI panel to define a Debug Adapter descriptor factory.
+ */
+public class DebugAdapterDescriptorFactoryPanel implements Disposable {
+
+    private static final int COMMAND_LENGTH_MAX = 140;
+
+    private final Project project;
+    private HyperlinkLabel editJsonSchemaAction;
+    private DebugAdapterDescriptorFactory currentServerFactory;
+    private boolean initialized;
+    private JBTabbedPane mainTabbedPane;
+
+    public enum EditionMode {
+        NEW_USER_DEFINED,
+        EDIT_USER_DEFINED,
+        EDIT_EXTENSION;
+    }
+
+    // Server settings
+    private ComboBox<DebugAdapterDescriptorFactory> serverFactoryCombo;
+    private JBTextField serverNameField;
+    private EnvironmentVariablesComponent environmentVariables;
+    private CommandLineWidget commandLine;
+    private DAPConnectingServerConfigurationPanel connectingServerConfigurationPanel;
+    private ComboBox<ServerTrace> serverTraceComboBox;
+
+    // Mappings settings
+    private DAPServerMappingsPanel mappingsPanel;
+
+    // Configuration settings
+    private TextFieldWithBrowseButton workingDirectoryField;
+    private TextFieldWithBrowseButton fileField;
+    private JBTabbedPane parametersTabbedPane;
+    private JRadioButton launchRadioButton;
+    private JRadioButton attachRadioButton;
+    private SchemaBackedJsonTextField launchConfigurationField;
+    private SchemaBackedJsonTextField attachConfigurationField;
+
+    public DebugAdapterDescriptorFactoryPanel(@NotNull FormBuilder builder,
+                                              @Nullable JComponent description,
+                                              @NotNull EditionMode mode,
+                                              @NotNull Project project) {
+        this(builder, description, mode, false, project);
+    }
+
+    public DebugAdapterDescriptorFactoryPanel(@NotNull FormBuilder builder,
+                                              @Nullable JComponent description,
+                                              @NotNull EditionMode mode,
+                                              boolean showFactoryCombo,
+                                              @NotNull Project project) {
+        this.project = project;
+        createUI(builder, description, mode, showFactoryCombo);
+    }
+
+    private void createUI(FormBuilder builder, JComponent description, EditionMode mode, boolean showFactoryCombo) {
+        mainTabbedPane = new JBTabbedPane();
+        builder.addComponentFillVertically(mainTabbedPane, 0);
+
+        // Server tab
+        addServerTab(mainTabbedPane, description, mode, showFactoryCombo);
+        // Mappings tab
+        addMappingsTab(mainTabbedPane, mode);
+        // Configuration tab
+        addConfigurationTab(mainTabbedPane);
+    }
+
+    private void addServerTab(JBTabbedPane tabbedPane, JComponent description, EditionMode mode, boolean showFactoryCombo) {
+        FormBuilder serverTab = addTab(tabbedPane, DAPBundle.message("dap.settings.editor.server.tab"));
+        if (description != null) {
+            serverTab.addComponent(description, 0);
+        }
+        if (showFactoryCombo) {
+            serverFactoryCombo = new ComboBox<>(new DefaultComboBoxModel<>(getServerFactories()));
+            serverFactoryCombo.setRenderer(new SimpleListCellRenderer<>() {
+                @Override
+                public void customize(@NotNull JList list,
+                                      @Nullable DebugAdapterDescriptorFactory serverFactory,
+                                      int index,
+                                      boolean selected,
+                                      boolean hasFocus) {
+                    if (serverFactory == null) {
+                        setText("");
+                    } else {
+                        setText(serverFactory.getName());
+                    }
+                }
+            });
+            JPanel serverFactoryPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+            serverFactoryPanel.add(serverFactoryCombo);
+            serverFactoryPanel.add(new JLabel(DAPBundle.message("dap.settings.editor.server.factory.or")));
+
+            var hyperLink = createHyperlinkLabel();
+            serverFactoryPanel.add(hyperLink);
+            serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.factory.field"), serverFactoryPanel);
+
+        }
+        if (mode == EditionMode.NEW_USER_DEFINED) {
+            // Server name
+            createServerNameField(serverTab);
+        }
+        if (mode != EditionMode.EDIT_EXTENSION) {
+            environmentVariables = new EnvironmentVariablesComponent();
+            serverTab.addComponent(environmentVariables);
+            // Command line
+            createCommandLineField(serverTab);
+        }
+        // Connecting server configuration
+        connectingServerConfigurationPanel = new DAPConnectingServerConfigurationPanel();
+        serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.connecting.strategy.label"), connectingServerConfigurationPanel, true);
+
+        serverTraceComboBox = new ComboBox<>(new DefaultComboBoxModel<>(ServerTrace.values()));
+        serverTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.serverTrace.field"), serverTraceComboBox);
+    }
+
+    private @NotNull HyperlinkLabel createHyperlinkLabel() {
+        var hyperLink = new HyperlinkLabel(DAPBundle.message("dap.settings.editor.server.factory.create"));
+        hyperLink.addHyperlinkListener(e -> {
+            var dialog = new NewDebugAdapterDescriptorFactoryDialog(project);
+            dialog.show();
+            if (dialog.isOK()) {
+                var createdFactory = dialog.getCreatedFactory();
+                if (createdFactory != null) {
+                    serverFactoryCombo.setModel(new DefaultComboBoxModel<>(getServerFactories()));
+                    serverFactoryCombo.setSelectedItem(createdFactory);
+                }
+            }
+        });
+        return hyperLink;
+    }
+
+    private static DebugAdapterDescriptorFactory[] getServerFactories() {
+        List<DebugAdapterDescriptorFactory> factories = new ArrayList<>();
+        factories.add(DebugAdapterDescriptorFactory.NONE);
+        factories.addAll(DebugAdapterManager.getInstance().getFactories());
+        return factories.toArray(new DebugAdapterDescriptorFactory[0]);
+    }
+
+    private void addMappingsTab(JBTabbedPane tabbedPane, EditionMode mode) {
+        FormBuilder mappingsTab = addTab(tabbedPane, DAPBundle.message("dap.settings.editor.mappings.tab"));
+        this.mappingsPanel = new DAPServerMappingsPanel(mappingsTab, mode != EditionMode.EDIT_EXTENSION);
+    }
+
+    private void addConfigurationTab(JBTabbedPane tabbedPane) {
+        FormBuilder configurationTab = addTab(tabbedPane, DAPBundle.message("dap.settings.editor.configuration.tab"));
+
+        workingDirectoryField = new TextFieldWithBrowseButton();
+        workingDirectoryField.addBrowseFolderListener(null, null, getProject(), FileChooserDescriptorFactory.createSingleFolderDescriptor());
+        configurationTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.configuration.cwd.field"), workingDirectoryField);
+
+        fileField = new TextFieldWithBrowseButton();
+        fileField.addBrowseFolderListener(null, null, getProject(), FileChooserDescriptorFactory.createSingleFileDescriptor());
+        configurationTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.configuration.file.field"), fileField);
+
+        ButtonGroup buttonGroup = new ButtonGroup();
+        launchRadioButton = new JRadioButton(DAPBundle.message("dap.settings.editor.configuration.debugging.launch.type"));
+        buttonGroup.add(launchRadioButton);
+        attachRadioButton = new JRadioButton(DAPBundle.message("dap.settings.editor.configuration.debugging.attach.type"));
+        buttonGroup.add(attachRadioButton);
+
+        JPanel radioPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        radioPanel.add(launchRadioButton);
+        radioPanel.add(attachRadioButton);
+        configurationTab.addLabeledComponent(DAPBundle.message("dap.settings.editor.configuration.debugging.type.field"), radioPanel);
+
+        parametersTabbedPane = new JBTabbedPane();
+        // Launch / Attach DAP parameters
+        configurationTab.addComponentFillVertically(parametersTabbedPane, 0);
+
+        FormBuilder launchTab = addTab(parametersTabbedPane, DAPBundle.message("dap.settings.editor.configuration.parameters.launch.tab"));
+        launchConfigurationField = new SchemaBackedJsonTextField(project);
+        launchTab.addLabeledComponentFillVertically(DAPBundle.message("dap.settings.editor.configuration.parameters.field"), launchConfigurationField);
+        FormBuilder attachTab = addTab(parametersTabbedPane, DAPBundle.message("dap.settings.editor.configuration.parameters.attach.tab"));
+        attachConfigurationField = new SchemaBackedJsonTextField(project);
+        attachTab.addLabeledComponentFillVertically(DAPBundle.message("dap.settings.editor.configuration.parameters.field"), attachConfigurationField);
+
+        // Select by default launch debugging type.
+        selectLaunchDebuggingType();
+        // Add radio listeners.
+        launchRadioButton.addActionListener(event -> {
+            selectLaunchDebuggingType();
+        });
+        attachRadioButton.addActionListener(event -> {
+            selectAttachDebuggingType();
+        });
+
+    }
+
+    private void selectAttachDebuggingType() {
+        attachRadioButton.setSelected(true);
+        parametersTabbedPane.setSelectedIndex(1);
+    }
+
+    private void selectLaunchDebuggingType() {
+        launchRadioButton.setSelected(true);
+        parametersTabbedPane.setSelectedIndex(0);
+    }
+
+    private static FormBuilder addTab(JBTabbedPane tabbedPane, String tabTitle) {
+        return addTab(tabbedPane, tabTitle, true);
+    }
+
+    @NotNull
+    private static FormBuilder addTab(JBTabbedPane tabbedPane, String tabTitle, boolean addToTop) {
+        FormBuilder builder = FormBuilder.createFormBuilder();
+        var tabPanel = new BorderLayoutPanel();
+        if (addToTop) {
+            tabPanel.addToTop(builder.getPanel());
+        } else {
+            tabPanel.addToCenter(builder.getPanel());
+        }
+        tabbedPane.add(tabTitle, tabPanel);
+        return builder;
+    }
+
+    private void createServerNameField(FormBuilder builder) {
+        serverNameField = new JBTextField();
+        builder.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.name.field"), serverNameField);
+    }
+
+    private void createCommandLineField(FormBuilder builder) {
+        commandLine = new CommandLineWidget();
+        JBScrollPane scrollPane = new JBScrollPane(commandLine);
+        scrollPane.setMinimumSize(new Dimension(JBUIScale.scale(600), JBUIScale.scale(100)));
+        JLabel previewCommandLabel = createLabelForComponent("", scrollPane);
+        updatePreviewCommand(commandLine, previewCommandLabel, project);
+        builder.addLabeledComponent(DAPBundle.message("dap.settings.editor.server.command.field"), scrollPane, true);
+        builder.addComponent(previewCommandLabel, 0);
+    }
+
+    /**
+     * Update preview command label with expanded macro response if needed.
+     *
+     * @param commandLine         the command line which could contains macro syntax.
+     * @param previewCommandLabel the preview command label.
+     * @param project             the project.
+     * @see <a href="https://www.jetbrains.com/help/idea/built-in-macros.html">Built In Macro</a>
+     */
+    private static void updatePreviewCommand(@NotNull CommandLineWidget commandLine,
+                                             @NotNull JLabel previewCommandLabel,
+                                             @NotNull Project project) {
+        commandLine.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                updateLabel(previewCommandLabel);
+            }
+
+            private void updateLabel(JLabel previewCommandLabel) {
+                String preview = UserDefinedLanguageServerDefinition.resolveCommandLine(commandLine.getText(), project);
+                if (preview.equals(commandLine.getText())) {
+                    previewCommandLabel.setToolTipText("");
+                    previewCommandLabel.setText("");
+                } else {
+                    previewCommandLabel.setToolTipText(preview);
+                    String shortPreview = preview.length() > COMMAND_LENGTH_MAX ? preview.substring(0, COMMAND_LENGTH_MAX) + "..." : preview;
+                    previewCommandLabel.setText(shortPreview);
+                }
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                updateLabel(previewCommandLabel);
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                updateLabel(previewCommandLabel);
+            }
+        });
+    }
+
+
+    private static JLabel createLabelForComponent(@NotNull @NlsContexts.Label String labelText, @NotNull JComponent component) {
+        JLabel label = new JLabel(UIUtil.replaceMnemonicAmpersand(labelText));
+        label.setLabelFor(component);
+        return label;
+    }
+
+    // Server settings
+
+    public void setServerId(String serverId) {
+        if (StringUtils.isNotBlank(serverId)) {
+            DebugAdapterDescriptorFactory factory = DebugAdapterManager.getInstance().getFactoryById(serverId);
+            if (factory != null) {
+                currentServerFactory = factory;
+                if (serverFactoryCombo != null) {
+                    serverFactoryCombo.setSelectedItem(factory);
+                }
+            }
+        }
+        if (!initialized) {
+            // Add Listener when server is selected, it must update Configuration / Mappings and Server tabs
+            if (serverFactoryCombo != null) {
+                serverFactoryCombo.addItemListener(e -> {
+                    currentServerFactory = (DebugAdapterDescriptorFactory) e.getItem();
+                    if (currentServerFactory instanceof UserDefinedDebugAdapterDescriptorFactory dapFactory) {
+                        if (dapFactory != UserDefinedDebugAdapterDescriptorFactory.NONE) {
+                            loadFromDapFactory(dapFactory);
+                        }
+                    }
+                });
+            }
+            // If DAP server is not configured, the Server tab must be selected
+            if (StringUtils.isEmpty(serverId) && getCommandLine().isEmpty()) {
+                mainTabbedPane.setSelectedIndex(0);
+            } else {
+                mainTabbedPane.setSelectedIndex(2);
+            }
+            initialized = true;
+        }
+    }
+
+    private void loadFromDapFactory(@NotNull UserDefinedDebugAdapterDescriptorFactory dapFactory) {
+        setServerId(dapFactory.getId());
+        // Update name
+        setServerName(dapFactory.getDisplayName());
+
+        // Update wait for trace
+        updateConnectingStrategy(null, getInt(dapFactory.getWaitForTimeout()),
+                dapFactory.getWaitForTrace());
+
+        // Update command
+        String command = getCommandLine(dapFactory);
+        this.setCommandLine(command);
+
+        // Update mappings
+        mappingsPanel.refreshMappings(dapFactory.getLanguageMappings(), dapFactory.getFileTypeMappings());
+
+        // Update DAP parameters
+        setLaunchConfiguration(dapFactory.getLaunchConfiguration());
+        setAttachConfiguration(dapFactory.getAttachConfiguration());
+    }
+
+    private static int getInt(String text) {
+        try {
+            return Integer.parseInt(text);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private static String getCommandLine(UserDefinedDebugAdapterDescriptorFactory entry) {
+        StringBuilder command = new StringBuilder();
+        if (entry.getCommandLine() != null) {
+            if (!command.isEmpty()) {
+                command.append(' ');
+            }
+            command.append(entry.getCommandLine());
+        }
+        return command.toString();
+    }
+
+    // Server settings
+
+    public JBTextField getServerNameField() {
+        return serverNameField;
+    }
+
+    public String getServerName() {
+        if (serverNameField == null) {
+            return "";
+        }
+        return serverNameField.getText();
+    }
+
+    public void setServerName(String serverName) {
+        if(serverNameField != null) {
+            this.serverNameField.setText(getText(serverName));
+        }
+    }
+
+    public void updateConnectingStrategy(ConnectingServerStrategy connectingServerStrategy, int waitForTimeout, String waitForTrace) {
+        connectingServerConfigurationPanel.update(connectingServerStrategy, waitForTimeout, waitForTrace);
+    }
+
+    public EnvironmentVariablesComponent getEnvironmentVariables() {
+        return environmentVariables;
+    }
+
+    private @NlsSafe @Nullable String getText(@Nullable String text) {
+        return text != null ? text : "";
+    }
+
+    public String getCommandLine() {
+        return commandLine.getText();
+    }
+
+    public CommandLineWidget getCommandLineWidget() {
+        return commandLine;
+    }
+
+    public void setCommandLine(String commandLine) {
+        this.commandLine.setText(getText(commandLine));
+    }
+
+    public DAPConnectingServerConfigurationPanel getConnectingServerConfigurationPanel() {
+        return connectingServerConfigurationPanel;
+    }
+
+    public ServerTrace getServerTrace() {
+        return (ServerTrace) serverTraceComboBox.getSelectedItem();
+    }
+
+    public void setServerTrace(ServerTrace serverTrace) {
+        serverTraceComboBox.setSelectedItem(serverTrace);
+    }
+
+    // Mappings settings
+
+    public DAPServerMappingsPanel getMappingsPanel() {
+        return mappingsPanel;
+    }
+
+    public @NotNull List<ServerMappingSettings> getMappings() {
+        return mappingsPanel.getAllMappings();
+    }
+
+    public void setMappings(@NotNull List<ServerMappingSettings> serverMappings) {
+        List<ServerMappingSettings> languageMappings = serverMappings
+                .stream()
+                .filter(mapping -> !StringUtils.isEmpty(mapping.getLanguage()))
+                .collect(Collectors.toList());
+        mappingsPanel.setLanguageMappings(languageMappings);
+
+        List<ServerMappingSettings> fileTypeMappings = serverMappings
+                .stream()
+                .filter(mapping -> !StringUtils.isEmpty(mapping.getFileType()))
+                .collect(Collectors.toList());
+        mappingsPanel.setFileTypeMappings(fileTypeMappings);
+
+        List<ServerMappingSettings> fileNamePatternMappings = serverMappings
+                .stream()
+                .filter(mapping -> mapping.getFileNamePatterns() != null)
+                .collect(Collectors.toList());
+        mappingsPanel.setFileNamePatternMappings(fileNamePatternMappings);
+    }
+
+    // Configuration settings
+
+    public String getWorkingDirectory() {
+        return workingDirectoryField.getText();
+    }
+
+    public void setWorkingDirectory(String workingDirectory) {
+        this.workingDirectoryField.setText(getText(workingDirectory));
+    }
+
+    public String getFile() {
+        return fileField.getText();
+    }
+
+    public void setFile(String file) {
+        this.fileField.setText(getText(file));
+    }
+
+    @NotNull
+    public DebuggingType getDebuggingType() {
+        return attachRadioButton.isSelected() ? DebuggingType.ATTACH : DebuggingType.LAUNCH;
+    }
+
+    public void setDebuggingType(@Nullable DebuggingType debuggingType) {
+        boolean attachType = debuggingType != null && debuggingType == DebuggingType.ATTACH;
+        if (attachType) {
+            selectAttachDebuggingType();
+        } else {
+            selectLaunchDebuggingType();
+        }
+    }
+
+    public String getLaunchConfiguration() {
+        return launchConfigurationField.getText();
+    }
+
+    public void setLaunchConfiguration(String launchConfiguration) {
+        this.launchConfigurationField.setText(getText(launchConfiguration));
+        this.launchConfigurationField.setCaretPosition(0);
+    }
+
+    public String getAttachConfiguration() {
+        return attachConfigurationField.getText();
+    }
+
+    public void setAttachConfiguration(String attachConfiguration) {
+        this.attachConfigurationField.setText(getText(attachConfiguration));
+        this.attachConfigurationField.setCaretPosition(0);
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public ComboBox<ServerTrace> getServerTraceComboBox() {
+        return serverTraceComboBox;
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterDescriptorFactoryView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterDescriptorFactoryView.java
@@ -1,0 +1,382 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.settings.ui;
+
+import com.google.common.collect.Streams;
+import com.intellij.execution.configuration.EnvironmentVariablesData;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UI;
+import com.redhat.devtools.lsp4ij.dap.configurations.DAPServerMappingsPanel;
+import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterManager;
+import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.dap.settings.UserDefinedDebugAdapterDescriptorFactorySettings;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
+import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
+import com.redhat.devtools.lsp4ij.settings.ServerTrace;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * UI view to define a Debug Adapter descriptor factory.
+ */
+public class DebugAdapterDescriptorFactoryView implements Disposable {
+
+    private final DebugAdapterDescriptorFactoryNameProvider descriptorFactoryNameProvider;
+    private final boolean isUserDefined;
+    private final Project project;
+
+    public interface DebugAdapterDescriptorFactoryNameProvider {
+        String getDisplayName();
+    }
+
+    private final JPanel myMainPanel;
+    private final @NotNull DebugAdapterDescriptorFactory dapDescriptorFactory;
+
+    private DebugAdapterDescriptorFactoryPanel dapDescriptorFactoryPanel;
+
+    private DAPServerMappingsPanel mappingPanel;
+
+    public DebugAdapterDescriptorFactoryView(@NotNull DebugAdapterDescriptorFactory dapDescriptorFactory,
+                                             @Nullable DebugAdapterDescriptorFactoryView.DebugAdapterDescriptorFactoryNameProvider dapDescriptorFactoryNameProvider,
+                                             @NotNull Project project) {
+        this.project = project;
+        this.dapDescriptorFactory = dapDescriptorFactory;
+        this.descriptorFactoryNameProvider = dapDescriptorFactoryNameProvider;
+        isUserDefined = dapDescriptorFactory instanceof UserDefinedDebugAdapterDescriptorFactory;
+        JComponent descriptionPanel = createDescription(dapDescriptorFactory.getDescription());
+        JPanel settingsPanel = createSettings(descriptionPanel, isUserDefined);
+        if (!isUserDefined) {
+            TitledBorder title = IdeBorderFactory.createTitledBorder(dapDescriptorFactory.getDisplayName());
+            settingsPanel.setBorder(title);
+        }
+        JPanel wrapper = JBUI.Panels.simplePanel(settingsPanel);
+        wrapper.setBorder(JBUI.Borders.emptyLeft(10));
+        this.myMainPanel = wrapper;
+    }
+
+    /**
+     * Returns true if there are some modification in the UI fields and false otherwise.
+     *
+     * @return true if there are some modification in the UI fields and false otherwise.
+     */
+    public boolean isModified() {
+        String descriptorFactoryId = dapDescriptorFactory.getId();
+        if (isUserDefined) {
+            UserDefinedDebugAdapterDescriptorFactorySettings.ItemSettings settings = UserDefinedDebugAdapterDescriptorFactorySettings.getInstance().getSettings(descriptorFactoryId);
+            if (settings == null) {
+                return true;
+            }
+            if (!(isEquals(getDisplayName(), settings.getServerName())
+                    && isEquals(this.getCommandLine(), settings.getCommandLine())
+                    && Objects.equals(this.getEnvData().getEnvs(), settings.getUserEnvironmentVariables())
+                    && this.getEnvData().isPassParentEnvs() == settings.isIncludeSystemEnvironmentVariables()
+                    && isEquals(this.getWaitForTimeout(), settings.getWaitForTimeout())
+                    && isEquals(this.getWaitForTrace(), settings.getWaitForTrace())
+                    && Objects.equals(this.getMappings(), settings.getMappings())
+                    && isEquals(this.getLaunchConfiguration(), settings.getLaunchConfiguration())
+                    && isEquals(this.getLaunchConfigurationSchema(), settings.getLaunchConfigurationSchema())
+                    && isEquals(this.getAttachConfiguration(), settings.getAttachConfiguration())
+                    && isEquals(this.getAttachConfigurationSchema(), settings.getAttachConfigurationSchema()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean isEquals(String s1, String s2) {
+        // the comparison between null and "" should return true
+        s1 = s1 == null ? "" : s1;
+        s2 = s2 == null ? "" : s2;
+        return Objects.equals(s1, s2);
+    }
+
+    static boolean isEquals(ServerTrace st1, ServerTrace st2) {
+        // the comparison between null and default value trace should return true
+        st1 = st1 == null ? ServerTrace.getDefaultValue() : st1;
+        st2 = st2 == null ? ServerTrace.getDefaultValue() : st2;
+        return Objects.equals(st1, st2);
+    }
+    /**
+     * Update the UI from the registered language server definition + settings.
+     */
+    public void reset() {
+        String descriptorFactoryId = dapDescriptorFactory.getId();
+
+        if (isUserDefined) {
+            // User defined language server
+            UserDefinedDebugAdapterDescriptorFactorySettings.ItemSettings settings = UserDefinedDebugAdapterDescriptorFactorySettings.getInstance().getSettings(descriptorFactoryId);
+            if (settings != null) {
+                this.setCommandLine(settings.getCommandLine());
+                this.setEnvData(EnvironmentVariablesData.create(
+                        settings.getUserEnvironmentVariables(),
+                        settings.isIncludeSystemEnvironmentVariables()));
+                this.dapDescriptorFactoryPanel.getConnectingServerConfigurationPanel().update(null,getInt(settings.getWaitForTimeout()), settings.getWaitForTrace() );
+
+                List<ServerMappingSettings> languageMappings = settings.getMappings()
+                        .stream()
+                        .filter(mapping -> !StringUtils.isEmpty(mapping.getLanguage()))
+                        .collect(Collectors.toList());
+                this.setLanguageMappings(languageMappings);
+
+                List<ServerMappingSettings> fileTypeMappings = settings.getMappings()
+                        .stream()
+                        .filter(mapping -> !StringUtils.isEmpty(mapping.getFileType()))
+                        .collect(Collectors.toList());
+                this.setFileTypeMappings(fileTypeMappings);
+
+                List<ServerMappingSettings> fileNamePatternMappings = settings.getMappings()
+                        .stream()
+                        .filter(mapping -> mapping.getFileNamePatterns() != null)
+                        .collect(Collectors.toList());
+                this.setFileNamePatternMappings(fileNamePatternMappings);
+
+                this.setLaunchConfiguration(settings.getLaunchConfiguration());
+                this.setAttachConfiguration(settings.getLaunchConfiguration());
+            }
+        } else {
+            // TODO : extension point
+            /*List<LanguageServerFileAssociation> mappings = LanguageServersRegistry.getInstance().findLanguageServerDefinitionFor(languageServerId);
+            List<ServerMappingSettings> languageMappings = mappings
+                    .stream()
+                    .filter(mapping -> mapping.getLanguage() != null)
+                    .map(mapping -> {
+                        Language language = mapping.getLanguage();
+                        String languageId = mapping.getLanguageId();
+                        return ServerMappingSettings.createLanguageMappingSettings(language.getID(), languageId);
+                    })
+                    .collect(Collectors.toList());
+            this.setLanguageMappings(languageMappings);
+
+            List<ServerMappingSettings> fileTypeMappings = mappings
+                    .stream()
+                    .filter(mapping -> mapping.getFileType() != null)
+                    .map(mapping -> {
+                        FileType fileType = mapping.getFileType();
+                        String languageId = mapping.getLanguageId();
+                        return ServerMappingSettings.createFileTypeMappingSettings(fileType.getName(), languageId);
+                    })
+                    .collect(Collectors.toList());
+            this.setFileTypeMappings(fileTypeMappings);
+
+            List<ServerMappingSettings> fileNamePatternMappings = mappings
+                    .stream()
+                    .filter(mapping -> mapping.getFileNameMatchers() != null)
+                    .map(mapping -> {
+                        List<FileNameMatcher> matchers = mapping.getFileNameMatchers();
+                        String languageId = mapping.getLanguageId();
+                        return ServerMappingSettings.createFileNamePatternsMappingSettings(matchers.
+                                stream()
+                                .map(FileNameMatcher::getPresentableString)
+                                .toList(), languageId);
+                    })
+                    .collect(Collectors.toList());
+            this.setFileNamePatternMappings(fileNamePatternMappings);*/
+        }
+    }
+
+    public void setLaunchConfiguration(String launchConfiguration) {
+        dapDescriptorFactoryPanel.setLaunchConfiguration(launchConfiguration);
+    }
+
+    public void setAttachConfiguration(String attachConfiguration) {
+        dapDescriptorFactoryPanel.setAttachConfiguration(attachConfiguration);
+    }
+
+    private static int getInt(String text) {
+        try {
+            return Integer.parseInt(text);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Update the proper debug adapter descriptor factory from the UI fields.
+     */
+    public void apply() {
+        String descriptorFactoryId = dapDescriptorFactory.getId();
+        UserDefinedDebugAdapterDescriptorFactorySettings.ItemSettings settings = UserDefinedDebugAdapterDescriptorFactorySettings.getInstance().getSettings(descriptorFactoryId);
+        if (dapDescriptorFactory instanceof UserDefinedDebugAdapterDescriptorFactory userDefinedFactory) {
+            // Register settings and server definition without firing events
+            var settingsChangedEvent = UserDefinedDebugAdapterDescriptorFactorySettings
+                    .getInstance()
+                    .updateSettings(descriptorFactoryId, settings, false);
+            // Update user-defined language server settings
+            var serverChangedEvent = DebugAdapterManager.getInstance()
+                    .updateDescriptorFactory(
+                            new DebugAdapterManager.UpdateDebugAdapterDescriptorFactoryRequest(
+                                    userDefinedFactory,
+                                    getDisplayName(),
+                                    getEnvData().getEnvs(),
+                                    getEnvData().isPassParentEnvs(),
+                                    getCommandLine(),
+                                    getWaitForTimeout(),
+                                    getWaitForTrace(),
+                                    getLanguageMappings(),
+                                    getFileTypeMappings(),
+                                    getLaunchConfiguration(),
+                                    getLaunchConfigurationSchema(),
+                                    getAttachConfiguration(),
+                                    getAttachConfigurationSchema()),
+                            false);
+            if (settingsChangedEvent != null) {
+                // Settings has changed, fire the event
+                UserDefinedDebugAdapterDescriptorFactorySettings
+                        .getInstance()
+                        .handleChanged(settingsChangedEvent);
+            }
+            if (serverChangedEvent != null) {
+                // Server definition has changed, fire the event
+                DebugAdapterManager.getInstance().handleChangeEvent(serverChangedEvent);
+            }
+        }
+    }
+
+    private String getDisplayName() {
+        return descriptorFactoryNameProvider != null ? descriptorFactoryNameProvider.getDisplayName() : dapDescriptorFactory.getDisplayName();
+    }
+
+    private JPanel createSettings(JComponent description, boolean launchingServerDefinition) {
+        FormBuilder builder = FormBuilder
+                .createFormBuilder()
+                .setFormLeftIndent(10);
+        this.dapDescriptorFactoryPanel = new DebugAdapterDescriptorFactoryPanel(builder,
+                description,
+                launchingServerDefinition ? DebugAdapterDescriptorFactoryPanel.EditionMode.EDIT_USER_DEFINED :
+                        DebugAdapterDescriptorFactoryPanel.EditionMode.EDIT_EXTENSION, project);
+        this.mappingPanel = dapDescriptorFactoryPanel.getMappingsPanel();
+        return builder.getPanel();
+    }
+
+    private JComponent createDescription(String description) {
+        /**
+         * Normally comments are below the controls.
+         * Here we want the comments to precede the controls, we therefore create an empty, 0-sized panel.
+         */
+        JPanel titledComponent = UI.PanelFactory.grid().createPanel();
+        titledComponent.setMinimumSize(JBUI.emptySize());
+        titledComponent.setPreferredSize(JBUI.emptySize());
+        if (description == null) {
+            description = "";
+        }
+        description = description.trim();
+        if (!description.isBlank()) {
+            titledComponent = UI.PanelFactory.panel(titledComponent)
+                    .withComment(description)
+                    .resizeX(true)
+                    .resizeY(true)
+                    .createPanel();
+        }
+        return titledComponent;
+    }
+
+    public void setEnvData(EnvironmentVariablesData envData) {
+        if (envData != null) {
+            dapDescriptorFactoryPanel.getEnvironmentVariables().setEnvData(envData);
+        }
+    }
+
+    public @NotNull EnvironmentVariablesData getEnvData() {
+        return dapDescriptorFactoryPanel.getEnvironmentVariables().getEnvData();
+    }
+
+    public JComponent getComponent() {
+        return myMainPanel;
+    }
+    
+    public String getCommandLine() {
+        return dapDescriptorFactoryPanel.getCommandLine();
+    }
+
+    public void setCommandLine(String commandLine) {
+        dapDescriptorFactoryPanel.setCommandLine(commandLine);
+    }
+
+    public String getWaitForTimeout() {
+        return dapDescriptorFactoryPanel.getConnectingServerConfigurationPanel().getTimeout();
+    }
+
+    public String getWaitForTrace() {
+        return dapDescriptorFactoryPanel.getConnectingServerConfigurationPanel().getTrace();
+    }
+
+    public ServerTrace getServerTrace() {
+        return (ServerTrace) dapDescriptorFactoryPanel.getServerTraceComboBox().getSelectedItem();
+    }
+
+    public void setServerTrace(ServerTrace serverTrace) {
+        dapDescriptorFactoryPanel.getServerTraceComboBox().setSelectedItem(serverTrace);
+    }
+    
+    public void setLanguageMappings(@NotNull List<ServerMappingSettings> mappings) {
+        mappingPanel.setLanguageMappings(mappings);
+    }
+
+    public void setFileTypeMappings(@NotNull List<ServerMappingSettings> mappings) {
+        mappingPanel.setFileTypeMappings(mappings);
+    }
+
+    public void setFileNamePatternMappings(List<ServerMappingSettings> mappings) {
+        mappingPanel.setFileNamePatternMappings(mappings);
+    }
+
+    @Override
+    public void dispose() {
+        dapDescriptorFactoryPanel.dispose();
+    }
+
+    public List<ServerMappingSettings> getLanguageMappings() {
+        return mappingPanel.getLanguageMappings();
+    }
+
+    public List<ServerMappingSettings> getFileTypeMappings() {
+        return Streams.concat(mappingPanel.getFileTypeMappings().stream(),
+                mappingPanel.getFileNamePatternMappings().stream())
+                .toList();
+    }
+
+    public List<ServerMappingSettings> getMappings() {
+        return Streams.concat(mappingPanel.getLanguageMappings().stream(),
+                        mappingPanel.getFileTypeMappings().stream(),
+                        mappingPanel.getFileNamePatternMappings().stream())
+                .toList();
+    }
+
+    public @Nullable String getLaunchConfiguration() {
+        return dapDescriptorFactoryPanel.getLaunchConfiguration();
+    }
+
+    public @Nullable String getLaunchConfigurationSchema() {
+        return null;
+    }
+
+    public @Nullable String getAttachConfiguration() {
+        return dapDescriptorFactoryPanel.getAttachConfiguration();
+    }
+
+    public @Nullable String getAttachConfigurationSchema() {
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/NewDebugAdapterDescriptorFactoryDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/NewDebugAdapterDescriptorFactoryDialog.java
@@ -1,0 +1,297 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.settings.ui;
+
+import com.google.common.collect.Streams;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.ui.DocumentAdapter;
+import com.intellij.ui.SimpleListCellRenderer;
+import com.intellij.util.ui.FormBuilder;
+import com.intellij.util.ui.JBInsets;
+import com.redhat.devtools.lsp4ij.dap.DAPBundle;
+import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterManager;
+import com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplate;
+import com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplateManager;
+import com.redhat.devtools.lsp4ij.dap.descriptors.userdefined.UserDefinedDebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.text.JTextComponent;
+import java.awt.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * New Debug Adapter descriptor factory dialog.
+ */
+public class NewDebugAdapterDescriptorFactoryDialog extends DialogWrapper {
+
+    private final ComboBox<DAPTemplate> templateCombo = new ComboBox<>(new DefaultComboBoxModel<>(getDAPTemplates()));
+    private final Project project;
+
+    private DebugAdapterDescriptorFactoryPanel dapDescriptorFactoryPanel;
+    private DAPTemplate currentTemplate = null;
+    private JButton showInstructionButton = null;
+    private UserDefinedDebugAdapterDescriptorFactory createdFactory;
+
+    private static DAPTemplate[] getDAPTemplates() {
+        List<DAPTemplate> templates = new ArrayList<>();
+        templates.add(DAPTemplate.NONE);
+        templates.addAll(DAPTemplateManager.getInstance().getTemplates());
+        return templates.toArray(new DAPTemplate[0]);
+    }
+
+    public NewDebugAdapterDescriptorFactoryDialog(@Nullable Project project) {
+        super(project);
+        this.project = project;
+        super.setTitle(DAPBundle.message("new.debug.adapter.dialog.title"));
+        init();
+        initValidation();
+    }
+
+    @Override
+    protected @Nullable JComponent createCenterPanel() {
+        FormBuilder builder = FormBuilder
+                .createFormBuilder();
+
+        // Template combo
+        createTemplateCombo(builder);
+        // Create server name,  command line, mappings, configuration UI
+        this.dapDescriptorFactoryPanel = new DebugAdapterDescriptorFactoryPanel(builder, null, DebugAdapterDescriptorFactoryPanel.EditionMode.NEW_USER_DEFINED, project);
+
+        // Add validation
+        addValidator(this.dapDescriptorFactoryPanel.getServerNameField());
+        addValidator(this.dapDescriptorFactoryPanel.getCommandLineWidget());
+
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(builder.getPanel(), BorderLayout.CENTER);
+        return panel;
+    }
+
+    private void createTemplateCombo(FormBuilder builder) {
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        templateCombo.setRenderer(new SimpleListCellRenderer<>() {
+            @Override
+            public void customize(@NotNull JList list,
+                                  @Nullable DAPTemplate value,
+                                  int index,
+                                  boolean selected,
+                                  boolean hasFocus) {
+                if (value == null) {
+                    setText("");
+                } else {
+                    setText(value.getName());
+                }
+            }
+        });
+
+        showInstructionButton = super.createHelpButton(new JBInsets(0, 0, 0, 0));
+        showInstructionButton.setText("");
+        templateCombo.addItemListener(getTemplateComboListener());
+
+        panel.add(templateCombo, BorderLayout.WEST);
+        panel.add(showInstructionButton, BorderLayout.CENTER);
+        builder.addLabeledComponent(DAPBundle.message("new.debug.adapter.dialog.template"), panel);
+    }
+
+    /**
+     * Create the template combo listener that handles item selection
+     *
+     * @return created ItemListener
+     */
+    private ItemListener getTemplateComboListener() {
+        return e -> {
+            // Only trigger listener on selected items to avoid double triggering
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+                currentTemplate = templateCombo.getItem();
+                showInstructionButton.setEnabled(hasValidDescription(currentTemplate));
+                if (currentTemplate != null) {
+                    loadFromTemplate(currentTemplate);
+                }
+            }
+        };
+    }
+
+    /**
+     * Check that the template is not a placeholder and that it has a valid description
+     *
+     * @param template to check
+     * @return true if template is not null, not a placeholder and has a description, else false
+     */
+    private boolean hasValidDescription(@Nullable DAPTemplate template) {
+        return template != null && template != DAPTemplate.NONE
+                && template != DAPTemplate.NEW_TEMPLATE
+                && StringUtils.isNotBlank(template.getDescription());
+    }
+
+   /* @Override
+    protected @NotNull Action getHelpAction() {
+        return new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (currentTemplate != null && StringUtils.isNotBlank(currentTemplate.getDescription())) {
+                    ShowInstructionDialog dialog = new ShowInstructionDialog(currentTemplate, project);
+                    dialog.show();
+                }
+            }
+        };
+    }*/
+
+    private void loadFromTemplate(DAPTemplate template) {
+        // Update name
+        var serverName = this.dapDescriptorFactoryPanel.getServerNameField();
+        serverName.setText(template.getName() != null ? template.getName() : "");
+
+        // Update command
+        String command = getCommandLine(template);
+        this.dapDescriptorFactoryPanel.setCommandLine(command);
+
+        // Update wait for trace
+        this.dapDescriptorFactoryPanel.getConnectingServerConfigurationPanel().update(null,
+                getInt(template.getWaitForTimeout()),
+                template.getWaitForTrace());
+
+        // Update mappings
+        var mappingsPanel = this.dapDescriptorFactoryPanel.getMappingsPanel();
+        mappingsPanel.refreshMappings(template.getLanguageMappings(), template.getFileTypeMappings());
+
+        // Update launch configuration
+        this.dapDescriptorFactoryPanel.setLaunchConfiguration(template.getLaunchConfiguration());
+
+        // Update attach configuration
+        this.dapDescriptorFactoryPanel.setAttachConfiguration(template.getAttachConfiguration());
+
+    }
+
+    private static int getInt(String text) {
+        try {
+            return Integer.parseInt(text);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private static String getCommandLine(DAPTemplate entry) {
+        StringBuilder command = new StringBuilder();
+        if (entry.getProgramArgs() != null) {
+            if (!command.isEmpty()) {
+                command.append(' ');
+            }
+            command.append(entry.getProgramArgs());
+        }
+        return command.toString();
+    }
+
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return this.dapDescriptorFactoryPanel.getServerNameField();
+    }
+
+    @Override
+    protected @NotNull List<ValidationInfo> doValidateAll() {
+        List<ValidationInfo> validations = new ArrayList<>();
+        addValidationInfo(validateServerName(), validations);
+        addValidationInfo(validateCommand(), validations);
+        return validations;
+    }
+
+    private void addValidationInfo(ValidationInfo validationInfo, List<ValidationInfo> validations) {
+        if (validationInfo == null) {
+            return;
+        }
+        validations.add((validationInfo));
+    }
+
+    private ValidationInfo validateServerName() {
+        var serverName = this.dapDescriptorFactoryPanel.getServerNameField();
+        if (serverName.getText().isBlank()) {
+            String errorMessage = DAPBundle.message("new.debug.adapter.dialog.validation.serverName.must.be.set");
+            return new ValidationInfo(errorMessage, serverName);
+        }
+        return null;
+    }
+
+    private ValidationInfo validateCommand() {
+        var commandLine = this.dapDescriptorFactoryPanel.getCommandLine();
+        if (commandLine.isBlank()) {
+            String errorMessage = DAPBundle.message("new.debug.adapter.dialog.validation.commandLine.must.be.set");
+            return new ValidationInfo(errorMessage, this.dapDescriptorFactoryPanel.getCommandLineWidget());
+        }
+        return null;
+    }
+
+    @Override
+    protected Action @NotNull [] createActions() {
+        return new Action[]{getOKAction(), getCancelAction()};
+    }
+
+
+    @Override
+    protected void doOKAction() {
+        super.doOKAction();
+
+        String serverId = UUID.randomUUID().toString();
+        // Register language server and mappings definition
+        String serverName = this.dapDescriptorFactoryPanel.getServerNameField().getText();
+        Map<String, String> userEnvironmentVariables = this.dapDescriptorFactoryPanel.getEnvironmentVariables().getEnvs();
+        boolean includeSystemEnvironmentVariables = this.dapDescriptorFactoryPanel.getEnvironmentVariables().isPassParentEnvs();
+        String commandLine = this.dapDescriptorFactoryPanel.getCommandLine();
+        String waitFor = this.dapDescriptorFactoryPanel.getConnectingServerConfigurationPanel().getTimeout();
+        String trackTrace = this.dapDescriptorFactoryPanel.getConnectingServerConfigurationPanel().getTrace();
+        String launchConfiguration = this.dapDescriptorFactoryPanel.getLaunchConfiguration();
+        String attachConfiguration = this.dapDescriptorFactoryPanel.getAttachConfiguration();
+        var mappingsPanel = dapDescriptorFactoryPanel.getMappingsPanel();
+        createdFactory = new UserDefinedDebugAdapterDescriptorFactory(serverId,
+                serverName,
+                commandLine,
+                mappingsPanel.getLanguageMappings(),
+                Streams.concat(mappingsPanel.getFileTypeMappings().stream(),
+                        mappingsPanel.getFileNamePatternMappings().stream())
+                        .toList());
+        createdFactory.setUserEnvironmentVariables(userEnvironmentVariables);
+        createdFactory.setIncludeSystemEnvironmentVariables(includeSystemEnvironmentVariables);
+        createdFactory.setWaitForTimeout(waitFor);
+        createdFactory.setWaitForTrace(trackTrace);
+        createdFactory.setLaunchConfiguration(launchConfiguration);
+        createdFactory.setAttachConfiguration(attachConfiguration);
+        DebugAdapterManager.getInstance().addDebugAdapterDescriptorFactory(createdFactory);
+    }
+
+    private void addValidator(JTextComponent textComponent) {
+        textComponent.getDocument().addDocumentListener(new DocumentAdapter() {
+            @Override
+            protected void textChanged(@NotNull DocumentEvent e) {
+                NewDebugAdapterDescriptorFactoryDialog.super.initValidation();
+            }
+        });
+    }
+
+    @Override
+    protected void dispose() {
+        this.dapDescriptorFactoryPanel.dispose();
+        super.dispose();
+    }
+
+    @Nullable
+    public UserDefinedDebugAdapterDescriptorFactory getCreatedFactory() {
+        return createdFactory;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/UserDefinedLanguageServerSettings.java
@@ -100,6 +100,7 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
      * @param newSettings      the language server settings for the given language server id with the given settings.
      * @param notify           true if a handle changed must be done and false otherwise.
      */
+    @Nullable
     public UserDefinedLanguageServerSettingsListener.LanguageServerSettingsChangedEvent updateSettings(@NotNull String languageServerId,
                                                                                                        @NotNull LanguageServerDefinitionSettings newSettings,
                                                                                                        boolean notify) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/EditJsonSchemaDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/EditJsonSchemaDialog.java
@@ -33,7 +33,7 @@ public class EditJsonSchemaDialog extends DialogWrapper {
     private String jsonSchemaContent;
     private JsonTextField jsonSchemaWidget;
 
-    protected EditJsonSchemaDialog(@NotNull Project project, String jsonSchemaContent) {
+    public EditJsonSchemaDialog(@NotNull Project project, String jsonSchemaContent) {
         super(true);
         this.project = project;
         this.jsonSchemaContent = jsonSchemaContent;

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
@@ -35,6 +35,7 @@ import com.redhat.devtools.lsp4ij.settings.ErrorReportingKind;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import com.redhat.devtools.lsp4ij.settings.jsonSchema.LSPClientConfigurationJsonSchemaFileProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -79,7 +80,10 @@ public class LanguageServerPanel implements Disposable {
     private JsonTextField initializationOptionsWidget;
     private JsonTextField clientConfigurationWidget;
 
-    public LanguageServerPanel(FormBuilder builder, JComponent description, EditionMode mode, Project project) {
+    public LanguageServerPanel(@NotNull FormBuilder builder,
+                               @Nullable JComponent description,
+                               @NotNull EditionMode mode,
+                               @NotNull Project project) {
         this.project = project;
         createUI(builder, description, mode);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/ServerMappingsPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/ServerMappingsPanel.java
@@ -83,7 +83,7 @@ public class ServerMappingsPanel {
      *
      * @param template the language server template.
      */
-    public void refreshMappings(LanguageServerTemplate template) {
+    public void refreshMappings(@NotNull LanguageServerTemplate template) {
         // refresh language mappings list
         setLanguageMappings(template.getLanguageMappings());
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -744,6 +744,15 @@ L
                                   implementation="com.redhat.devtools.lsp4ij.dap.configurations.DAPRunConfigurationProvider" />
         <applicationService
                 serviceImplementation="com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplateManager"/>
+        <projectConfigurable
+                groupId="debugger"
+                id="debugAdapterDescriptorFactories"
+                bundle="messages.DAPBundle"
+                nonDefaultProject="true"
+                key="debug.adapter"
+                instance="com.redhat.devtools.lsp4ij.dap.settings.DebugAdapterDescriptorFactoryListConfigurable"/>
+        <applicationService id="UserDefinedDAPServerSettings"
+                            serviceImplementation="com.redhat.devtools.lsp4ij.dap.settings.UserDefinedDebugAdapterDescriptorFactorySettings"/>
     </extensions>
 
 </idea-plugin>

--- a/src/main/resources/dap/templates/go-delve/attach.json
+++ b/src/main/resources/dap/templates/go-delve/attach.json
@@ -1,5 +1,5 @@
 {
-  "type": "pwa-node",
+  "type": "go",
   "request": "attach",
   "program": "${file}",
   "cwd": "${workspaceFolder}"

--- a/src/main/resources/messages/DAPBundle.properties
+++ b/src/main/resources/messages/DAPBundle.properties
@@ -15,8 +15,37 @@
 DAPRunConfigurationType.displayName=Debug Adapter Protocol
 DAPRunConfigurationType.description=Debug Adapter Protocol configuration type
 
+## List configurable
+debug.adapter=Debug Adapter Protocol
+debug.adapter.action.add=Add Debug Adapter descriptor factory
+debug.adapter.action.remove=Remove selected Debug Adapter descriptor factory(ies)
+
+## New Debug Adapter descriptor factory dialog
+new.debug.adapter.dialog.title=New Debug Adapter descriptor factory
+new.debug.adapter.dialog.template=Template:
+new.debug.adapter.dialog.validation.serverName.must.be.set=Server name must be set
+new.debug.adapter.dialog.validation.commandLine.must.be.set=Command must be set
+
 # DAP settings editor
-# - Program settings
+# - Server settings
+dap.settings.editor.server.tab=Server
+dap.settings.editor.server.factory.field=Use an existing Debug Adapter Server:
+dap.settings.editor.server.factory.or=or
+dap.settings.editor.server.factory.create=create a new.
+dap.settings.editor.server.name.field=Name:
+dap.settings.editor.server.command.field=Command:
+dap.settings.editor.server.connecting.strategy.label=Connecting to the server:
+dap.settings.editor.server.connecting.strategy.none=after starting server.
+dap.settings.editor.server.connecting.strategy.timeout=after waiting for (ms):
+dap.settings.editor.server.connecting.strategy.trace=after finding trace:
+dap.settings.editor.server.serverTrace.field=Trace:
+# - Mappings settings
+dap.settings.editor.mappings.tab=Mappings
+dap.settings.editor.mappings.title=Declare file associations to allow setting breakpoints
+dap.settings.editor.mappings.language=Language
+dap.settings.editor.mappings.fileType=File type
+dap.settings.editor.mappings.fileNamePattern=File name patterns
+# - Configuration settings
 dap.settings.editor.configuration.tab=Configuration
 dap.settings.editor.configuration.cwd.field=Working directory:
 dap.settings.editor.configuration.file.field=File:
@@ -27,25 +56,6 @@ dap.settings.editor.configuration.parameters.field=DAP parameters (JSON):
 dap.settings.editor.configuration.parameters.launch.tab=Launch
 dap.settings.editor.configuration.parameters.attach.tab=Attach
 
-dap.settings.editor.mappings.tab=Mappings
-dap.settings.editor.mappings.title=Declare file associations to allow setting breakpoints
-dap.settings.editor.mappings.language=Language
-dap.settings.editor.mappings.fileType=File type
-dap.settings.editor.mappings.fileNamePattern=File name patterns
-
-dap.settings.editor.server.tab=Server
-dap.settings.editor.server.factory.field=Existing server:
-dap.settings.editor.server.name.field=Name:
-dap.settings.editor.server.command.field=Command:
-dap.settings.editor.server.connecting.strategy.label=Connecting to the server:
-dap.settings.editor.server.connecting.strategy.none=after starting server.
-dap.settings.editor.server.connecting.strategy.timeout=after waiting for (ms):
-dap.settings.editor.server.connecting.strategy.trace=after finding trace:
-dap.settings.editor.server.waitForTimeout.field=Wait for (ms):
-dap.settings.editor.server.waitForTrace.field=Wait for trace:
-dap.settings.editor.server.serverTrace.field=Trace:
-
-# DAP client
+# DAP client connecting...
 dap.client.connecting.no.port.title=Connecting to {0}...
 dap.client.connecting.at.port.title=Connecting to {0} at ''{1}'' port...
-


### PR DESCRIPTION
feat: provide UI to define DAP descriptor factory

Now it is possible to define Debug Adapter server in global settings:

![image](https://github.com/user-attachments/assets/8ff0d7a2-b9e9-4dd0-a2f1-8fef133a7def)

After that we can use it in the launch:

![image](https://github.com/user-attachments/assets/2c4917f4-0c1f-498e-8a9e-93a7b5e1e38b)

We can also click on "create new" to open the dialog and fill it:

![image](https://github.com/user-attachments/assets/c52694c1-9a20-47ad-94b1-e1edd0cce9ff)
