### PR TITLE
fix: Fixed a boundary case issue when a close brace is typed at the very end of a file that would have resulted in an `IndexOutOfBoundsException` (fixes #822)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPClientSideOnTypeFormattingTypedHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPClientSideOnTypeFormattingTypedHandler.java
@@ -190,12 +190,14 @@ public class LSPClientSideOnTypeFormattingTypedHandler extends TypedHandlerDeleg
             int beforeOffset = offset - 1;
             TextRange codeBlockRange = LSPCodeBlockProvider.getCodeBlockRange(editor, file, beforeOffset);
             if (codeBlockRange != null) {
-                int startOffset = codeBlockRange.getStartOffset();
-                int endOffset = codeBlockRange.getEndOffset();
-
-                // Make sure the range includes the brace pair
                 Document document = editor.getDocument();
                 CharSequence documentChars = document.getCharsSequence();
+
+                // Constrain the offsets to the valid range of the file
+                int startOffset = Math.max(codeBlockRange.getStartOffset(), 0);
+                int endOffset = Math.min(codeBlockRange.getEndOffset(), documentChars.length() - 1);
+
+                // Make sure the range includes the brace pair
                 if ((startOffset > 0) && (documentChars.charAt(startOffset) != openBraceChar)) {
                     startOffset--;
                 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptClientSideFormatOnCloseBraceTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptClientSideFormatOnCloseBraceTest.java
@@ -172,6 +172,77 @@ public class TypeScriptClientSideFormatOnCloseBraceTest extends LSPClientSideOnT
         );
     }
 
+    // BOUNDARY TESTS
+
+    // language=json
+    private static final String BOUNDARY_MOCK_SELECTION_RANGE_JSON = """
+            [
+              {
+                "range": {
+                  "start": {
+                    "line": 1,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 1,
+                    "character": 1
+                  }
+                },
+                "parent": {
+                  "range": {
+                    "start": {
+                      "line": 0,
+                      "character": 15
+                    },
+                    "end": {
+                      "line": 1,
+                      "character": 1
+                    }
+                  },
+                  "parent": {
+                    "range": {
+                      "start": {
+                        "line": 0,
+                        "character": 0
+                      },
+                      "end": {
+                        "line": 1,
+                        "character": 1
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+            """;
+
+    // language=json
+    private static final String BOUNDARY_MOCK_FOLDING_RANGE_JSON = "[]";
+
+    // language=json
+    private static final String BOUNDARY_MOCK_RANGE_FORMATTING_JSON = "[]";
+
+    // No language injection here because there are syntax errors
+    private static final String BOUNDARY_FILE_BODY_BEFORE = """
+            function foo() {
+            // type }"""; // NOTE: It's critical that this happen at the VERY end of the file to confirm the fix for 822
+
+    // Confirms the fix for https://github.com/redhat-developer/lsp4ij/issues/822
+    public void testCloseBraceAtEndOfFile() {
+        assertOnTypeFormatting(
+                TEST_FILE_NAME,
+                BOUNDARY_FILE_BODY_BEFORE,
+                // language=typescript
+                """
+                        function foo() {
+                        }""",
+                BOUNDARY_MOCK_SELECTION_RANGE_JSON,
+                BOUNDARY_MOCK_FOLDING_RANGE_JSON,
+                BOUNDARY_MOCK_RANGE_FORMATTING_JSON,
+                clientConfiguration -> clientConfiguration.format.onTypeFormatting.clientSide.formatOnCloseBrace = true
+        );
+    }
+
     // COMPLEX TESTS
 
     // language=json


### PR DESCRIPTION
The issue here is that the code block end is reported as the offset after the close brace, and when the brace is the very end of the file, trying to dereference the code block end offset was resulting in an `IndexOutOfBoundsException`. Now the offsets are constrained to those valid in the file before adjusting them.

I added a new test that reproduces the issue without the fix and of course therefore confirms the fix.