### PR TITLE
fix: LSP doesn't work for external dependencies (like jars)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
@@ -50,6 +50,11 @@ public class DAPExpressionCodeFragment extends PsiFileBase {
         return fileType;
     }
 
+    @Override
+    public boolean isPhysical() {
+        return false;
+    }
+
     public @Nullable DAPStackFrame getCurrentDapStackFrame() {
         return debugProcess.getCurrentDapStackFrame();
     }


### PR DESCRIPTION
fix: LSP doesn't work for external dependencies (like jars)

Fixes #782