### PR TITLE
chore: fix latest_ij workflow

### DIFF
--- a/.github/workflows/IJ-latest.yml
+++ b/.github/workflows/IJ-latest.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build with Gradle
         run: |
           LATEST_EAP_SNAPSHOT=$(./gradlew printProductsReleases | grep 'IC-' | head -n 1 | cut -d'-' -f2)
-          ./gradlew check -PplatformVersion=LATEST-EAP-SNAPSHOT
+          ./gradlew check -PplatformVersion=$LATEST_EAP_SNAPSHOT
 
       - name: Collect Tests Result
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
fix typo for runing latest-ij workflow.

but, build still fails with compile issues 
```
$ ./gradlew check -PplatformVersion=251.20015.29
Reusing configuration cache.

> Task :compileJava

/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:18: error: package com.jetbrains.jsonSchema.extension does not exist
import com.jetbrains.jsonSchema.extension.JsonSchemaFileProvider;
                                         ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:19: error: package com.jetbrains.jsonSchema.extension does not exist
import com.jetbrains.jsonSchema.extension.SchemaType;
                                         ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:20: error: package com.jetbrains.jsonSchema.impl does not exist
import com.jetbrains.jsonSchema.impl.JsonSchemaVersion;
                                    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:27: error: cannot find symbol
abstract class AbstractLSPJsonSchemaFileProvider implements JsonSchemaFileProvider {
                                                            ^
  symbol: class JsonSchemaFileProvider
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:48: error: cannot find symbol
    public final SchemaType getSchemaType() {
                 ^
  symbol:   class SchemaType
  location: class AbstractLSPJsonSchemaFileProvider
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:53: error: cannot find symbol
    public final JsonSchemaVersion getSchemaVersion() {
                 ^
  symbol:   class JsonSchemaVersion
  location: class AbstractLSPJsonSchemaFileProvider
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/LSPJsonSchemaProviderFactory.java:17: error: package com.jetbrains.jsonSchema.extension does not exist
import com.jetbrains.jsonSchema.extension.JsonSchemaFileProvider;
                                         ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/LSPJsonSchemaProviderFactory.java:18: error: package com.jetbrains.jsonSchema.extension does not exist
import com.jetbrains.jsonSchema.extension.JsonSchemaProviderFactory;
                                         ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/LSPJsonSchemaProviderFactory.java:27: error: cannot find symbol
public class LSPJsonSchemaProviderFactory implements JsonSchemaProviderFactory {
                                                     ^
  symbol: class JsonSchemaProviderFactory
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/LSPJsonSchemaProviderFactory.java:31: error: cannot find symbol
    public List<JsonSchemaFileProvider> getProviders(@NotNull Project project) {
                ^
  symbol:   class JsonSchemaFileProvider
  location: class LSPJsonSchemaProviderFactory
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java:29: warning: [removal] projectOpened(Project) in ProjectManagerListener has been deprecated and marked for removal
    public void projectOpened(@NotNull Project project) {
                ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterDescriptorFactoryPanel.java:217: warning: [removal] addBrowseFolderListener(String,String,Project,FileChooserDescriptor) in TextFieldWithBrowseButton has been deprecated and marked for removal
        workingDirectoryField.addBrowseFolderListener(null, null, getProject(), FileChooserDescriptorFactory.createSingleFolderDescriptor());
                             ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterDescriptorFactoryPanel.java:221: warning: [removal] addBrowseFolderListener(String,String,Project,FileChooserDescriptor) in TextFieldWithBrowseButton has been deprecated and marked for removal
        fileField.addBrowseFolderListener(null, null, getProject(), FileChooserDescriptorFactory.createSingleFileDescriptor());
                 ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:35: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:41: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:47: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:49: error: cannot find symbol
        return SchemaType.schema;
               ^
  symbol:   variable SchemaType
  location: class AbstractLSPJsonSchemaFileProvider
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:52: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:54: error: cannot find symbol
        return JsonSchemaVersion.SCHEMA_7;
               ^
  symbol:   variable JsonSchemaVersion
  location: class AbstractLSPJsonSchemaFileProvider
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:58: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileProvider.java:63: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/AbstractLSPJsonSchemaFileSystemProvider.java:37: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/LSPJsonSchemaProviderFactory.java:30: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/LSPJsonSchemaProviderFactory.java:32: error: cannot find symbol
        List<JsonSchemaFileProvider> providers = new ArrayList<>();
             ^
  symbol:   class JsonSchemaFileProvider
  location: class LSPJsonSchemaProviderFactory
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/settings/jsonSchema/LSPServerConfigurationJsonSchemaFileProvider.java:64: error: method does not override or implement a method from a supertype
    @Override
    ^
/home/sbouchet/IdeaProjects/lsp4ij/src/main/java/com/redhat/devtools/lsp4ij/installation/ServerInstallerBase.java:137: error: Alternatives in a multi-catch statement cannot be related by subclassing
                } catch (CancellationException | ProcessCanceledException e) {
                                                 ^
  Alternative ProcessCanceledException is a subclass of alternative CancellationException
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
23 errors
3 warnings

> Task :compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --info option to get more log output.
> Run with --scan to get full insights.

BUILD FAILED in 3s
8 actionable tasks: 2 executed, 6 up-to-date
Configuration cache entry reused.

```