### PR TITLE
feat: Inlay hints refactor

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -170,8 +170,9 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     private void refreshInlayHintsForAllOpenedFiles() {
         for (var fileData : wrapper.getConnectedFiles()) {
             VirtualFile file = fileData.getFile();
-            EditorFeatureManager.getInstance(getProject())
-                    .refreshEditorFeature(file, EditorFeatureType.INLAY_HINT, true);
+            EditorFeatureManager efm = EditorFeatureManager.getInstance(getProject());
+            efm.refreshEditorFeature(file, EditorFeatureType.INLAY_HINT, true);
+            efm.refreshEditorFeature(file, EditorFeatureType.DECLARATIVE_INLAY_HINT, true);
         }
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
@@ -40,7 +40,7 @@ import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNorma
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.waitUntilDone;
 
 /**
- * LSP textDocument/color support.
+ * LSP textDocument/colorInformation support.
  */
 public class LSPColorProvider extends AbstractLSPInlayHintsProvider {
 
@@ -51,7 +51,7 @@ public class LSPColorProvider extends AbstractLSPInlayHintsProvider {
                              @NotNull Editor editor,
                              @NotNull PresentationFactory factory,
                              @NotNull InlayHintsSink inlayHintsSink,
-                             @NotNull List<CompletableFuture> pendingFutures) {
+                             @NotNull List<CompletableFuture<?>> pendingFutures) {
         // Get LSP color information from cache or create them
         LSPColorSupport colorSupport = LSPFileSupport.getSupport(psiFile).getColorSupport();
         var params = new DocumentColorParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()));

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/AbstractLSPDeclarativeInlayHintsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/AbstractLSPDeclarativeInlayHintsProvider.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * FalsePattern - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.inlayhint;
+
+import com.intellij.codeInsight.hints.declarative.*;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.client.ExecuteLSPFeatureStatus;
+import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
+import com.redhat.devtools.lsp4ij.commands.CommandExecutor;
+import com.redhat.devtools.lsp4ij.commands.LSPCommandContext;
+import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager;
+import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureType;
+import org.eclipse.lsp4j.Command;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+import java.awt.event.InputEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/*
+ * Abstract class used to display IntelliJ inlay hints.
+ */
+public abstract class AbstractLSPDeclarativeInlayHintsProvider implements InlayHintsProvider {
+
+    private static final SharedBypassCollector EMPTY_INLAY_HINTS_COLLECTOR = (psiElement, inlayHintsSink) -> {
+        // Do nothing
+    };
+
+    @Override
+    public @Nullable InlayHintsCollector createCollector(@NotNull PsiFile psiFile, @NotNull Editor editor) {
+        if (ProjectIndexingManager.canExecuteLSPFeature(psiFile) != ExecuteLSPFeatureStatus.NOW) {
+            return EMPTY_INLAY_HINTS_COLLECTOR;
+        }
+
+        final long modificationStamp = psiFile.getModificationStamp();
+        return new Collector(editor, modificationStamp);
+    }
+
+    protected void executeCommand(@Nullable Command command,
+                                  @NotNull PsiFile file,
+                                  @NotNull Editor editor,
+                                  @Nullable InputEvent event,
+                                  @NotNull LanguageServerItem languageServer) {
+        if (command == null) {
+            return;
+        }
+        LSPCommandContext context = new LSPCommandContext(command, file, LSPCommandContext.ExecutedBy.INLAY_HINT, editor, languageServer)
+                .setSource(event != null ? (Component) event.getSource() : null)
+                .setInputEvent(event);
+        CommandExecutor.executeCommand(context);
+    }
+
+    protected abstract void doCollect(@NotNull PsiFile psiFile,
+                                      @NotNull Editor editor,
+                                      @NotNull InlayTreeSink inlayHintsSink,
+                                      @NotNull List<CompletableFuture<?>> pendingFutures);
+
+
+    private class Collector implements OwnBypassCollector {
+        private final @NotNull Editor editor;
+        private final long modificationStamp;
+
+        public Collector(@NotNull Editor editor, long modificationStamp) {
+            this.editor = editor;
+            this.modificationStamp = modificationStamp;
+        }
+
+        @Override
+        public void collectHintsForFile(@NotNull PsiFile psiFile, @NotNull InlayTreeSink inlayTreeSink) {
+            Project project = psiFile.getProject();
+            if (project.isDisposed()) {
+                // InlayHint must not be collected
+                return;
+            }
+
+            final List<CompletableFuture<?>> pendingFutures = new ArrayList<>();
+            doCollect(psiFile, editor, inlayTreeSink, pendingFutures);
+            if (!pendingFutures.isEmpty()) {
+                // Some LSP requests:
+                // - textDocument/inlayHint, inlayHint/resolve
+                // are pending, wait for their completion and refresh the declarative inlay hints UI to render them
+                EditorFeatureManager.getInstance(project).refreshEditorFeatureWhenAllDone(pendingFutures, modificationStamp, psiFile, EditorFeatureType.DECLARATIVE_INLAY_HINT);
+            }
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPDeclarativeInlayActionHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPDeclarativeInlayActionHandler.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * FalsePattern - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.inlayhint;
+
+import com.intellij.codeInsight.hints.declarative.InlayActionHandler;
+import com.intellij.codeInsight.hints.declarative.InlayActionPayload;
+import com.intellij.codeInsight.hints.declarative.PsiPointerInlayActionPayload;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Segment;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.SmartPsiElementPointer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
+
+/**
+ * LSP textDocument/inlayHint command handling
+ */
+public class LSPDeclarativeInlayActionHandler implements InlayActionHandler {
+    public static final String HANDLER_ID = "LSP4IJ";
+
+    @Override
+    public void handleClick(@NotNull Editor editor, @NotNull InlayActionPayload payload) {
+        if (!(payload instanceof PsiPointerInlayActionPayload pointerPayload))
+            return;
+        var thePointer = pointerPayload.getPointer();
+        if (!(thePointer instanceof LSPPayloadAction action))
+            return;
+        action.onClick(editor);
+    }
+
+    //This is technically a hack, but it seems to be reliable enough for the time being.
+    public static InlayActionPayload createPayload(Project project, Consumer<Editor> callback) {
+        return new PsiPointerInlayActionPayload(new LSPPayloadAction() {
+            @Override
+            public void onClick(Editor editor) {
+                callback.accept(editor);
+            }
+
+            @Override
+            public @NotNull Project getProject() {
+                return project;
+            }
+        });
+    }
+
+    public interface LSPPayloadAction extends SmartPsiElementPointer<PsiElement> {
+        void onClick(Editor editor);
+
+        @Override
+        default @Nullable PsiElement getElement() {
+            return null;
+        }
+
+        @Override
+        default @Nullable PsiFile getContainingFile() {
+            return null;
+        }
+
+        @Override
+        default VirtualFile getVirtualFile() {
+            return null;
+        }
+
+        @Override
+        default @Nullable Segment getRange() {
+            return null;
+        }
+
+        @Override
+        default @Nullable Segment getPsiRange() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPDeclarativeInlayHintProvidersFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPDeclarativeInlayHintProvidersFactory.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * FalsePattern - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.inlayhint;
+
+
+import com.intellij.codeInsight.hints.declarative.InlayHintsProviderFactory;
+import com.intellij.codeInsight.hints.declarative.InlayProviderInfo;
+import com.intellij.lang.Language;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * {@link InlayHintsProviderFactory inlay hint factory} implementation
+ * to register all languages mapped with a language server with {@link LSPInlayHintsProvider}
+ * to avoid for the external plugin to declare in plugin.xml the 'codeInsight.inlayProvider'.
+ */
+public class LSPDeclarativeInlayHintProvidersFactory implements InlayHintsProviderFactory {
+    @Override
+    public @Nullable InlayProviderInfo getProviderInfo(@NotNull Language language, @NotNull String providerId) {
+        return getProvidersForLanguage(language)
+                .stream()
+                .filter(info -> info.getProviderId().equals(providerId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public @NotNull List<InlayProviderInfo> getProvidersForLanguage(@NotNull Language language) {
+        return LanguageServersRegistry.getInstance().getDeclarativeInlayHintProviderInfos().getOrDefault(language.getID(), Collections.emptyList());
+    }
+
+    @Override
+    public @NotNull Set<Language> getSupportedLanguages() {
+        return LanguageServersRegistry.getInstance().getDeclarativeInlayHintProviderInfos().keySet().stream().map(Language::findLanguageByID).collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/CodeVisionEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/CodeVisionEditorFeature.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.lsp4ij.internal.editor;
 import com.intellij.codeInsight.codeVision.CodeVisionHost;
 import com.intellij.codeInsight.codeVision.CodeVisionInitializer;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.features.codeLens.DummyCodeVisionProviderFactory;
@@ -61,7 +62,7 @@ public class CodeVisionEditorFeature implements EditorFeature {
     }
 
     @Override
-    public void clearEditorCache(@NotNull Editor editor) {
+    public void clearEditorCache(@NotNull Editor editor, @NotNull Project project) {
         try {
             // Clear the modification stamp stored in the editor user-data
             // (with the key PSI_MODIFICATION_STAMP)

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/DeclarativeInlayHintsEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/DeclarativeInlayHintsEditorFeature.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * FalsePattern - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.internal.editor;
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
+import com.intellij.codeInsight.hints.declarative.impl.DeclarativeInlayHintsPassFactory;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Declarative inlay hints feature to refresh IntelliJ declarative inlay hints (even if Psi file doesn't change).
+ */
+@ApiStatus.Internal
+public class DeclarativeInlayHintsEditorFeature implements EditorFeature {
+    @Override
+    public EditorFeatureType getFeatureType() {
+        return EditorFeatureType.DECLARATIVE_INLAY_HINT;
+    }
+
+    @Override
+    public void clearEditorCache(@NotNull Editor editor, @NotNull Project project) {
+        DeclarativeInlayHintsPassFactory.Companion.scheduleRecompute(editor, project);
+    }
+
+    @Override
+    public void clearLSPCache(PsiFile file) {
+        // Evict the cache of LSP requests from inlayHint support
+        var fileSupport = LSPFileSupport.getSupport(file);
+        fileSupport.getInlayHintsSupport().cancel();
+    }
+
+    @Override
+    public void collectUiRunnable(@NotNull Editor editor,
+                                  @NotNull PsiFile file,
+                                  @NotNull List<Runnable> runnableList) {
+        Runnable runnable = () -> {
+            // Refresh the annotations, inlay hints both
+            DaemonCodeAnalyzer.getInstance(file.getProject()).restart(file);
+        };
+        runnableList.add(runnable);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeature.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.internal.editor;
 
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -35,7 +36,7 @@ public interface EditorFeature {
      *
      * @param editor the editor.
      */
-    void clearEditorCache(@NotNull Editor editor);
+    void clearEditorCache(@NotNull Editor editor, @NotNull Project project);
 
     /**
      * Clear LSP data cache (ex : LSP CodeLens).

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureType.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureType.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
 @ApiStatus.Internal
 public enum EditorFeatureType {
     CODE_VISION,
+    DECLARATIVE_INLAY_HINT,
     INLAY_HINT,
     FOLDING,
     ALL

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/FoldingEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/FoldingEditorFeature.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.internal.editor;
 
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import org.jetbrains.annotations.ApiStatus;
@@ -43,7 +44,7 @@ public class FoldingEditorFeature implements EditorFeature {
     }
 
     @Override
-    public void clearEditorCache(@NotNull Editor editor) {
+    public void clearEditorCache(@NotNull Editor editor, @NotNull Project project) {
         try {
             // Clear the modification stamp stored in the editor user-data
             // (with the key CODE_FOLDING_KEY)

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/InlayHintsEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/InlayHintsEditorFeature.java
@@ -12,6 +12,7 @@ package com.redhat.devtools.lsp4ij.internal.editor;
 
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import org.jetbrains.annotations.ApiStatus;
@@ -59,7 +60,7 @@ public class InlayHintsEditorFeature implements EditorFeature {
     }
 
     @Override
-    public void clearEditorCache(@NotNull Editor editor) {
+    public void clearEditorCache(@NotNull Editor editor, @NotNull Project project) {
         // old class: com.intellij.codeInsight.hints.InlayHintsPassFactory
         // --> InlayHintsPassFactory.Companion.clearModificationStamp(editor);
         //
@@ -78,9 +79,8 @@ public class InlayHintsEditorFeature implements EditorFeature {
 
     @Override
     public void clearLSPCache(PsiFile file) {
-        // Evict the cache of LSP requests from inlayHint and color support
+        // Evict the cache of LSP requests from color support
         var fileSupport = LSPFileSupport.getSupport(file);
-        fileSupport.getInlayHintsSupport().cancel();
         fileSupport.getColorSupport().cancel();
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/InlayHintCapabilityRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/InlayHintCapabilityRegistry.java
@@ -44,7 +44,7 @@ public class InlayHintCapabilityRegistry extends TextDocumentServerCapabilityReg
             hasCapability(o.getResolveProvider());
 
     public InlayHintCapabilityRegistry(@NotNull LSPClientFeatures clientFeatures) {
-        super(clientFeatures, EditorFeatureType.INLAY_HINT );
+        super(clientFeatures, EditorFeatureType.DECLARATIVE_INLAY_HINT );
     }
 
     class ExtendedInlayHintRegistrationOptions extends InlayHintRegistrationOptions implements ExtendedDocumentSelector.DocumentFilersProvider {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -307,7 +307,16 @@ L
                 id="LSPCodeLensProvider"
                 implementation="com.redhat.devtools.lsp4ij.features.codeLens.LSPCodeLensProvider"/>
 
-        <!-- LSP textDocument/inlayHint + textDocument/colorInformation requests support -->
+        <!-- LSP textDocument/inlayHint requests support -->
+        <codeInsight.declarativeInlayProviderFactory
+                id="LSPDeclarativeInlayHintProvidersFactory"
+                implementation="com.redhat.devtools.lsp4ij.features.inlayhint.LSPDeclarativeInlayHintProvidersFactory"/>
+
+        <codeInsight.inlayActionHandler
+                handlerId="LSP4IJ"
+                implementationClass="com.redhat.devtools.lsp4ij.features.inlayhint.LSPDeclarativeInlayActionHandler"/>
+
+        <!-- LSP textDocument/colorInformation requests support -->
         <codeInsight.inlayProviderFactory
                 id="LSPInlayHintProvidersFactory"
                 implementation="com.redhat.devtools.lsp4ij.features.LSPInlayHintProvidersFactory"/>

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -219,3 +219,6 @@ lsp.goto.declaration.progress.title=Find declaration(s) of ''{0}'' at ''{1}''
 lsp.goto.implementation.progress.title=Find implementation(s) of ''{0}'' at ''{1}''
 lsp.goto.reference.progress.title=Find type reference(s) of ''{0}'' at ''{1}''
 lsp.goto.typeDefinition.progress.title=Find type definition(s) of ''{0}'' at ''{1}''
+
+# Inlay hints
+lsp.hints.declarative.provider.name=Language Server


### PR DESCRIPTION
## Goals
- ~~Completely remove the dependency on the deprecated inlay hints API.~~ non-goal for this PR, it's needed for color hints
- Migrate inlay hints support to the declarative API
- Fix the double inlay hints bug

## Fixes
- https://github.com/redhat-developer/lsp4ij/issues/606, primary goal of this PR
- https://github.com/redhat-developer/lsp4ij/issues/382, as a side effect of the rendering being completely delegated to the intellij gui backend 
![image](https://github.com/user-attachments/assets/111299ab-56ce-4d5d-b80a-a96be870b5ac)


## Current draft regressions
- ~~Inlay hint hover/click actions are not yet implemented~~ fixed
- ~~`textDocument/color` support is impossible through the declarative API due to its limitations, it only supports text nodes, and "trees" of text nodes~~ fixed, uses the old api

