### PR TITLE
feat: manage unexpectedly stop of server

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -12,6 +12,7 @@ package com.redhat.devtools.lsp4ij;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonObject;
+import com.intellij.notification.Notification;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
@@ -54,6 +55,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
+import static com.redhat.devtools.lsp4ij.internal.CancellationSupport.showNotificationError;
 import static com.redhat.devtools.lsp4ij.internal.IntelliJPlatformUtils.getClientInfo;
 
 /**
@@ -114,6 +116,8 @@ public class LanguageServerWrapper implements Disposable {
 
     private LSPClientFeatures clientFeatures;
     private final AtomicInteger keepAliveCounter = new AtomicInteger();
+    // error notification displayed when server start fails.
+    private @Nullable Notification errorNotification;
 
     /* Backwards compatible constructor */
     public LanguageServerWrapper(@NotNull Project project, @NotNull LanguageServerDefinition serverDefinition) {
@@ -277,6 +281,17 @@ public class LanguageServerWrapper implements Disposable {
 
                         // Add error log
                         provider.addLogErrorHandler(error -> ServerMessageHandler.logMessage(this.getServerDefinition(), new MessageParams(MessageType.Error, error), getProject()));
+                        provider.addUnexpectedServerStopHandler(() -> {
+                            // There is an unexpected stop of the connection
+                            // 1. the process was killed outside IntelliJ
+                            // 2. the start command takes some times and fails
+                            // -->
+                            // Stop the language server
+                            stop();
+                            // Show a notification error with "The server was stopped unexpectedly." error message.
+                            serverError = new ServerWasStoppedException("The server was stopped unexpectedly.");
+                            showNotificationStartServerError();
+                        });
 
                         // Starting process...
                         updateStatus(ServerStatus.starting);
@@ -343,6 +358,12 @@ public class LanguageServerWrapper implements Disposable {
                     .thenCompose(unused -> initServer(rootURI))
                     .thenAccept(res -> {
                         serverError = null;
+                        if (errorNotification != null) {
+                            // Close the current error notification
+                            // displayed when server start fails.
+                            errorNotification.expire();
+                            errorNotification = null;
+                        }
                         serverCapabilities = res.getCapabilities();
                         getClientFeatures().setServerCapabilities(serverCapabilities);
                         this.initiallySupportsWorkspaceFolders = supportsWorkspaceFolders(serverCapabilities);
@@ -371,11 +392,34 @@ public class LanguageServerWrapper implements Disposable {
                         } else {
                             serverError = new CannotStartServerException("Error while starting language server '" + serverDefinition.getId() + "' (pid=" + getCurrentProcessId() + ")", e);
                         }
+                        showNotificationStartServerError();
                         initializeFuture.completeExceptionally(serverError);
                         getLanguageServerLifecycleManager().onError(this, e);
                         stop(false);
                         return null;
                     });
+        }
+    }
+
+    /**
+     * Show a notification error when server cannot be started.
+     */
+    private void showNotificationStartServerError() {
+        if (serverError == null) {
+            return;
+        }
+        // Show the notification if needed
+        boolean showNotification = errorNotification == null ||
+                errorNotification.getBalloon() == null ||
+                errorNotification.isExpired() ||
+                !errorNotification.getContent().equals(serverError.getMessage());
+        if (showNotification) {
+            // Close old error notification if needed
+            if (errorNotification != null && !errorNotification.isExpired()) {
+                errorNotification.expire();
+            }
+            // Show start server error notification.
+            errorNotification = showNotificationError(this.getServerDefinition(), "Cannot start server", serverError, this.getProject());
         }
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
+import com.redhat.devtools.lsp4ij.server.LanguageServerException;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures.FutureCancelChecker;
 import org.jetbrains.annotations.NotNull;
@@ -134,11 +135,15 @@ public class CompletableFutures {
                 // Ignore timeout
             } catch (ExecutionException | CompletionException e) {
                 Throwable cause = e.getCause();
-                if (cause instanceof CancellationException ce) {
-                    throw ce;
-                }
                 if (cause instanceof ProcessCanceledException pce) {
                     throw pce;
+                }
+                if (cause instanceof LanguageServerException) {
+                    // Server cannot be started, throws a ProcessCanceledException to ignore the error.
+                    throw new ProcessCanceledException(cause);
+                }
+                if (cause instanceof CancellationException ce) {
+                    throw ce;
                 }
                 throw e;
             } catch (InterruptedException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/StreamConnectionProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/StreamConnectionProvider.java
@@ -36,6 +36,11 @@ public interface StreamConnectionProvider {
     default void addLogErrorHandler(LanguageServerLogErrorHandler handler) {
 
     }
+
+    default void addUnexpectedServerStopHandler(Runnable handler) {
+
+    }
+
     /**
      * User provided initialization options.
      */

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
@@ -332,7 +332,7 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
         if (fileType == null) {
             return null;
         }
-        return languageIdLanguageMappings.get(fileType);
+        return languageIdFileTypeMappings.get(fileType);
     }
     /**
      * @return The language ID that this wrapper is dealing with if defined in the

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/actions/ReportErrorInLogAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/actions/ReportErrorInLogAction.java
@@ -14,8 +14,9 @@ import com.intellij.notification.Notification;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
-import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
 import com.redhat.devtools.lsp4ij.settings.ErrorReportingKind;
 import com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings;
 import org.jetbrains.annotations.NotNull;
@@ -25,20 +26,23 @@ import org.jetbrains.annotations.NotNull;
  */
 public class ReportErrorInLogAction extends AnAction {
 
-    private final Notification notification;
-    private final LanguageServerItem languageServer;
+    private final @NotNull Notification notification;
+    private final @NotNull LanguageServerDefinition languageServerDefinition;
+    private final @NotNull Project project;
 
     public ReportErrorInLogAction(@NotNull Notification notification,
-                                  @NotNull LanguageServerItem languageServer) {
+                                  @NotNull LanguageServerDefinition languageServerDefinition,
+                                  @NotNull Project project) {
         super(LanguageServerBundle.message("action.language.server.error.reporting.in_log.text"));
         this.notification = notification;
-        this.languageServer = languageServer;
+        this.languageServerDefinition = languageServerDefinition;
+        this.project = project;
     }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        UserDefinedLanguageServerSettings manager = UserDefinedLanguageServerSettings.getInstance(languageServer.getProject());
-        manager.updateSettings(languageServer.getServerDefinition().getId(),
+        UserDefinedLanguageServerSettings manager = UserDefinedLanguageServerSettings.getInstance(project);
+        manager.updateSettings(languageServerDefinition.getId(),
                 new UserDefinedLanguageServerSettings.LanguageServerDefinitionSettings()
                         .setErrorReportingKind(ErrorReportingKind.in_log));
         notification.expire();

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/actions/ShowErrorLogAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/actions/ShowErrorLogAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Red Hat, Inc.
+ * Copyright (c) 2025 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -10,42 +10,33 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.settings.actions;
 
-import com.intellij.notification.Notification;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
+import com.redhat.devtools.lsp4ij.console.LSPConsoleToolWindowPanel;
 import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
-import com.redhat.devtools.lsp4ij.settings.ErrorReportingKind;
-import com.redhat.devtools.lsp4ij.settings.UserDefinedLanguageServerSettings;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Disable error reporting action.
+ * Select "log" tab (for a given language server definition) action.
  */
-public class DisableLanguageServerErrorAction extends AnAction {
+public class ShowErrorLogAction extends AnAction {
 
-    private final @NotNull Notification notification;
     private final @NotNull LanguageServerDefinition languageServerDefinition;
     private final @NotNull Project project;
 
-    public DisableLanguageServerErrorAction(@NotNull Notification notification,
-                                            @NotNull LanguageServerDefinition languageServerDefinition,
-                                            @NotNull Project project) {
-        super(LanguageServerBundle.message("action.language.server.error.reporting.disable.text"));
-        this.notification = notification;
+    public ShowErrorLogAction(@NotNull LanguageServerDefinition languageServerDefinition,
+                              @NotNull Project project) {
+        super(LanguageServerBundle.message("action.language.server.error.show.logs.text"));
         this.languageServerDefinition = languageServerDefinition;
         this.project = project;
     }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        UserDefinedLanguageServerSettings manager = UserDefinedLanguageServerSettings.getInstance(project);
-        manager.updateSettings(languageServerDefinition.getId(),
-                new UserDefinedLanguageServerSettings.LanguageServerDefinitionSettings()
-                        .setErrorReportingKind(ErrorReportingKind.none));
-        notification.expire();
+        LSPConsoleToolWindowPanel.selectLogTab(languageServerDefinition, project);
     }
 
     @Override

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -54,6 +54,7 @@ language.server.error.reporting.context.help.link=More at LSP Specification
 action.language.server.error.reporting.disable.text=Disable error reporting
 action.language.server.error.reporting.in_log.text=Report error in Log
 action.open.website.text=Open LSP4IJ documentation
+action.language.server.error.show.logs.text=Show Logs
 
 language.server.trace=Trace:
 language.server.debug.port=Debug port:


### PR DESCRIPTION
feat: manage unexpectedly stop of server:

 * when server start command is wrong
 * when process is killed outside IJ

When server starts with wrong command, it throws a CannotStartProcessException. This exception is ignored now in the log and a notification error is shown:

Ex: `foo`

![image](https://github.com/user-attachments/assets/65b45a4f-17f7-4d1a-88c6-a73cb6cbc858)

When server start command takes some times (ex: julia, java command) and the command is wrong, the server is now stopped.

Ex : with Julia LS

`julia -e "using LanguageServer; foo()"`

![image](https://github.com/user-attachments/assets/da070907-b137-4443-983e-aa06d7ca4021)

When process is killed outside IJ, the server is stopped.