### PR TITLE
feat: Statement group and code block selectioners

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/AbstractLSPExtendWordSelectionHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/AbstractLSPExtendWordSelectionHandler.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.selectionRange;
+
+import com.intellij.codeInsight.editorActions.ExtendWordSelectionHandler;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Abstract base class for 'extendWordSelectionHandler' implementations for LSP4IJ files.
+ */
+abstract class AbstractLSPExtendWordSelectionHandler implements ExtendWordSelectionHandler {
+
+    @Override
+    public boolean canSelect(@NotNull PsiElement element) {
+        if (!element.isValid()) {
+            return false;
+        }
+
+        PsiFile file = element.getContainingFile();
+        if ((file == null) || !file.isValid()) {
+            return false;
+        }
+
+        Project project = file.getProject();
+        if (project.isDisposed()) {
+            return false;
+        }
+
+        VirtualFile virtualFile = file.getVirtualFile();
+        if ((virtualFile == null) || !virtualFile.isValid()) {
+            return false;
+        }
+
+        return LanguageServersRegistry.getInstance().isFileSupported(file);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockBodySelectioner.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockBodySelectioner.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.selectionRange;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+import static com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase.expandToWholeLinesWithBlanks;
+
+/**
+ * Extend word selection handler that includes all distinct lines within a code block.
+ */
+class LSPCodeBlockBodySelectioner implements LSPCodeBlockSelectioner {
+
+    @Override
+    @Nullable
+    public List<TextRange> getTextRanges(@NotNull PsiFile file,
+                                         @NotNull Editor editor,
+                                         @NotNull CharSequence editorText,
+                                         @NotNull TextRange codeBlockRange,
+                                         int currentLineNumber) {
+        // Make sure there's actually a code block to select
+        Document document = editor.getDocument();
+        int codeBlockStartLineNumber = document.getLineNumber(codeBlockRange.getStartOffset());
+        int codeBlockEndLineNumber = document.getLineNumber(codeBlockRange.getEndOffset());
+        if ((codeBlockEndLineNumber - codeBlockStartLineNumber) < 2) {
+            return null;
+        }
+
+        // Select all lines in the code block
+        int codeBlockBodyStartOffset = document.getLineStartOffset(codeBlockStartLineNumber + 1);
+        int codeBlockBodyEndOffset = document.getLineEndOffset(codeBlockEndLineNumber - 1);
+        TextRange codeBlockBodyTextRange = TextRange.create(codeBlockBodyStartOffset, codeBlockBodyEndOffset);
+        return expandToWholeLinesWithBlanks(editorText, codeBlockBodyTextRange);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockExtendWordSelectionHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockExtendWordSelectionHandler.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.selectionRange;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.text.TextRangeUtil;
+import com.redhat.devtools.lsp4ij.features.codeBlockProvider.LSPCodeBlockProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Composite extend word selection handler for contents of LSP-defined code blocks that ensures that we only have to
+ * retrieve the code block text range once for all constituent selectioners.
+ */
+public class LSPCodeBlockExtendWordSelectionHandler extends AbstractLSPExtendWordSelectionHandler {
+
+    // This is a composite implementation that derives its information from each of the following
+    private final List<LSPCodeBlockSelectioner> codeBlockSelectioners = List.of(
+            new LSPCodeBlockStatementGroupSelectioner(),
+            new LSPCodeBlockBodySelectioner()
+    );
+
+    @Override
+    @Nullable
+    public final List<TextRange> select(@NotNull PsiElement element,
+                                        @NotNull CharSequence editorText,
+                                        int offset,
+                                        @NotNull Editor editor) {
+        PsiFile file = element.getContainingFile();
+        if (file == null) {
+            return null;
+        }
+
+        Document document = editor.getDocument();
+        int currentLineNumber = document.getLineNumber(offset);
+
+        // If necessary, move to the first non-whitespace character in the line for finding the code block
+        int currentLineStartOffset = document.getLineStartOffset(currentLineNumber);
+        int currentLineEndOffset = document.getLineEndOffset(currentLineNumber);
+        int effectiveOffset = Math.max(offset, currentLineStartOffset);
+        while ((effectiveOffset <= currentLineEndOffset) && Character.isWhitespace(editorText.charAt(effectiveOffset))) {
+            effectiveOffset++;
+        }
+
+        // Get the current code block once
+        TextRange codeBlockRange = LSPCodeBlockProvider.getCodeBlockRange(editor, file, effectiveOffset);
+        if (codeBlockRange == null) {
+            return null;
+        }
+
+        // Add text ranges from all constituent selectioners
+        Set<TextRange> textRanges = new LinkedHashSet<>();
+        for (LSPCodeBlockSelectioner codeBlockSelectioner : codeBlockSelectioners) {
+            List<TextRange> textRangesForSelectioner = codeBlockSelectioner.getTextRanges(
+                    file,
+                    editor,
+                    editorText,
+                    codeBlockRange,
+                    currentLineNumber
+            );
+            if (!ContainerUtil.isEmpty(textRangesForSelectioner)) {
+                ContainerUtil.addAllNotNull(textRanges, textRangesForSelectioner);
+            }
+        }
+        if (textRanges.isEmpty()) {
+            return null;
+        }
+
+        List<TextRange> sortedTextRanges = new ArrayList<>(textRanges);
+        sortedTextRanges.sort(TextRangeUtil.RANGE_COMPARATOR);
+        return sortedTextRanges;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockSelectioner.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockSelectioner.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.selectionRange;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Extend word selection handler interface for contents of LSP-defined code blocks retrieved via
+ * {@link LSPCodeBlockExtendWordSelectionHandler}.
+ */
+interface LSPCodeBlockSelectioner {
+
+    /**
+     * Returns the selection text ranges for the specified code block and current line number.
+     *
+     * @param file              the PSI file
+     * @param editor            the editor
+     * @param editorText        the editor text
+     * @param codeBlockRange    the code block text range
+     * @param currentLineNumber the current line number
+     * @return the selection text ranges or null if this selectioner cannot provide selection text ranges
+     */
+    @Nullable
+    List<TextRange> getTextRanges(@NotNull PsiFile file,
+                                  @NotNull Editor editor,
+                                  @NotNull CharSequence editorText,
+                                  @NotNull TextRange codeBlockRange,
+                                  int currentLineNumber);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockStatementGroupSelectioner.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockStatementGroupSelectioner.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.selectionRange;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.features.codeBlockProvider.LSPCodeBlockProvider;
+import com.redhat.devtools.lsp4ij.features.codeBlockProvider.LSPCodeBlockUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.intellij.codeInsight.editorActions.ExtendWordSelectionHandlerBase.expandToWholeLinesWithBlanks;
+
+/**
+ * Extend word selection handler that includes statement groups, i.e., groups of statements within the same code block
+ * that have no intermediate empty lines.
+ */
+class LSPCodeBlockStatementGroupSelectioner implements LSPCodeBlockSelectioner {
+
+    @Nullable
+    public List<TextRange> getTextRanges(@NotNull PsiFile file,
+                                         @NotNull Editor editor,
+                                         @NotNull CharSequence editorText,
+                                         @NotNull TextRange codeBlockRange,
+                                         int currentLineNumber) {
+        // Must be starting on a non-empty line
+        Document document = editor.getDocument();
+        if (isEmpty(document, editorText, currentLineNumber)) {
+            return null;
+        }
+
+        // The current statement group contains all non-empty lines within the code block from the start offset
+        int codeBlockStartLineNumber = document.getLineNumber(codeBlockRange.getStartOffset());
+        int codeBlockEndLineNumber = document.getLineNumber(codeBlockRange.getEndOffset());
+        if ((codeBlockStartLineNumber >= currentLineNumber) || (codeBlockEndLineNumber <= currentLineNumber)) {
+            return null;
+        }
+
+        int statementGroupStartLineNumber = currentLineNumber;
+        while ((statementGroupStartLineNumber > codeBlockStartLineNumber) &&
+               !isEmpty(document, editorText, statementGroupStartLineNumber - 1)) {
+            int pendingStatementGroupStartLineNumber = statementGroupStartLineNumber - 1;
+
+            // If this line looks like it might end a nested code block, confirm that to be the case or not, and if so,
+            // add all lines in that nested code block
+            int currentLineStartOffset = document.getLineStartOffset(statementGroupStartLineNumber);
+            int currentLineEndOffset = document.getLineEndOffset(statementGroupStartLineNumber);
+            while ((currentLineStartOffset <= currentLineEndOffset) && Character.isWhitespace(editorText.charAt(currentLineStartOffset))) {
+                currentLineStartOffset++;
+            }
+            if (LSPCodeBlockUtils.isCodeBlockEndChar(file, editorText.charAt(currentLineStartOffset))) {
+                TextRange nestedCodeBlockRange = LSPCodeBlockProvider.getCodeBlockRange(editor, file, currentLineStartOffset - 1);
+                if ((nestedCodeBlockRange != null) && codeBlockRange.contains(nestedCodeBlockRange) && !Objects.equals(codeBlockRange, nestedCodeBlockRange)) {
+                    int nestedCodeBlockStartLineNumber = document.getLineNumber(nestedCodeBlockRange.getStartOffset());
+                    if ((nestedCodeBlockStartLineNumber > codeBlockStartLineNumber) && (nestedCodeBlockStartLineNumber < statementGroupStartLineNumber)) {
+                        pendingStatementGroupStartLineNumber = nestedCodeBlockStartLineNumber;
+                    }
+                }
+            }
+
+            statementGroupStartLineNumber = pendingStatementGroupStartLineNumber;
+        }
+        statementGroupStartLineNumber = Math.max(statementGroupStartLineNumber, codeBlockStartLineNumber + 1);
+
+        int statementGroupEndLineNumber = currentLineNumber;
+        while ((statementGroupEndLineNumber < codeBlockEndLineNumber) &&
+               !isEmpty(document, editorText, statementGroupEndLineNumber + 1)) {
+            int pendingStatementGroupEndLineNumber = statementGroupEndLineNumber + 1;
+
+            // If this line looks like it might start a nested code block, confirm that to be the case or not, and if
+            // so, add all lines in that nested code block
+            int currentLineStartOffset = document.getLineStartOffset(statementGroupEndLineNumber);
+            int currentLineEndOffset = document.getLineEndOffset(statementGroupEndLineNumber);
+            while ((currentLineEndOffset >= currentLineStartOffset) && Character.isWhitespace(editorText.charAt(currentLineEndOffset))) {
+                currentLineEndOffset--;
+            }
+            if (LSPCodeBlockUtils.isCodeBlockStartChar(file, editorText.charAt(currentLineEndOffset))) {
+                TextRange nestedCodeBlockRange = LSPCodeBlockProvider.getCodeBlockRange(editor, file, currentLineEndOffset + 1);
+                if ((nestedCodeBlockRange != null) && codeBlockRange.contains(nestedCodeBlockRange) && !Objects.equals(codeBlockRange, nestedCodeBlockRange)) {
+                    int nestedCodeBlockEndLineNumber = document.getLineNumber(nestedCodeBlockRange.getEndOffset());
+                    if ((nestedCodeBlockEndLineNumber < codeBlockEndLineNumber) && (nestedCodeBlockEndLineNumber > statementGroupEndLineNumber)) {
+                        pendingStatementGroupEndLineNumber = nestedCodeBlockEndLineNumber;
+                    }
+                }
+            }
+
+            statementGroupEndLineNumber = pendingStatementGroupEndLineNumber;
+        }
+        statementGroupEndLineNumber = Math.min(statementGroupEndLineNumber, codeBlockEndLineNumber - 1);
+
+        int statementGroupStartOffset = document.getLineStartOffset(statementGroupStartLineNumber);
+        int statementGroupEndOffset = document.getLineEndOffset(statementGroupEndLineNumber);
+        TextRange statementGroupTextRange = TextRange.create(statementGroupStartOffset, statementGroupEndOffset);
+        return expandToWholeLinesWithBlanks(editorText, statementGroupTextRange);
+    }
+
+    private static boolean isEmpty(@NotNull Document document,
+                                   @NotNull CharSequence editorText,
+                                   int lineNumber) {
+        int lineStartOffset = document.getLineStartOffset(lineNumber);
+        int lineEndOffset = document.getLineEndOffset(lineNumber);
+        if (lineEndOffset > lineStartOffset) {
+            for (int offset = lineStartOffset; offset <= lineEndOffset; offset++) {
+                if (!Character.isWhitespace(editorText.charAt(offset))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -377,7 +377,12 @@ L
         <!-- LSP textDocument/selectionRange request support -->
         <extendWordSelectionHandler
                 implementation="com.redhat.devtools.lsp4ij.features.selectionRange.LSPExtendWordSelectionHandler"
+                id="LSPExtendWordSelectionHandler"
                 order="first"/>
+        <extendWordSelectionHandler
+                implementation="com.redhat.devtools.lsp4ij.features.selectionRange.LSPCodeBlockExtendWordSelectionHandler"
+                id="LSPCodeBlockExtendWordSelectionHandler"
+                order="first, before LSPExtendWordSelectionHandler"/>
 
         <!-- LSP textDocument/semanticTokens request support -->
         <highlightVisitor

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/selectionRange/TypeScriptSelectionersTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/selectionRange/TypeScriptSelectionersTest.java
@@ -1,0 +1,1125 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.selectionRange;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPSelectionersFixtureTestCase;
+
+public class TypeScriptSelectionersTest extends LSPSelectionersFixtureTestCase {
+
+    private static final String TEST_FILE_NAME = "test.ts";
+
+    public TypeScriptSelectionersTest() {
+        super("*.ts");
+    }
+
+    // SIMPLE TESTS
+
+    // NOTE: This is sufficient to test both the statement group and code block body selectioners
+    // language=typescript
+    private static final String SIMPLE_TEST_FILE_BODY = """
+            export class Foo {
+                bar() {
+                    console.log('foo'); // line 2
+                    console.log('bar'); // line 3
+                    console.log('baz'); // line 4
+            
+                    console.log('foo'); // line 6
+                    console.log('bar'); // line 7
+                    console.log('baz'); // line 8
+                }
+            }
+            """;
+
+    // NOTE: This is slightly truncated to include selection ranges starting with the code block itself
+    // language=json
+    private static final String SIMPLE_MOCK_SELECTION_RANGES_JSON = """
+            [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 11
+                  },
+                  "end": {
+                    "line": 9,
+                    "character": 4
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 1,
+                      "character": 10
+                    },
+                    "end": {
+                      "line": 9,
+                      "character": 5
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 1,
+                        "character": 4
+                      },
+                      "end": {
+                        "line": 9,
+                        "character": 5
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 0,
+                          "character": 18
+                        },
+                        "end": {
+                          "line": 10,
+                          "character": 0
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 0,
+                            "character": 0
+                          },
+                          "end": {
+                            "line": 10,
+                            "character": 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+            """;
+
+    // language=json
+    private static final String SIMPLE_MOCK_FOLDING_RANGES_JSON = """
+            [
+              {
+                "startLine": 0,
+                "endLine": 9
+              },
+              {
+                "startLine": 1,
+                "endLine": 8
+              }
+            ]
+            """;
+
+    public void testSelectionersSimple() {
+        // Test from the start of any of the first three lines and the results should be the first statement group
+        // followed by that group plus the intermediate empty line followed by the code block body
+        for (int startLineNumber = 2; startLineNumber <= 4; startLineNumber++) {
+            testSelectioner(
+                    TEST_FILE_NAME,
+                    SIMPLE_TEST_FILE_BODY,
+                    SIMPLE_MOCK_SELECTION_RANGES_JSON,
+                    SIMPLE_MOCK_FOLDING_RANGES_JSON,
+                    startLineNumber,
+                    new int[][]{
+                            new int[]{2, 4},
+                            new int[]{2, 5},
+                            new int[]{2, 8},
+                    }
+            );
+        }
+
+        // Test from the start of any of the last three lines and the results should be the second statement group
+        // followed by that group plus the intermediate empty line followed by the code block body
+        for (int startLineNumber = 6; startLineNumber <= 8; startLineNumber++) {
+            testSelectioner(
+                    TEST_FILE_NAME,
+                    SIMPLE_TEST_FILE_BODY,
+                    SIMPLE_MOCK_SELECTION_RANGES_JSON,
+                    SIMPLE_MOCK_FOLDING_RANGES_JSON,
+                    startLineNumber,
+                    new int[][]{
+                            new int[]{6, 8},
+                            new int[]{5, 8},
+                            new int[]{2, 8},
+                    }
+            );
+        }
+    }
+
+    // COMPLEX TESTS
+
+    // NOTE: This is sufficient to test both the statement group and code block body selectioners
+    // language=typescript
+    @SuppressWarnings("TypeScriptUnresolvedReference")
+    private static final String COMPLEX_TEST_FILE_BODY = """
+            export class Foo {
+                bar(args) {
+                    console.log('Separate statement before');       // line 2
+            
+                    console.log('Contiguous statement before');     // line 4
+                    let condition: boolean = true;                  // line 5
+                    if (condition) {                                // line 6
+                        console.log('Separate statement before');   // line 7
+            
+                        console.log('Contiguous statement before'); // line 9
+                        invokePromise(args)                         // line 10
+                            .then(() => {                           // line 11
+                                console.log('demo');                // line 12
+                            })                                      // line 13
+                            .catch((error) => {                     // line 14
+                                console.error(error);               // line 15
+                            });                                     // line 16
+                        console.log('Contiguous statement after');  // line 17
+            
+                        console.log('Separate statement after');    // line 19
+                    }                                               // line 20
+                    console.log('Contiguous statement after');      // line 21
+            
+                    console.log('Separate statement after');        // line 23
+                }
+            }
+            """;
+
+    // NOTE: This includes selection ranges taken from all of the lines required for these tests and is slightly
+    // truncated to include selection ranges starting with the code block itself
+    // language=json
+    private static final String COMPLEX_MOCK_SELECTION_RANGES_JSON = """
+            [
+              {
+                "range": {
+                  "start": {
+                    "line": 2,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 15
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 2,
+                      "character": 8
+                    },
+                    "end": {
+                      "line": 2,
+                      "character": 19
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 2,
+                        "character": 8
+                      },
+                      "end": {
+                        "line": 2,
+                        "character": 48
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 2,
+                          "character": 8
+                        },
+                        "end": {
+                          "line": 2,
+                          "character": 49
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 1,
+                            "character": 15
+                          },
+                          "end": {
+                            "line": 24,
+                            "character": 4
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 4,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 15
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 4,
+                      "character": 8
+                    },
+                    "end": {
+                      "line": 4,
+                      "character": 19
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 4,
+                        "character": 8
+                      },
+                      "end": {
+                        "line": 4,
+                        "character": 50
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 4,
+                          "character": 8
+                        },
+                        "end": {
+                          "line": 4,
+                          "character": 51
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 1,
+                            "character": 15
+                          },
+                          "end": {
+                            "line": 24,
+                            "character": 4
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 5,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 11
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 5,
+                      "character": 8
+                    },
+                    "end": {
+                      "line": 5,
+                      "character": 38
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 6,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 10
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 6,
+                      "character": 8
+                    },
+                    "end": {
+                      "line": 20,
+                      "character": 9
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 1,
+                        "character": 15
+                      },
+                      "end": {
+                        "line": 24,
+                        "character": 4
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 7,
+                    "character": 12
+                  },
+                  "end": {
+                    "line": 7,
+                    "character": 19
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 7,
+                      "character": 12
+                    },
+                    "end": {
+                      "line": 7,
+                      "character": 23
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 7,
+                        "character": 12
+                      },
+                      "end": {
+                        "line": 7,
+                        "character": 52
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 7,
+                          "character": 12
+                        },
+                        "end": {
+                          "line": 7,
+                          "character": 53
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 6,
+                            "character": 24
+                          },
+                          "end": {
+                            "line": 20,
+                            "character": 8
+                          }
+                        },
+                        "parent": {
+                          "range": {
+                            "start": {
+                              "line": 6,
+                              "character": 8
+                            },
+                            "end": {
+                              "line": 20,
+                              "character": 9
+                            }
+                          },
+                          "parent": {
+                            "range": {
+                              "start": {
+                                "line": 1,
+                                "character": 15
+                              },
+                              "end": {
+                                "line": 24,
+                                "character": 4
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 9,
+                    "character": 12
+                  },
+                  "end": {
+                    "line": 9,
+                    "character": 19
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 9,
+                      "character": 12
+                    },
+                    "end": {
+                      "line": 9,
+                      "character": 23
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 9,
+                        "character": 12
+                      },
+                      "end": {
+                        "line": 9,
+                        "character": 54
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 9,
+                          "character": 12
+                        },
+                        "end": {
+                          "line": 9,
+                          "character": 55
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 6,
+                            "character": 24
+                          },
+                          "end": {
+                            "line": 20,
+                            "character": 8
+                          }
+                        },
+                        "parent": {
+                          "range": {
+                            "start": {
+                              "line": 6,
+                              "character": 8
+                            },
+                            "end": {
+                              "line": 20,
+                              "character": 9
+                            }
+                          },
+                          "parent": {
+                            "range": {
+                              "start": {
+                                "line": 1,
+                                "character": 15
+                              },
+                              "end": {
+                                "line": 24,
+                                "character": 4
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 10,
+                    "character": 12
+                  },
+                  "end": {
+                    "line": 10,
+                    "character": 25
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 10,
+                      "character": 12
+                    },
+                    "end": {
+                      "line": 10,
+                      "character": 31
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 10,
+                        "character": 12
+                      },
+                      "end": {
+                        "line": 11,
+                        "character": 21
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 10,
+                          "character": 12
+                        },
+                        "end": {
+                          "line": 13,
+                          "character": 18
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 10,
+                            "character": 12
+                          },
+                          "end": {
+                            "line": 14,
+                            "character": 22
+                          }
+                        },
+                        "parent": {
+                          "range": {
+                            "start": {
+                              "line": 10,
+                              "character": 12
+                            },
+                            "end": {
+                              "line": 16,
+                              "character": 18
+                            }
+                          },
+                          "parent": {
+                            "range": {
+                              "start": {
+                                "line": 10,
+                                "character": 12
+                              },
+                              "end": {
+                                "line": 16,
+                                "character": 19
+                              }
+                            },
+                            "parent": {
+                              "range": {
+                                "start": {
+                                  "line": 6,
+                                  "character": 24
+                                },
+                                "end": {
+                                  "line": 20,
+                                  "character": 8
+                                }
+                              },
+                              "parent": {
+                                "range": {
+                                  "start": {
+                                    "line": 6,
+                                    "character": 8
+                                  },
+                                  "end": {
+                                    "line": 20,
+                                    "character": 9
+                                  }
+                                },
+                                "parent": {
+                                  "range": {
+                                    "start": {
+                                      "line": 1,
+                                      "character": 15
+                                    },
+                                    "end": {
+                                      "line": 24,
+                                      "character": 4
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 17,
+                    "character": 12
+                  },
+                  "end": {
+                    "line": 17,
+                    "character": 19
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 17,
+                      "character": 12
+                    },
+                    "end": {
+                      "line": 17,
+                      "character": 23
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 17,
+                        "character": 12
+                      },
+                      "end": {
+                        "line": 17,
+                        "character": 53
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 17,
+                          "character": 12
+                        },
+                        "end": {
+                          "line": 17,
+                          "character": 54
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 6,
+                            "character": 24
+                          },
+                          "end": {
+                            "line": 20,
+                            "character": 8
+                          }
+                        },
+                        "parent": {
+                          "range": {
+                            "start": {
+                              "line": 6,
+                              "character": 8
+                            },
+                            "end": {
+                              "line": 20,
+                              "character": 9
+                            }
+                          },
+                          "parent": {
+                            "range": {
+                              "start": {
+                                "line": 1,
+                                "character": 15
+                              },
+                              "end": {
+                                "line": 24,
+                                "character": 4
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 19,
+                    "character": 12
+                  },
+                  "end": {
+                    "line": 19,
+                    "character": 19
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 19,
+                      "character": 12
+                    },
+                    "end": {
+                      "line": 19,
+                      "character": 23
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 19,
+                        "character": 12
+                      },
+                      "end": {
+                        "line": 19,
+                        "character": 51
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 19,
+                          "character": 12
+                        },
+                        "end": {
+                          "line": 19,
+                          "character": 52
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 6,
+                            "character": 24
+                          },
+                          "end": {
+                            "line": 20,
+                            "character": 8
+                          }
+                        },
+                        "parent": {
+                          "range": {
+                            "start": {
+                              "line": 6,
+                              "character": 8
+                            },
+                            "end": {
+                              "line": 20,
+                              "character": 9
+                            }
+                          },
+                          "parent": {
+                            "range": {
+                              "start": {
+                                "line": 1,
+                                "character": 15
+                              },
+                              "end": {
+                                "line": 24,
+                                "character": 4
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 21,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 21,
+                    "character": 15
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 21,
+                      "character": 8
+                    },
+                    "end": {
+                      "line": 21,
+                      "character": 19
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 21,
+                        "character": 8
+                      },
+                      "end": {
+                        "line": 21,
+                        "character": 49
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 21,
+                          "character": 8
+                        },
+                        "end": {
+                          "line": 21,
+                          "character": 50
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 1,
+                            "character": 15
+                          },
+                          "end": {
+                            "line": 24,
+                            "character": 4
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "range": {
+                  "start": {
+                    "line": 23,
+                    "character": 8
+                  },
+                  "end": {
+                    "line": 23,
+                    "character": 15
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 23,
+                      "character": 8
+                    },
+                    "end": {
+                      "line": 23,
+                      "character": 19
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 23,
+                        "character": 8
+                      },
+                      "end": {
+                        "line": 23,
+                        "character": 47
+                      }
+                    },
+                    "parent": {
+                      "range": {
+                        "start": {
+                          "line": 23,
+                          "character": 8
+                        },
+                        "end": {
+                          "line": 23,
+                          "character": 48
+                        }
+                      },
+                      "parent": {
+                        "range": {
+                          "start": {
+                            "line": 1,
+                            "character": 15
+                          },
+                          "end": {
+                            "line": 24,
+                            "character": 4
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+            """;
+
+    // language=json
+    private static final String COMPLEX_MOCK_FOLDING_RANGES_JSON = """
+            [
+              {
+                "startLine": 0,
+                "endLine": 24
+              },
+              {
+                "startLine": 1,
+                "endLine": 23
+              },
+              {
+                "startLine": 6,
+                "endLine": 19
+              },
+              {
+                "startLine": 11,
+                "endLine": 13
+              },
+              {
+                "startLine": 11,
+                "endLine": 12
+              },
+              {
+                "startLine": 14,
+                "endLine": 16
+              },
+              {
+                "startLine": 14,
+                "endLine": 15
+              }
+            ]
+            """;
+
+    public void testSelectionersComplex() {
+
+        // Test from the start of the first line in bar() and it should select that line plus the blank line after it
+        // then all lines in the body of bar()
+        testSelectioner(
+                TEST_FILE_NAME,
+                COMPLEX_TEST_FILE_BODY,
+                COMPLEX_MOCK_SELECTION_RANGES_JSON,
+                COMPLEX_MOCK_FOLDING_RANGES_JSON,
+                2,
+                new int[][]{
+                        new int[]{2, 2}, // No newline
+                        new int[]{2, 2}, // Newline
+                        new int[]{2, 3},
+                        new int[]{2, 23},
+                }
+        );
+
+        // Test from the start of any of the lines in the second larger statement group and it should select the entire
+        // statement group then all lines in the body of bar()
+        for (int[] startAndInitialEndLineNumbers : new int[][]{
+                new int[]{4, 4},
+                new int[]{5, 5},
+                new int[]{6, 20},
+                new int[]{21, 21}
+        }) {
+            int startLineNumber = startAndInitialEndLineNumbers[0];
+            int initialEndLineNumber = startAndInitialEndLineNumbers[1];
+            testSelectioner(
+                    TEST_FILE_NAME,
+                    COMPLEX_TEST_FILE_BODY,
+                    COMPLEX_MOCK_SELECTION_RANGES_JSON,
+                    COMPLEX_MOCK_FOLDING_RANGES_JSON,
+                    startLineNumber,
+                    new int[][]{
+                            new int[]{startLineNumber, initialEndLineNumber},
+                            new int[]{4, 21},
+                            new int[]{4, 22},
+                            new int[]{2, 23},
+                    }
+            );
+        }
+
+        // Test from the start of the last line in bar() and it should select that line plus the blank line before it
+        // then all lines in the body of bar()
+        testSelectioner(
+                TEST_FILE_NAME,
+                COMPLEX_TEST_FILE_BODY,
+                COMPLEX_MOCK_SELECTION_RANGES_JSON,
+                COMPLEX_MOCK_FOLDING_RANGES_JSON,
+                23,
+                new int[][]{
+                        new int[]{23, 23}, // No newline
+                        new int[]{23, 23}, // Newline
+                        new int[]{22, 23},
+                        new int[]{2, 23},
+                }
+        );
+
+        // Test from the start of the first line in the conditional block and it should select that line plus the blank
+        // line after it then all lines in the conditional block
+        testSelectioner(
+                TEST_FILE_NAME,
+                COMPLEX_TEST_FILE_BODY,
+                COMPLEX_MOCK_SELECTION_RANGES_JSON,
+                COMPLEX_MOCK_FOLDING_RANGES_JSON,
+                7,
+                new int[][]{
+                        new int[]{7, 7}, // No newline
+                        new int[]{7, 7}, // Newline
+                        new int[]{7, 8},
+                        new int[]{7, 19}
+                }
+        );
+
+        // Test from the start of any of the (simple) lines in the second larger statement group in the conditional
+        // block and it should select the entire statement group then all lines in the conditional block of bar()
+        for (int[] startAndInitialEndLineNumbers : new int[][]{
+                new int[]{9, 9},
+                // Line 10 is tested below
+                new int[]{17, 17}
+        }) {
+            int startLineNumber = startAndInitialEndLineNumbers[0];
+            int initialEndLineNumber = startAndInitialEndLineNumbers[1];
+            testSelectioner(
+                    TEST_FILE_NAME,
+                    COMPLEX_TEST_FILE_BODY,
+                    COMPLEX_MOCK_SELECTION_RANGES_JSON,
+                    COMPLEX_MOCK_FOLDING_RANGES_JSON,
+                    startLineNumber,
+                    new int[][]{
+                            new int[]{startLineNumber, initialEndLineNumber},
+                            new int[]{9, 17},
+                            new int[]{9, 18},
+                            new int[]{7, 19}
+                    }
+            );
+        }
+
+        // Test from the "invokePromise()" call in the conditional block and should select the call followed by the
+        // call plus the ".then" portion followed by that plus the ".catch" portion followed by all lines in the
+        // statement group followed by all lines in the conditional block
+        testSelectioner(
+                TEST_FILE_NAME,
+                COMPLEX_TEST_FILE_BODY,
+                COMPLEX_MOCK_SELECTION_RANGES_JSON,
+                COMPLEX_MOCK_FOLDING_RANGES_JSON,
+                10,
+                new int[][]{
+                        new int[]{10, 10},
+                        new int[]{10, 13},
+                        new int[]{10, 16},
+                        new int[]{9, 17},
+                        new int[]{9, 18},
+                        new int[]{7, 19}
+                }
+        );
+
+        // Test from the start of the last line in the conditional block and it should select that line plus the blank
+        // line before it then all lines in the conditional block
+        testSelectioner(
+                TEST_FILE_NAME,
+                COMPLEX_TEST_FILE_BODY,
+                COMPLEX_MOCK_SELECTION_RANGES_JSON,
+                COMPLEX_MOCK_FOLDING_RANGES_JSON,
+                19,
+                new int[][]{
+                        new int[]{19, 19}, // No newline
+                        new int[]{19, 19}, // Newline
+                        new int[]{18, 19},
+                        new int[]{7, 19}
+                }
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/selectionRange/TypeScriptSelectionersTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/selectionRange/TypeScriptSelectionersTest.java
@@ -13,6 +13,9 @@ package com.redhat.devtools.lsp4ij.features.selectionRange;
 
 import com.redhat.devtools.lsp4ij.fixtures.LSPSelectionersFixtureTestCase;
 
+/**
+ * TypeScript test for {@link LSPCodeBlockStatementGroupSelectioner} and {@link LSPCodeBlockBodySelectioner}.
+ */
 public class TypeScriptSelectionersTest extends LSPSelectionersFixtureTestCase {
 
     private static final String TEST_FILE_NAME = "test.ts";

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionersFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionersFixtureTestCase.java
@@ -28,12 +28,27 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Base class for language-specific testing of selectioner behavior.
+ */
 public abstract class LSPSelectionersFixtureTestCase extends LSPCodeInsightFixtureTestCase {
 
     protected LSPSelectionersFixtureTestCase(String... fileNamePatterns) {
         super(fileNamePatterns);
     }
 
+    /**
+     * Confirms selection ranges for the <b>Extend Selection</b> action.
+     *
+     * @param fileName                   the file name
+     * @param fileBody                   the file body
+     * @param mockSelectionRangesJson    mock {@code textDocument/selectionRange} response JSON
+     * @param mockFoldingRangesJson      mock {@code textDocument/foldingRange} response JSON
+     * @param startLineNumber            the line number at the beginning of which the <b>Extend Selection</b> action
+     *                                   will be invoked
+     * @param expectedSelectedLineRanges the expected selection ranges for each subsequent invocation of the
+     *                                   <b>Extend Selection</b> action from from {@code startLineNumber}
+     */
     protected void testSelectioner(@NotNull String fileName,
                                    @NotNull String fileBody,
                                    @NotNull String mockSelectionRangesJson,

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionersFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionersFixtureTestCase.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.fixtures;
+
+import com.google.gson.reflect.TypeToken;
+import com.intellij.openapi.actionSystem.IdeActions;
+import com.intellij.openapi.editor.CaretModel;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.SelectionModel;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.SelectionRange;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public abstract class LSPSelectionersFixtureTestCase extends LSPCodeInsightFixtureTestCase {
+
+    protected LSPSelectionersFixtureTestCase(String... fileNamePatterns) {
+        super(fileNamePatterns);
+    }
+
+    protected void testSelectioner(@NotNull String fileName,
+                                   @NotNull String fileBody,
+                                   @NotNull String mockSelectionRangesJson,
+                                   @NotNull String mockFoldingRangesJson,
+                                   int startLineNumber,
+                                   int[][] expectedSelectedLineRanges) {
+        MockLanguageServer.INSTANCE.setTimeToProceedQueries(100);
+        List<SelectionRange> mockSelectionRanges = JSONUtils.getLsp4jGson().fromJson(mockSelectionRangesJson, new TypeToken<List<SelectionRange>>() {
+        }.getType());
+        MockLanguageServer.INSTANCE.setSelectionRanges(mockSelectionRanges);
+
+        List<FoldingRange> mockFoldingRanges = JSONUtils.getLsp4jGson().fromJson(mockFoldingRangesJson, new TypeToken<List<FoldingRange>>() {
+        }.getType());
+        MockLanguageServer.INSTANCE.setFoldingRanges(mockFoldingRanges);
+
+        String fileBodyWithoutReferenceLineNumbers = fileBody.replaceAll("(?ms)[ \t]+// line \\d+[ \t]*$", "");
+        PsiFile file = myFixture.configureByText(fileName, fileBodyWithoutReferenceLineNumbers);
+        Editor editor = myFixture.getEditor();
+        Document document = editor.getDocument();
+
+        // Initialize the language server
+        try {
+            LanguageServiceAccessor.getInstance(file.getProject())
+                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .get(5000, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        // Move the caret to the beginning of the start line
+        int lineStartOffset = document.getLineStartOffset(startLineNumber);
+        CaretModel caretModel = editor.getCaretModel();
+        caretModel.moveToOffset(lineStartOffset);
+
+        // Make sure there's no initial selection
+        SelectionModel selectionModel = editor.getSelectionModel();
+        assertFalse(selectionModel.hasSelection());
+
+        // Extend the selection for each of the provided selection ranges and confirm they match expectations
+        for (int[] expectedSelectedLineRange : expectedSelectedLineRanges) {
+            int expectedSelectionStartLine = expectedSelectedLineRange[0];
+            int expectedSelectionEndLine = expectedSelectedLineRange[1];
+
+            myFixture.performEditorAction(IdeActions.ACTION_EDITOR_SELECT_WORD_AT_CARET);
+
+            String selectedText = selectionModel.getSelectedText();
+            assertNotNull(selectedText);
+            assertFalse(selectedText.isEmpty());
+
+            int actualSelectionStartOffset = selectionModel.getSelectionStart();
+            int actualSelectionStartLine = document.getLineNumber(actualSelectionStartOffset);
+            assertEquals(expectedSelectionStartLine, actualSelectionStartLine);
+            assertEquals(actualSelectionStartOffset, document.getLineStartOffset(actualSelectionStartLine));
+
+            int actualSelectionEndOffset = selectionModel.getSelectionEnd();
+            int actualSelectionEndLine = document.getLineNumber(actualSelectionEndOffset);
+            // The selection may actually extend to the beginning of the next line
+            if (selectedText.endsWith("\n")) {
+                assertEquals(expectedSelectionEndLine + 1, actualSelectionEndLine);
+                assertEquals(actualSelectionEndOffset, document.getLineStartOffset(actualSelectionEndLine));
+            } else {
+                assertEquals(expectedSelectionEndLine, actualSelectionEndLine);
+                assertEquals(actualSelectionEndOffset, document.getLineEndOffset(actualSelectionEndLine));
+            }
+        }
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/mock/MockTextDocumentService.java
@@ -384,7 +384,27 @@ public class MockTextDocumentService implements TextDocumentService {
 
     @Override
     public CompletableFuture<List<SelectionRange>> selectionRange(SelectionRangeParams params) {
-        return CompletableFuture.completedFuture(mockSelectionRanges);
+        // Find the mock selection ranges that apply to the specified position. This allows us to have a single mock
+        // response that covers multiple positions that might be queried during a given test.
+        List<SelectionRange> applicableMockSelectionRanges = mockSelectionRanges
+                .stream()
+                .filter(selectionRange -> {
+                    Position startPosition = selectionRange.getRange().getStart();
+                    Position endPosition = selectionRange.getRange().getEnd();
+                    for (Position currentPosition : params.getPositions()) {
+                        if (((startPosition.getLine() < currentPosition.getLine()) ||
+                             ((startPosition.getLine() == currentPosition.getLine()) &&
+                              (startPosition.getCharacter() <= currentPosition.getCharacter()))) &&
+                            ((endPosition.getLine() > currentPosition.getLine()) ||
+                             ((endPosition.getLine() == currentPosition.getLine()) &&
+                              (endPosition.getCharacter() >= currentPosition.getCharacter())))) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .toList();
+        return CompletableFuture.completedFuture(applicableMockSelectionRanges);
     }
 
     public void setSemanticTokens(final SemanticTokens semanticTokens) {


### PR DESCRIPTION
Previously we added support for the IDE's `extendWordSelectionHandler` using the LSP `textDocument/selectionRange` feature. That effectively allowed the user to extend and shrink the editor selection based on the document's syntax tree nodes with additional provisions to extend to full lines as appropriate. Natively-supported languages in JetBrains IDEs also include other _selectioners_ (not my term; see `com.intellij.codeInsight.editorActions.wordSelection.AbstractWordSelectioner`) to participate in this syntax-aware selection process that are not directly reflected in the document's AST. Two of the most useful ones are for selection of a _statement group_ -- a contiguous span of statements in the same code block with no intermediate blank lines -- and selection of all full lines within the same code block.

This PR includes those two selectioners for LSP4IJ-based files. For example, here is the selection behavior for a simple code block _without_ these changes:

![LSP_Code_Block_Selectioners_Simple_Without](https://github.com/user-attachments/assets/525b2ada-ec02-473b-a562-edd0ad4c202f)

and here is the behavior _with_ these changes:

![LSP_Code_Block_Selectioners_Simple_With](https://github.com/user-attachments/assets/c1d7ede2-ed1d-4c38-b6d0-633e02e05d72)

It's also important that the statement group selectioner understand nested code blocks that it doesn't end selection due to a blank line in, say, the nested code block for a conditional statement, instead treating the nested code block as part of that conditional statement in the current code block. Here's a more complex example, again first demonstrating the behavior _without_ these changes:

![LSP_Code_Block_Selectioners_Complex_Without](https://github.com/user-attachments/assets/3c6556f3-0d40-469e-b081-cc0c9310ea00)

and _with_ these changes:

![LSP_Code_Block_Selectioners_Complex_With](https://github.com/user-attachments/assets/135ab05c-6ced-406e-ab69-0a41721df1ea)

Hopefully those demonstrations properly convey the differences and that these changes provide the desired behavior for selection of statement groups and all statements within the current code block. If you use the **Extend/Shrink Selection** actions in a Java source file in IntelliJ IDEA, you should see the exact same behavior...and that's the whole point. I'm trying to make LSP-based files behave as close as possible to natively-supported files, at least within the limitations of LSP.

Note that these selectioners only apply to the current code block. If the selection is extended beyond the current code block, they are not used. This is to avoid having to call `LSPCodeBlockProvider.getCodeBlockRange()` excessively. But for the most common use case of wanting to select the current statement group and/or the current code block, it should work properly.