### PR TITLE
feat: store template id in the user ls definition

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
@@ -159,6 +159,7 @@ public class LanguageServersRegistry {
                 // Register server definition from settings
                 addServerDefinitionWithoutNotification(new UserDefinedLanguageServerDefinition(
                                 serverId,
+                                launch.getTemplateId(),
                                 launch.getServerName(),
                                 "",
                                 launch.getCommandLine(),
@@ -370,6 +371,7 @@ public class LanguageServersRegistry {
         // Update settings
         if (serverDefinition instanceof UserDefinedLanguageServerDefinition definitionFromSettings) {
             UserDefinedLanguageServerSettings.UserDefinedLanguageServerItemSettings settings = new UserDefinedLanguageServerSettings.UserDefinedLanguageServerItemSettings();
+            settings.setTemplateId(definitionFromSettings.getTemplateId());
             settings.setServerId(languageServerId);
             settings.setServerName(definitionFromSettings.getDisplayName());
             settings.setCommandLine(definitionFromSettings.getCommandLine());

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/UserDefinedLanguageServerSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/UserDefinedLanguageServerSettings.java
@@ -107,6 +107,8 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
 
         private String serverId;
 
+        private String templateId;
+
         private String serverName;
 
         private String commandLine;
@@ -132,6 +134,14 @@ public class UserDefinedLanguageServerSettings implements PersistentStateCompone
 
         public void setServerId(String serverId) {
             this.serverId = serverId;
+        }
+
+        public String getTemplateId() {
+            return templateId;
+        }
+
+        public void setTemplateId(String templateId) {
+            this.templateId = templateId;
         }
 
         public String getServerName() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplate.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplate.java
@@ -44,6 +44,8 @@ public class LanguageServerTemplate {
     public static final String CLIENT_SETTINGS_FILE_NAME = "clientSettings.json";
     public static final String README_FILE_NAME = "README.md";
 
+    public static final String ID_JSON_PROPERTY = "id";
+    public static final String NAME_JSON_PROPERTY = "name";
     public static final String LANGUAGE_ID_JSON_PROPERTY = "languageId";
     public static final String FILE_TYPE_JSON_PROPERTY = "fileType";
     public static final String DEFAULT_JSON_PROPERTY = "default";
@@ -52,7 +54,6 @@ public class LanguageServerTemplate {
     public static final String LANGUAGE_MAPPINGS_JSON_PROPERTY = "languageMappings";
     public static final String PATTERNS_JSON_PROPERTY = "patterns";
     public static final String FILE_TYPE_MAPPINGS_JSON_PROPERTY = "fileTypeMappings";
-    public static final String NAME_JSON_PROPERTY = "name";
 
     private static final String WINDOWS_KEY = "windows";
     private static final String MAC_KEY = "mac";
@@ -61,6 +62,7 @@ public class LanguageServerTemplate {
 
     private static final String OS_KEY = SystemInfo.isWindows ? WINDOWS_KEY : (SystemInfo.isMac ? MAC_KEY : (SystemInfo.isUnix ? UNIX_KEY : null));
 
+    private String id;
     private String name;
     private Map<String /* OS */, String /* program args */> programArgs;
 
@@ -74,6 +76,14 @@ public class LanguageServerTemplate {
     private String configurationSchema;
     private String initializationOptions;
     private String clientConfiguration;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplateDeserializer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplateDeserializer.java
@@ -28,6 +28,8 @@ public class LanguageServerTemplateDeserializer implements JsonDeserializer<Lang
         JsonObject jsonObject = jsonElement.getAsJsonObject();
         LanguageServerTemplate languageServerTemplate = new LanguageServerTemplate();
 
+        var id = jsonObject.get(ID_JSON_PROPERTY);
+        languageServerTemplate.setId(id != null ? id.getAsString() : null);
         languageServerTemplate.setName(jsonObject.get(NAME_JSON_PROPERTY).getAsString());
         JsonObject programArgs = jsonObject.get(PROGRAM_ARGS_JSON_PROPERTY).getAsJsonObject();
         if (programArgs != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/NewLanguageServerDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/NewLanguageServerDialog.java
@@ -195,7 +195,7 @@ public class NewLanguageServerDialog extends DialogWrapper {
         };
     }
 
-    private void loadFromTemplate(LanguageServerTemplate template) {
+    private void loadFromTemplate(@NotNull LanguageServerTemplate template) {
         // Update name
         var serverName = this.languageServerPanel.getServerName();
         serverName.setText(template.getName() != null ? template.getName() : "");
@@ -291,6 +291,7 @@ public class NewLanguageServerDialog extends DialogWrapper {
         List<ServerMappingSettings> mappingSettings = this.languageServerPanel.getMappingsPanel().getAllMappings();
 
         // Register language server and mappings definition
+        String templateId = currentTemplate != null && currentTemplate != LanguageServerTemplate.NEW_TEMPLATE ? currentTemplate.getId() : null;
         String serverName = this.languageServerPanel.getServerName().getText();
         String commandLine = this.languageServerPanel.getCommandLine().getText();
         Map<String, String> userEnvironmentVariables = this.languageServerPanel.getEnvironmentVariables().getEnvs();
@@ -300,6 +301,7 @@ public class NewLanguageServerDialog extends DialogWrapper {
         String initializationOptions = this.languageServerPanel.getInitializationOptionsWidget().getText();
         String clientConfiguration = this.languageServerPanel.getClientConfigurationWidget().getText();
         UserDefinedLanguageServerDefinition definition = new UserDefinedLanguageServerDefinition(serverId,
+                templateId,
                 serverName,
                 "",
                 commandLine,

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedLanguageServerDefinition.java
@@ -42,6 +42,7 @@ public class UserDefinedLanguageServerDefinition extends LanguageServerDefinitio
 
     @SerializedName("displayName")
     private String name;
+    private String templateId;
     private String commandLine;
     private Map<String, String> userEnvironmentVariables;
     private boolean includeSystemEnvironmentVariables;
@@ -54,6 +55,7 @@ public class UserDefinedLanguageServerDefinition extends LanguageServerDefinitio
     private ClientConfigurationSettings clientConfiguration;
 
     public UserDefinedLanguageServerDefinition(@NotNull String id,
+                                               @Nullable String templateId,
                                                @NotNull String name,
                                                @Nullable String description,
                                                @NotNull String commandLine,
@@ -65,6 +67,7 @@ public class UserDefinedLanguageServerDefinition extends LanguageServerDefinitio
                                                @Nullable String clientConfigurationContent) {
         super(id, name, description, true, null, false);
         this.name = name;
+        this.templateId = templateId;
         this.commandLine = commandLine;
         this.userEnvironmentVariables = userEnvironmentVariables;
         this.includeSystemEnvironmentVariables = includeSystemEnvironmentVariables;
@@ -84,6 +87,7 @@ public class UserDefinedLanguageServerDefinition extends LanguageServerDefinitio
                                                @Nullable String configurationContent,
                                                @Nullable String initializationOptionsContent) {
         this(id,
+                null,
                 name,
                 description,
                 commandLine,
@@ -113,6 +117,16 @@ public class UserDefinedLanguageServerDefinition extends LanguageServerDefinitio
     @Override
     public @NotNull LSPClientFeatures createClientFeatures() {
         return new UserDefinedClientFeatures();
+    }
+
+    /**
+     * Returns the template id which has been used to create the language server definition and null otherwise.
+     *
+     * @return the template id which has been used to create the language server definition and null otherwise.
+     */
+    @Nullable
+    public String getTemplateId() {
+        return templateId;
     }
 
     public void setName(String name) {

--- a/src/main/resources/templates/sourcekit-lsp/template.json
+++ b/src/main/resources/templates/sourcekit-lsp/template.json
@@ -1,4 +1,5 @@
 {
+  "id": "sourcekit-lsp",
   "name": "SourceKit-LSP",
   "programArgs": {
     "default": "sourcekit-lsp"

--- a/src/test/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerDefinitionSerializerTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerDefinitionSerializerTest.java
@@ -32,6 +32,7 @@ public class LanguageServerDefinitionSerializerTest {
     public void testBasicUserDefinedLsSerialization() {
         UserDefinedLanguageServerDefinition lsDef = new UserDefinedLanguageServerDefinition(
                 "id",
+                null,
                 "lsName",
                 "description",
                 "./start.sh",
@@ -56,6 +57,7 @@ public class LanguageServerDefinitionSerializerTest {
     public void testLanguageMapping() {
         UserDefinedLanguageServerDefinition lsDef = new UserDefinedLanguageServerDefinition(
                 "id",
+                null,
                 "lsName",
                 "description",
                 "./start.sh",
@@ -84,6 +86,7 @@ public class LanguageServerDefinitionSerializerTest {
     public void testFilePatternsMapping() {
         UserDefinedLanguageServerDefinition lsDef = new UserDefinedLanguageServerDefinition(
                 "id",
+                null,
                 "lsName",
                 "description",
                 "./start.sh",
@@ -119,6 +122,7 @@ public class LanguageServerDefinitionSerializerTest {
     public void testFileTypeMappings() {
         UserDefinedLanguageServerDefinition lsDef = new UserDefinedLanguageServerDefinition(
                 "id",
+                null,
                 "lsName",
                 "description",
                 "./start.sh",

--- a/src/test/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplateManagerTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplateManagerTest.java
@@ -103,6 +103,7 @@ public class LanguageServerTemplateManagerTest {
     private UserDefinedLanguageServerDefinition createUserDefinedLanguageServerDefinition(String identifier) {
         return new UserDefinedLanguageServerDefinition(
                 identifier,
+                null,
                 identifier,
                 null,
                 "cmd",


### PR DESCRIPTION
feat: store template id in the user ls definition

//cc @SCWells72 this PR provides `UserDedfinedLanguageServerDefinition#getTemplateId()` which is the original template id which have created the ls definition and null otherwise.