### PR TITLE
docs: add angelscript language server for intellij

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Here are some projects that use LSP4IJ:
  * [Clojure LSP Intellij](https://github.com/clojure-lsp/clojure-lsp-intellij)
  * [GroovyScript for IntelliJ](https://github.com/IntegerLimit/GroovyScriptPlugin)
  * [Redscript Intellij](https://github.com/pawrequest/redscript-intellij)
+ * [AngelScript Language Server for IntelliJ](https://github.com/pawrequest/redscript-intellij)
 
 ## Requirements
 


### PR DESCRIPTION
Reference: https://github.com/sashi0034/angel-intellij/issues/10

Add [AngelScript Language Server for IntelliJ](https://plugins.jetbrains.com/plugin/26645-angelscript-language-server/) to README.md

