### PR TITLE
fix: Single/double quotes displayed not correctly in warch area when debug TypeScript file

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/variables/DAPValue.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/variables/DAPValue.java
@@ -92,34 +92,11 @@ public class DAPValue extends XNamedValue {
     public void computeSourcePosition(@NotNull XNavigatable navigatable) {
         stackFrame
                 .getSourcePositionFor(variable)
-                        .thenAccept(sourcePosition -> {
-                            if (sourcePosition != null) {
-                                navigatable.setSourcePosition(sourcePosition);
-                            }
-                        });
-
-            /*@Nullable
-            private XSourcePosition findPosition() {
-                XDebugSession debugSession = client.getSession();
-                if (debugSession == null) {
-                    return null;
-                }
-                XStackFrame stackFrame = debugSession.getCurrentStackFrame();
-                if (stackFrame == null) {
-                    return null;
-                }
-                Project project = debugSession.getProject();
-                XSourcePosition position = debugSession.getCurrentPosition();
-                Editor editor = ((FileEditorManagerImpl) FileEditorManager.getInstance(project))
-                        .getSelectedTextEditor(true);
-                if (editor == null || position == null) {
-                    return null;
-                }
-                VirtualFile virtualFile = null;
-                int offset = 0;
-                return XDebuggerUtil.getInstance().createPositionByOffset(virtualFile, resolved.getTextOffset());
-            }*/
-
+                .thenAccept(sourcePosition -> {
+                    if (sourcePosition != null) {
+                        navigatable.setSourcePosition(sourcePosition);
+                    }
+                });
     }
 
     @NotNull

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterVariableSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterVariableSupport.java
@@ -11,12 +11,9 @@
 package com.redhat.devtools.lsp4ij.dap.descriptors;
 
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
-import com.intellij.xdebugger.frame.presentation.XRegularValuePresentation;
-import com.intellij.xdebugger.frame.presentation.XStringValuePresentation;
-import com.intellij.xdebugger.frame.presentation.XValuePresentation;
-import com.redhat.devtools.lsp4ij.dap.client.variables.providers.HighlighterDebugVariablePositionProvider;
+import com.intellij.xdebugger.frame.presentation.*;
 import com.redhat.devtools.lsp4ij.dap.client.variables.providers.DebugVariablePositionProvider;
+import com.redhat.devtools.lsp4ij.dap.client.variables.providers.HighlighterDebugVariablePositionProvider;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.debug.Variable;
 import org.jetbrains.annotations.NotNull;
@@ -45,7 +42,7 @@ public class DebugAdapterVariableSupport {
         if (StringUtils.isEmpty(type)) {
             return AllIcons.Nodes.Variable;
         }
-        if (isStringType(type) || isNumberType(type) || isBooleanType(type)) {
+        if (isStringType(type) || isNumericType(type) || isBooleanType(type)) {
             return AllIcons.Debugger.Db_primitive;
         }
         if (isObjectType(type)) {
@@ -71,33 +68,39 @@ public class DebugAdapterVariableSupport {
      * @return value representation for the given variable.
      */
     public @NotNull XValuePresentation getValuePresentation(@NotNull Variable variable) {
+        final String type = variable.getType() != null ? variable.getType() : "";
+        final String formattedValue = formatValue(variable);
+
+        // String type
+        if (isStringType(type)) {
+            return new XStringValuePresentation(formattedValue);
+        }
+
+        // Numeric type
+        if (isNumericType(type)) {
+            return new XNumericValuePresentation(formattedValue);
+        }
+
+        // Boolean type
+        if (isBooleanType(type)) {
+            return new XKeywordValuePresentation(formattedValue);
+        }
+
+        // Other type
+        return new XRegularValuePresentation(formattedValue, type);
+    }
+
+    @NotNull
+    protected String formatValue(@NotNull Variable variable) {
         final String value = variable.getValue() != null ? variable.getValue() : "";
         final String type = variable.getType() != null ? variable.getType() : "";
-
         if (isStringType(type)) {
-            String stringValue = value.replaceAll("^\"+|\"+$", "");
-            return new XStringValuePresentation(stringValue);
+            // String type (ex:value='foo' or "foo")
+            // Remove start/end simple and double quote
+            // to display only foo
+            return removeQuotes(value);
         }
-
-        if (isNumberType(type)) {
-            return new XRegularValuePresentation(value, type) {
-                @Override
-                public void renderValue(@NotNull XValueTextRenderer renderer) {
-                    renderer.renderValue(value, DefaultLanguageHighlighterColors.NUMBER);
-                }
-            };
-        }
-
-        if (isBooleanType(type)) {
-            return new XValuePresentation() {
-                @Override
-                public void renderValue(@NotNull XValueTextRenderer renderer) {
-                    renderer.renderValue(value, DefaultLanguageHighlighterColors.KEYWORD);
-                }
-            };
-        }
-
-        return new XRegularValuePresentation(value, type);
+        return value;
     }
 
     protected boolean isStringType(@NotNull String type) {
@@ -109,7 +112,7 @@ public class DebugAdapterVariableSupport {
                 "bool".equalsIgnoreCase(type);
     }
 
-    protected boolean isNumberType(@NotNull String type) {
+    protected boolean isNumericType(@NotNull String type) {
         return "number".equalsIgnoreCase(type) ||
                 "int".equalsIgnoreCase(type) ||
                 "long".equalsIgnoreCase(type) ||
@@ -143,5 +146,12 @@ public class DebugAdapterVariableSupport {
 
     public @NotNull Collection<DebugVariablePositionProvider> getDebugVariablePositionProvider() {
         return Collections.singletonList(new HighlighterDebugVariablePositionProvider());
+    }
+
+    @NotNull
+    private static String removeQuotes(@NotNull String value) {
+        return value
+                .replaceAll("^\"+|\"+$", "")
+                .replaceAll("^\'+|\'+$", "");
     }
 }


### PR DESCRIPTION
fix: Single/double quotes displayed not correctly in warch area when debug TypeScript file

Fixes #812

Here the result with inline value:

![image](https://github.com/user-attachments/assets/8174671d-9645-45c4-95b8-68f298e97783)

Here the result in the watch expression

![image](https://github.com/user-attachments/assets/3878a614-5158-4c12-acb2-010150064197)
