### PR TITLE
fix: DAP debugger doesn't support Run to Cursor

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugSession;
+import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
 import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider;
 import com.intellij.xdebugger.frame.XStackFrame;
@@ -293,5 +294,16 @@ public class DAPDebugProcess extends XDebugProcess {
             return dapStackFrame;
         }
         return null;
+    }
+
+    @Override
+    public void runToPosition(@NotNull XSourcePosition position,
+                              @Nullable XSuspendContext context) {
+        getBreakpointHandler()
+                .sendTemporaryBreakpoint(position)// Send a temporary breakpoint with the proper position to the DAP server
+                .thenApply(unused -> {
+                    resume(context); // and resume the debugger
+                    return null;
+                });
     }
 }


### PR DESCRIPTION
fix: DAP debugger doesn't support Run to Cursor

Fixes #840

Here a demo:

![RunToCursorDemo](https://github.com/user-attachments/assets/9415ab8f-78b3-4236-9fc3-91398ee3455d)
