### PR TITLE
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'future' of com/redhat/devtools/lsp4ij/internal/CompletableFutures.waitUntilDone must not be null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
@@ -94,7 +94,7 @@ public class CompletableFutures {
         return future != null && future.isDone() && !future.isCancelled() && !future.isCompletedExceptionally();
     }
 
-    public static void waitUntilDone(@NotNull CompletableFuture<?> future) throws ExecutionException, ProcessCanceledException {
+    public static void waitUntilDone(@Nullable CompletableFuture<?> future) throws ExecutionException, ProcessCanceledException {
         waitUntilDone(future, null);
     }
 


### PR DESCRIPTION
fix: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'future' of com/redhat/devtools/lsp4ij/internal/CompletableFutures.waitUntilDone must not be null

Fixes #876