### PR TITLE
docs: Add GroovyScript to LSP4IJ Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Here are some projects that use LSP4IJ:
  * [Jimmer DTO LSP](https://github.com/Enaium/jimmer-dto-lsp)
  * [Qt Tools for Android Studio](https://code.qt.io/cgit/qt-labs/android-studio-tools.git/)
  * [Clojure LSP Intellij](https://github.com/clojure-lsp/clojure-lsp-intellij)
+ * [GroovyScript for IntelliJ](https://github.com/IntegerLimit/GroovyScriptPlugin)
 
 ## Requirements
 


### PR DESCRIPTION
This PR adds the GroovyScript Plugin (https://github.com/IntegerLimit/GroovyScriptPlugin, https://plugins.jetbrains.com/plugin/25915-groovyscript/), to the list of plugins that utilise LSP4IJ.

This was requested in https://github.com/IntegerLimit/GroovyScriptPlugin/issues/9.