### PR TITLE
feat: Custom file view provider for LSP4IJ TextMate files that uses semantic token information to create a simple PSI "tree" (fixes #98, #531, and #813)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/EditorBehaviorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/EditorBehaviorFeature.java
@@ -99,6 +99,17 @@ public class EditorBehaviorFeature {
         return false;
     }
 
+    /**
+     * Whether or not the semantic tokens-based file view provider is enabled.
+     *
+     * @param file the file
+     * @return true if the semantic tokens-based file view provider is enabled; otherwise false
+     */
+    public boolean isEnableSemanticTokensFileViewProvider(@NotNull PsiFile file) {
+        // Default to enabled, but a file view provider must be registered for the provided file to be truly enabled
+        return true;
+    }
+
     // Utility methods to check the state of these feature flags easily
 
     /**
@@ -155,6 +166,19 @@ public class EditorBehaviorFeature {
         return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
                 file.getVirtualFile(),
                 ls -> ls.getClientFeatures().getEditorBehaviorFeature().isEnableTextMateNestedBracesImprovements(file)
+        );
+    }
+
+    /**
+     * Whether or not the semantic tokens-based file view provider is enabled.
+     *
+     * @param file the PSI file
+     * @return true if the semantic tokens-based file view provider is enabled; otherwise false
+     */
+    public static boolean enableSemanticTokensFileViewProvider(@NotNull PsiFile file) {
+        return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
+                file.getVirtualFile(),
+                ls -> ls.getClientFeatures().getEditorBehaviorFeature().isEnableSemanticTokensFileViewProvider(file)
         );
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDocumentSymbolFeature.java
@@ -22,7 +22,6 @@ import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.SymbolKind;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -97,8 +96,7 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
     }
 
     /**
-     * Finds the text offset of the symbol as the start of its selection range. Only types and methods/functions are
-     * reported as having a text offset.
+     * Finds the text offset of the symbol as the start of its selection range if available and range if not.
      *
      * @param documentSymbol the document symbol
      * @param psiFile        the file
@@ -106,20 +104,13 @@ public class LSPDocumentSymbolFeature extends AbstractLSPDocumentFeature {
      */
     public int getTextOffset(@NotNull DocumentSymbol documentSymbol,
                              @NotNull PsiFile psiFile) {
-        SymbolKind symbolKind = documentSymbol.getKind();
-        // TODO: This works quite well without having to implement MethodNavigationOffsetProvider
-        if ((symbolKind == SymbolKind.Class) ||
-                (symbolKind == SymbolKind.Interface) ||
-                (symbolKind == SymbolKind.Enum) ||
-                (symbolKind == SymbolKind.Struct) ||
-                (symbolKind == SymbolKind.Method) ||
-                (symbolKind == SymbolKind.Function)) {
-            Range selectionRange = documentSymbol.getSelectionRange();
-            Position startPosition = selectionRange != null ? selectionRange.getStart() : null;
-            Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());
-            if ((startPosition != null) && (document != null)) {
-                return LSPIJUtils.toOffset(startPosition, document);
-            }
+        // NOTE: This works quite well without having to implement MethodNavigationOffsetProvider
+        Range selectionRange = documentSymbol.getSelectionRange();
+        Range range = documentSymbol.getRange();
+        Position startPosition = selectionRange != null ? selectionRange.getStart() : range.getStart();
+        Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());
+        if ((startPosition != null) && (document != null)) {
+            return LSPIJUtils.toOffset(startPosition, document);
         }
         return 0;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTarget.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTarget.java
@@ -17,6 +17,7 @@ import com.intellij.platform.backend.presentation.TargetPresentation;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import org.eclipse.lsp4j.MarkupContent;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,7 +56,13 @@ public class LSPDocumentationTarget implements DocumentationTarget {
     @Nullable
     @Override
     public DocumentationResult computeDocumentation() {
-        return DocumentationResult.documentation(convertToHtml(contents, languageServer, file));
+        return DocumentationResult.documentation(getHtml());
+    }
+
+    @NotNull
+    @ApiStatus.Internal
+    public String getHtml() {
+        return convertToHtml(contents, languageServer, file);
     }
 
     @NotNull

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPTargetElementEvaluator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPTargetElementEvaluator.java
@@ -8,6 +8,7 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
+
 package com.redhat.devtools.lsp4ij.features.highlight;
 
 import com.intellij.codeInsight.TargetElementEvaluatorEx2;
@@ -19,6 +20,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.LSPPsiElement;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokensFileViewProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,7 +29,12 @@ import org.jetbrains.annotations.Nullable;
  */
 public class LSPTargetElementEvaluator extends TargetElementEvaluatorEx2 {
     @Override
-    public @Nullable PsiElement adjustReferenceOrReferencedElement(@NotNull PsiFile file, @NotNull Editor editor, int offset, int flags, @Nullable PsiElement refElement) {
+    @Nullable
+    public PsiElement adjustReferenceOrReferencedElement(@NotNull PsiFile file,
+                                                         @NotNull Editor editor,
+                                                         int offset,
+                                                         int flags,
+                                                         @Nullable PsiElement refElement) {
         if (!LanguageServersRegistry.getInstance().isFileSupported(file)) {
             return null;
         }
@@ -36,7 +43,13 @@ public class LSPTargetElementEvaluator extends TargetElementEvaluatorEx2 {
             return null;
         }
 
-        // Try to find the word at the caret and return a fake PSI element for it
+        // See if the view provider can provide an element
+        LSPSemanticTokensFileViewProvider semanticTokensFileViewProvider = LSPSemanticTokensFileViewProvider.getInstance(file);
+        if (semanticTokensFileViewProvider != null) {
+            return semanticTokensFileViewProvider.findElementAt(offset);
+        }
+
+        // Nope. Try to find the word at the caret and return a fake PSI element for it
         TextRange targetTextRange = LSPIJUtils.getWordRangeAt(editor.getDocument(), file, offset);
         return targetTextRange != null ? new LSPPsiElement(file, targetTextRange) : null;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPGotoDeclarationHandler.java
@@ -8,20 +8,30 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
+
 package com.redhat.devtools.lsp4ij.features.navigation;
 
+import com.intellij.codeInsight.navigation.CtrlMouseHandler2;
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
+import com.intellij.util.ArrayUtil;
+import com.intellij.util.ExceptionUtil;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokensFileViewProvider;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,25 +52,85 @@ public class LSPGotoDeclarationHandler implements GotoDeclarationHandler {
 
     @Nullable
     @Override
-    public PsiElement[] getGotoDeclarationTargets(@Nullable PsiElement sourceElement, int offset, Editor editor) {
+    public PsiElement[] getGotoDeclarationTargets(@Nullable PsiElement sourceElement,
+                                                  int offset,
+                                                  Editor editor) {
         Project project = editor.getProject();
         if (project == null || project.isDisposed()) {
             return PsiElement.EMPTY_ARRAY;
         }
-        PsiFile psiFile = sourceElement.getContainingFile();
+        PsiFile psiFile = sourceElement != null ? sourceElement.getContainingFile() : null;
         if (psiFile == null) {
             return PsiElement.EMPTY_ARRAY;
         }
         if (!LanguageServersRegistry.getInstance().isFileSupported(psiFile)) {
             return PsiElement.EMPTY_ARRAY;
         }
+
+        // If this was called for a populated semantic tokens view provider, try to get the target directly from it
+        LSPSemanticTokensFileViewProvider semanticTokensFileViewProvider = LSPSemanticTokensFileViewProvider.getInstance(psiFile);
+        if (semanticTokensFileViewProvider != null) {
+            // If this is definitely a reference, resolve it
+            if (semanticTokensFileViewProvider.isReference(offset)) {
+                PsiReference reference = semanticTokensFileViewProvider.findReferenceAt(offset);
+                PsiElement target = reference != null ? reference.resolve() : null;
+                return target != null ? new PsiElement[]{target} : PsiElement.EMPTY_ARRAY;
+            }
+            // If it's definitely a declaration, just return an empty set of targets
+            else if (semanticTokensFileViewProvider.isDeclaration(offset)) {
+                return PsiElement.EMPTY_ARRAY;
+            }
+        }
+
+        // Use LSP to find targets
+        PsiElement[] targets = getGotoDeclarationTargets(sourceElement, offset);
+
+        // If this is a semantic token-backed file and there were targets but this wasn't represented in semantic tokens
+        // as a reference, stub a reference for the word at the current offset
+        if (semanticTokensFileViewProvider != null) {
+            if (!ArrayUtil.isEmpty(targets)) {
+                TextRange wordRange = LSPIJUtils.getWordRangeAt(editor.getDocument(), psiFile, offset);
+                if (wordRange != null) {
+                    // This will ensure it's stubbed as a generic reference
+                    semanticTokensFileViewProvider.addSemanticToken(wordRange, SemanticTokenTypes.Type, null);
+                }
+            }
+
+            // NOTE: When invoked during Ctrl/Cmd+Mouseover, it's CRITICAL that we short-circuit any further Goto
+            // Declaration Handler processing if this file is backed by semantic tokens and it's not a reference or a
+            // declaration. Otherwise things that can't act as references will show up as hyperlinked incorrectly.
+            // Unfortunately there's no symbolic state available as to whether or not this was invoked that way, so
+            // we have to check the stack trace for the known caller.
+            if (ExceptionUtil.currentStackTrace().contains(CtrlMouseHandler2.class.getName())) {
+                throw new ProcessCanceledException();
+            }
+        }
+
+        return targets;
+    }
+
+    /**
+     * Uses LSP to resolve the target elements for the reference at the specified offset in the file containing the
+     * provided source element.
+     *
+     * @param sourceElement the source element
+     * @param offset        the offset
+     * @return the resolved reference
+     */
+    @ApiStatus.Internal
+    public static PsiElement @NotNull [] getGotoDeclarationTargets(@NotNull PsiElement sourceElement, int offset) {
         VirtualFile file = LSPIJUtils.getFile(sourceElement);
         if (file == null) {
             return PsiElement.EMPTY_ARRAY;
         }
-        Document document = editor.getDocument();
+
+        Document document = LSPIJUtils.getDocument(file);
+        if (document == null) {
+            return PsiElement.EMPTY_ARRAY;
+        }
 
         // Consume LSP 'textDocument/definition' request
+        PsiFile psiFile = sourceElement.getContainingFile();
         LSPDefinitionSupport definitionSupport = LSPFileSupport.getSupport(psiFile).getDefinitionSupport();
         var params = new LSPDefinitionParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> definitionsFuture = definitionSupport.getDefinitions(params);
@@ -80,6 +150,7 @@ public class LSPGotoDeclarationHandler implements GotoDeclarationHandler {
             // textDocument/definition has been collected correctly
             List<LocationData> locations = definitionsFuture.getNow(null);
             if (locations != null) {
+                Project project = psiFile.getProject();
                 return locations
                         .stream()
                         .map(location -> toPsiElement(location.location(), location.languageServer().getClientFeatures(), project))
@@ -89,5 +160,4 @@ public class LSPGotoDeclarationHandler implements GotoDeclarationHandler {
         }
         return PsiElement.EMPTY_ARRAY;
     }
-
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameRefactoringDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameRefactoringDialog.java
@@ -14,6 +14,7 @@
 package com.redhat.devtools.lsp4ij.features.rename;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileTypes.FileTypes;
@@ -239,10 +240,10 @@ class LSPRenameRefactoringDialog extends RefactoringDialog {
                 @Override
                 public void run(@NotNull ProgressIndicator progressIndicator) {
                     progressIndicator.setIndeterminate(true);
-                    LSPExternalReferencesFinder.processExternalReferences(file, offset, reference -> {
+                    ReadAction.run(() -> LSPExternalReferencesFinder.processExternalReferences(file, offset, reference -> {
                         externalReferences.add(reference);
                         return true;
-                    });
+                    }));
                 }
             });
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/DefaultSemanticTokensColorsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/DefaultSemanticTokensColorsProvider.java
@@ -29,6 +29,18 @@ public class DefaultSemanticTokensColorsProvider implements SemanticTokensColors
     public @Nullable TextAttributesKey getTextAttributesKey(@NotNull String tokenType,
                                                             @NotNull List<String> tokenModifiers,
                                                             @NotNull PsiFile file) {
+        LSPSemanticTokenType lspSemanticTokenType = LSPSemanticTokenTypes.valueOf(tokenType);
+        if (lspSemanticTokenType != null) {
+            // If this is for a custom semantic token type that expresses an inheritance relationship, swap it out now
+            if (lspSemanticTokenType.getInheritFrom() != null) {
+                tokenType = lspSemanticTokenType.getInheritFrom();
+            }
+            // If it's for one that has a specific text attributes key, use it
+            else if (lspSemanticTokenType.getTextAttributesKey() != null) {
+                return TextAttributesKey.find(lspSemanticTokenType.getTextAttributesKey());
+            }
+        }
+
         switch (tokenType) {
 
             // namespace: for identifiers that declare or reference a namespace, module, or package.
@@ -159,12 +171,6 @@ public class DefaultSemanticTokensColorsProvider implements SemanticTokensColors
             // macro: for identifiers that declare a macro.
             case SemanticTokenTypes.Macro:
                 return SemanticTokensHighlightingColors.MACRO;
-
-            // label: for identifiers that declare a label.
-            case "label":
-                // LSP doesn't define "label", but vscode defines it
-                // See https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
-                return SemanticTokensHighlightingColors.LABEL;
 
             // comment: for tokens that represent a comment.
             case SemanticTokenTypes.Comment:

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenType.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenType.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A custom semantic token type.
+ */
+@ApiStatus.Internal
+public class LSPSemanticTokenType {
+
+    private final String name;
+    private final boolean identifier;
+    private final boolean type;
+    private final boolean keyword;
+    private final String inheritFrom;
+    private final String textAttributesKey;
+
+    /**
+     * Creates a custom semantic token type.
+     *
+     * @param name              the name
+     * @param identifier        whether or not the token represents an identifier
+     * @param type              whether or not the token represents a type
+     * @param keyword           whether or not the token represents a keyword
+     * @param inheritFrom       an optional existing semantic token type from which this one should inherit its behavior
+     * @param textAttributesKey an optional text attributes key that should be used for syntax highlighting
+     */
+    LSPSemanticTokenType(@NotNull String name,
+                         boolean identifier,
+                         boolean type,
+                         boolean keyword,
+                         @Nullable String inheritFrom,
+                         @Nullable String textAttributesKey) {
+        this.name = name;
+        this.identifier = identifier;
+        this.type = type;
+        this.keyword = keyword;
+        this.inheritFrom = inheritFrom;
+        this.textAttributesKey = textAttributesKey;
+    }
+
+    /**
+     * The semantic token type name.
+     */
+    @NotNull
+    @ApiStatus.Internal
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Whether or not the semantic token should be interpreted as being an identifier.
+     */
+    @ApiStatus.Internal
+    public boolean isIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * Whether or not the semantic token should be interpreted as being a type.
+     */
+    @ApiStatus.Internal
+    public boolean isType() {
+        return type;
+    }
+
+    /**
+     * Whether or not the semantic token should be interpreted as being a keyword.
+     */
+    @ApiStatus.Internal
+    public boolean isKeyword() {
+        return keyword;
+    }
+
+    /**
+     * The name of the existing semantic token type from which this one should inherit its behavior.
+     */
+    @Nullable
+    @ApiStatus.Internal
+    public String getInheritFrom() {
+        return inheritFrom;
+    }
+
+    /**
+     * The text attributes key that should be used for syntax highlighting of this semantic token.
+     */
+    @Nullable
+    @ApiStatus.Internal
+    public String getTextAttributesKey() {
+        return textAttributesKey;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenTypes.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenTypes.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens;
+
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Custom semantic token types.
+ */
+@ApiStatus.Internal
+public class LSPSemanticTokenTypes {
+
+    // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
+    private static final LSPSemanticTokenType Label = new LSPSemanticTokenType(
+            "label",
+            true,
+            false,
+            false,
+            null,
+            SemanticTokensHighlightingColors.LABEL.getExternalName()
+    );
+
+    // TypeScript "member"
+    private static final LSPSemanticTokenType Member = new LSPSemanticTokenType(
+            "member",
+            true,
+            false,
+            false,
+            SemanticTokenTypes.Method,
+            null
+    );
+
+    // All custom semantic token types
+    private static final LSPSemanticTokenType[] values = new LSPSemanticTokenType[]{
+            Label,
+            Member
+    };
+
+    // An index for finding a custom semantic token type by its name
+    private static final Map<String, LSPSemanticTokenType> nameIndex = new LinkedHashMap<>();
+
+    static {
+        for (LSPSemanticTokenType value : values) {
+            nameIndex.put(value.getName(), value);
+        }
+    }
+
+    /**
+     * Returns all custom semantic token types.
+     *
+     * @return all custom semantic token types
+     */
+    @NotNull
+    @ApiStatus.Internal
+    public static LSPSemanticTokenType[] values() {
+        return values;
+    }
+
+    /**
+     * Returns the custom semantic token type with the specified name.
+     *
+     * @param name the custom semantic token type name
+     * @return the custom semantic token type, or null if none exists with the specified name
+     */
+    @Nullable
+    @ApiStatus.Internal
+    public static LSPSemanticTokenType valueOf(@NotNull String name) {
+        return nameIndex.get(name);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticToken.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticToken.java
@@ -1,0 +1,276 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.ThreeState;
+import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.LSPSemanticTokenTypes;
+import org.eclipse.lsp4j.SemanticTokenModifiers;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a concrete semantic token in a file.
+ */
+class LSPSemanticToken {
+
+    // All semantic token types
+    private static final Set<String> ALL_TOKEN_TYPES = ContainerUtil.union(
+            Set.of(
+                    SemanticTokenTypes.Namespace,
+                    SemanticTokenTypes.Type,
+                    SemanticTokenTypes.Class,
+                    SemanticTokenTypes.Enum,
+                    SemanticTokenTypes.Interface,
+                    SemanticTokenTypes.Struct,
+                    SemanticTokenTypes.TypeParameter,
+                    SemanticTokenTypes.Parameter,
+                    SemanticTokenTypes.Variable,
+                    SemanticTokenTypes.Property,
+                    SemanticTokenTypes.EnumMember,
+                    SemanticTokenTypes.Event,
+                    SemanticTokenTypes.Function,
+                    SemanticTokenTypes.Method,
+                    SemanticTokenTypes.Macro,
+                    SemanticTokenTypes.Modifier,
+                    SemanticTokenTypes.Comment,
+                    SemanticTokenTypes.String,
+                    SemanticTokenTypes.Number,
+                    SemanticTokenTypes.Regexp,
+                    SemanticTokenTypes.Operator,
+                    SemanticTokenTypes.Decorator
+            ),
+            Arrays.stream(LSPSemanticTokenTypes.values())
+                    .map(t -> t.getName())
+                    .collect(Collectors.toSet())
+    );
+
+    // Semantic token types that should be interpreted as representing identifiers
+    private static final Set<String> IDENTIFIER_TOKEN_TYPES = ContainerUtil.union(
+            Set.of(
+                    SemanticTokenTypes.Namespace,
+                    SemanticTokenTypes.Type,
+                    SemanticTokenTypes.Class,
+                    SemanticTokenTypes.Enum,
+                    SemanticTokenTypes.Interface,
+                    SemanticTokenTypes.Struct,
+                    SemanticTokenTypes.TypeParameter,
+                    SemanticTokenTypes.Parameter,
+                    SemanticTokenTypes.Variable,
+                    SemanticTokenTypes.Property,
+                    SemanticTokenTypes.EnumMember,
+                    SemanticTokenTypes.Event,
+                    SemanticTokenTypes.Function,
+                    SemanticTokenTypes.Method,
+                    SemanticTokenTypes.Macro,
+                    SemanticTokenTypes.Decorator
+            ),
+            Arrays.stream(LSPSemanticTokenTypes.values())
+                    .filter(t -> t.isIdentifier())
+                    .map(t -> t.getName())
+                    .collect(Collectors.toSet())
+    );
+
+    // Semantic token types that should NOT be interpreted as representing identifiers
+    private static final Set<String> NON_IDENTIFIER_TOKEN_TYPES = new LinkedHashSet<>(ContainerUtil.subtract(ALL_TOKEN_TYPES, IDENTIFIER_TOKEN_TYPES));
+
+    // Semantic token types that should be interpreted as representing types
+    private static final Set<String> TYPE_TOKEN_TYPES = ContainerUtil.union(
+            Set.of(
+                    SemanticTokenTypes.Namespace,
+                    SemanticTokenTypes.Type,
+                    SemanticTokenTypes.Class,
+                    SemanticTokenTypes.Enum,
+                    SemanticTokenTypes.Interface,
+                    SemanticTokenTypes.Struct
+            ),
+            Arrays.stream(LSPSemanticTokenTypes.values())
+                    .filter(t -> t.isType())
+                    .map(t -> t.getName())
+                    .collect(Collectors.toSet())
+    );
+
+    // Semantic token types that should NOT be interpreted as representing types
+    private static final Set<String> NON_TYPE_TOKEN_TYPES = new LinkedHashSet<>(ContainerUtil.subtract(ALL_TOKEN_TYPES, TYPE_TOKEN_TYPES));
+
+    // Semantic token types that should be interpreted as representing keywords/reserved words in the language
+    private static final Set<String> KEYWORD_TOKEN_TYPES = ContainerUtil.union(
+            Set.of(
+                    SemanticTokenTypes.Keyword,
+                    SemanticTokenTypes.Modifier
+            ),
+            Arrays.stream(LSPSemanticTokenTypes.values())
+                    .filter(t -> t.isKeyword())
+                    .map(t -> t.getName())
+                    .collect(Collectors.toSet())
+    );
+
+    // Semantic token modifiers that should be interpreted as representing declarations
+    private static final Set<String> DECLARATION_TOKEN_MODIFIERS = Set.of(
+            SemanticTokenModifiers.Declaration,
+            SemanticTokenModifiers.Definition
+    );
+
+    private final PsiFile file;
+    private final TextRange textRange;
+    private final String tokenType;
+    private final List<String> tokenModifiers;
+
+    private final boolean isFileLevel;
+    private final LSPSemanticTokenElementType elementType;
+    private volatile LSPSemanticTokenPsiElement element = null;
+
+    /**
+     * Creates a new semantic token.
+     *
+     * @param file           the file
+     * @param textRange      the semantic token's text range
+     * @param tokenType      the token type
+     * @param tokenModifiers the token modifiers
+     */
+    LSPSemanticToken(
+            @NotNull PsiFile file,
+            @NotNull TextRange textRange,
+            @Nullable String tokenType,
+            @Nullable List<String> tokenModifiers
+    ) {
+        this.file = file;
+        this.textRange = textRange;
+        this.tokenType = tokenType;
+        this.tokenModifiers = tokenModifiers != null ? tokenModifiers : Collections.emptyList();
+        this.isFileLevel = Objects.equals(file.getTextRange(), textRange);
+        this.elementType = getElementType(this.tokenType, this.tokenModifiers);
+    }
+
+    @NotNull
+    PsiFile getFile() {
+        return file;
+    }
+
+    @NotNull
+    TextRange getTextRange() {
+        return textRange;
+    }
+
+    @Nullable
+    String getTokenType() {
+        return tokenType;
+    }
+
+    @NotNull
+    ThreeState isIdentifier() {
+        if (tokenType != null) {
+            if (IDENTIFIER_TOKEN_TYPES.contains(tokenType)) {
+                return ThreeState.YES;
+            } else if (NON_IDENTIFIER_TOKEN_TYPES.contains(tokenType)) {
+                return ThreeState.NO;
+            }
+        }
+        return ThreeState.UNSURE;
+    }
+
+    @NotNull
+    ThreeState isType() {
+        if (tokenType != null) {
+            if (TYPE_TOKEN_TYPES.contains(tokenType)) {
+                return ThreeState.YES;
+            } else if (NON_TYPE_TOKEN_TYPES.contains(tokenType)) {
+                return ThreeState.NO;
+            }
+        }
+        return ThreeState.UNSURE;
+    }
+
+    @NotNull
+    List<String> getTokenModifiers() {
+        return tokenModifiers;
+    }
+
+    boolean isFileLevel() {
+        return isFileLevel;
+    }
+
+    @NotNull
+    LSPSemanticTokenElementType getElementType() {
+        return elementType;
+    }
+
+    @NotNull
+    private static LSPSemanticTokenElementType getElementType(@Nullable String tokenType,
+                                                              @NotNull List<String> tokenModifiers) {
+        if (tokenType != null) {
+            // If this is an identifier token, see if it's a declaration or a reference
+            if (IDENTIFIER_TOKEN_TYPES.contains(tokenType)) {
+                return ContainerUtil.intersects(DECLARATION_TOKEN_MODIFIERS, tokenModifiers) ?
+                        LSPSemanticTokenElementType.DECLARATION :
+                        LSPSemanticTokenElementType.REFERENCE;
+            }
+            // Keyword/reserved word
+            else if (KEYWORD_TOKEN_TYPES.contains(tokenType)) {
+                return LSPSemanticTokenElementType.KEYWORD;
+            }
+            // Other, e.g., string/numeric literal, comment, operator, etc.
+            else {
+                return switch (tokenType) {
+                    case SemanticTokenTypes.Comment -> LSPSemanticTokenElementType.COMMENT;
+                    case SemanticTokenTypes.String -> LSPSemanticTokenElementType.STRING;
+                    case SemanticTokenTypes.Number -> LSPSemanticTokenElementType.NUMBER;
+                    case SemanticTokenTypes.Regexp -> LSPSemanticTokenElementType.REGEXP;
+                    case SemanticTokenTypes.Operator -> LSPSemanticTokenElementType.OPERATOR;
+                    default -> LSPSemanticTokenElementType.UNKNOWN;
+                };
+            }
+        }
+
+        // Fallback is unknown
+        return LSPSemanticTokenElementType.UNKNOWN;
+    }
+
+    @NotNull
+    LSPSemanticTokenPsiElement getElement() {
+        // Create the element lazily so that if it's never needed, it's never created
+        if (element == null) {
+            synchronized (this) {
+                if (element == null) {
+                    element = new LSPSemanticTokenPsiElement(this);
+                }
+            }
+        }
+        return element;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ((o == null) || (getClass() != o.getClass())) return false;
+        LSPSemanticToken that = (LSPSemanticToken) o;
+        return Objects.equals(file, that.file) &&
+                Objects.equals(textRange, that.textRange) &&
+                Objects.equals(tokenType, that.tokenType) &&
+                Objects.equals(tokenModifiers, that.tokenModifiers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                file,
+                textRange,
+                tokenType,
+                tokenModifiers
+        );
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenDocumentationProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenDocumentationProvider.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.util.ThreeState;
+import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.features.documentation.LSPDocumentationTarget;
+import com.redhat.devtools.lsp4ij.features.documentation.LSPDocumentationTargetProvider;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Documentation provider for {@link LSPSemanticTokensFileViewProvider} files that provides quick navigation info
+ * based on the LSP documentation for a semantic token.
+ */
+public class LSPSemanticTokenDocumentationProvider extends AbstractDocumentationProvider {
+
+    private static final LSPDocumentationTargetProvider LSP_DOCUMENTATION_TARGET_PROVIDER = new LSPDocumentationTargetProvider();
+
+    @Override
+    @Nullable
+    @Nls
+    public String getQuickNavigateInfo(PsiElement targetElement,
+                                       PsiElement sourceElement) {
+        String documentation = getDocumentation(sourceElement, targetElement);
+        return documentation != null ? documentation : super.getQuickNavigateInfo(targetElement, sourceElement);
+    }
+
+    /**
+     * Provides external access to documentation for other parts of LSP4IJ, e.g.,
+     * {@link com.redhat.devtools.lsp4ij.usages.LSPUsageElementDescriptionProvider}.
+     *
+     * @param element the element for which documentation is requested
+     * @return documentation for the element, or null if none could be found
+     */
+    @Nullable
+    @ApiStatus.Internal
+    public static String getDocumentation(@Nullable PsiElement element) {
+        return getDocumentation(element, element);
+    }
+
+    @Nullable
+    private static String getDocumentation(@Nullable PsiElement sourceElement,
+                                           @Nullable PsiElement targetElement) {
+        LSPSemanticTokensFileViewProvider semanticTokensFileViewProvider = LSPSemanticTokensFileViewProvider.getInstance(sourceElement);
+        if (semanticTokensFileViewProvider != null) {
+            int offset = sourceElement.getTextOffset();
+            ThreeState isIdentifier = semanticTokensFileViewProvider.isIdentifier(offset);
+            if ((isIdentifier == ThreeState.YES) ||
+                // If the token is definitely not an identifier and it's not whitespace, give the benefit of the doubt
+                ((isIdentifier == ThreeState.NO) && !semanticTokensFileViewProvider.isWhitespace(offset))) {
+                // Try to get the actual documentation for the element via LSP
+                try {
+                    PsiFile file = sourceElement.getContainingFile();
+                    List<LSPDocumentationTarget> lspDocumentationTargets = LSP_DOCUMENTATION_TARGET_PROVIDER
+                            .documentationTargets(file, offset)
+                            .stream()
+                            .filter((Predicate<DocumentationTarget>) dt -> dt instanceof LSPDocumentationTarget)
+                            .map((Function<DocumentationTarget, LSPDocumentationTarget>) dt -> (LSPDocumentationTarget) dt)
+                            .toList();
+                    if (!ContainerUtil.isEmpty(lspDocumentationTargets)) {
+                        String documentation = StringUtil.join(lspDocumentationTargets, LSPDocumentationTarget::getHtml, "\n").trim();
+                        if (StringUtil.isNotEmpty(documentation)) {
+                            return documentation;
+                        }
+                    }
+                } catch (ProcessCanceledException pce) {
+                    // Larger documentation can time out, so just degrade gracefully to fallback documentation
+                }
+            }
+        }
+
+        return getFallbackDocumentation(sourceElement, targetElement);
+    }
+
+    @Nullable
+    private static String getFallbackDocumentation(@Nullable PsiElement sourceElement,
+                                                   @Nullable PsiElement targetElement) {
+        // Minimally try to include the element's name
+        if (targetElement instanceof PsiNamedElement namedElement) {
+            String elementName = namedElement.getName();
+            if (StringUtil.isNotEmpty(elementName)) {
+                // If the source and target are in different files, include the target file name
+                PsiFile targetFile = namedElement.getContainingFile();
+                return "<html><code>" + elementName + "</code>" +
+                       // If the source and target are in different files, include the target file name
+                       ((sourceElement != null) && !Objects.equals(targetFile, sourceElement.getContainingFile()) ?
+                               " in <code>" + targetFile.getName() + "</code>" :
+                               "") +
+                       "</html>";
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenElementType.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenElementType.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * LSP semantic token element types.
+ */
+class LSPSemanticTokenElementType extends IElementType {
+    // These are the concrete element types that we can derive from semantic token types and modifiers
+    static final LSPSemanticTokenElementType DECLARATION = new LSPSemanticTokenElementType("DECLARATION");
+    static final LSPSemanticTokenElementType REFERENCE = new LSPSemanticTokenElementType("REFERENCE");
+    static final LSPSemanticTokenElementType KEYWORD = new LSPSemanticTokenElementType("KEYWORD");
+    static final LSPSemanticTokenElementType COMMENT = new LSPSemanticTokenElementType("COMMENT");
+    static final LSPSemanticTokenElementType STRING = new LSPSemanticTokenElementType("STRING");
+    static final LSPSemanticTokenElementType NUMBER = new LSPSemanticTokenElementType("NUMBER");
+    static final LSPSemanticTokenElementType REGEXP = new LSPSemanticTokenElementType("REGEXP");
+    static final LSPSemanticTokenElementType OPERATOR = new LSPSemanticTokenElementType("OPERATOR");
+    static final LSPSemanticTokenElementType UNKNOWN = new LSPSemanticTokenElementType("UNKNOWN");
+
+    LSPSemanticTokenElementType(@NonNls @NotNull String debugName) {
+        super(debugName, LSPSemanticTokenLanguage.INSTANCE);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenLanguage.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenLanguage.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.lang.Language;
+
+/**
+ * Simple proxy language for {@link LSPSemanticTokenElementType} instances.
+ */
+class LSPSemanticTokenLanguage extends Language {
+
+    static final LSPSemanticTokenLanguage INSTANCE = new LSPSemanticTokenLanguage();
+
+    LSPSemanticTokenLanguage() {
+        super(LSPSemanticTokenLanguage.class.getSimpleName());
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenPsiElement.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiNameIdentifierOwner;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.features.LSPPsiElement;
+import com.redhat.devtools.lsp4ij.ui.IconMapper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.Icon;
+import java.util.Objects;
+
+/**
+ * A PSI element for a semantic token in a {@link LSPSemanticTokensFileViewProvider} file.
+ */
+public class LSPSemanticTokenPsiElement extends LSPPsiElement implements PsiNameIdentifierOwner {
+    private final LSPSemanticToken semanticToken;
+    private final Icon icon;
+    private volatile LeafPsiElement node = null;
+    private volatile String text = null;
+
+    /**
+     * Creates a new PSI element for the provided semantic token.
+     *
+     * @param semanticToken the semantic token
+     */
+    LSPSemanticTokenPsiElement(@NotNull LSPSemanticToken semanticToken) {
+        super(semanticToken.getFile(), semanticToken.getTextRange());
+        this.semanticToken = semanticToken;
+        // If this is a declaration or reference, try to use an appropriate icon
+        LSPSemanticTokenElementType elementType = semanticToken.getElementType();
+        this.icon = (elementType == LSPSemanticTokenElementType.DECLARATION) || (elementType == LSPSemanticTokenElementType.REFERENCE) ?
+                IconMapper.getIcon(semanticToken.getTokenType()) :
+                null;
+    }
+
+    @Override
+    public boolean isPhysical() {
+        // These do represent real text ranges in physical files
+        return true;
+    }
+
+    @Override
+    public boolean isValid() {
+        // Tie the validity of this element to that of its containing file
+        return semanticToken.getFile().isValid();
+    }
+
+    @Override
+    public boolean canNavigate() {
+        // References can be navigated
+        return semanticToken.getElementType() == LSPSemanticTokenElementType.REFERENCE;
+    }
+
+    @Override
+    public String getName() {
+        return semanticToken.isFileLevel() ? getContainingFile().getName() : super.getName();
+    }
+
+    @Override
+    @Nullable
+    public PsiElement getNameIdentifier() {
+        // If this is a declaration, return this element as the name identifier
+        return semanticToken.getElementType() == LSPSemanticTokenElementType.DECLARATION ? this : null;
+    }
+
+    @Override
+    @Nullable
+    public Icon getIcon(boolean open) {
+        return icon != null ? icon : super.getIcon(open);
+    }
+
+    @Override
+    @Nullable
+    public ASTNode getNode() {
+        // This is lazy-initialized because it needs the element text which is itself lazy-initialized
+        if (node == null) {
+            synchronized (this) {
+                if (node == null) {
+                    node = new LeafPsiElement(semanticToken.getElementType(), getText());
+                }
+            }
+        }
+
+        return node;
+    }
+
+    /**
+     * Returns the element's semantic token type.
+     *
+     * @return the element's semantic token type, or null if the element doesn't have a token type
+     */
+    @Nullable
+    public String getType() {
+        return semanticToken.getTokenType();
+    }
+
+    @Override
+    @NotNull
+    public String getText() {
+        // Optimization for full-file elements to avoid copying the full file text
+        if (semanticToken.isFileLevel()) return getContainingFile().getText();
+
+        // This is lazy-initialized because to avoid having to derive it until/unless needed
+        if (text == null) {
+            synchronized (this) {
+                if (text == null) {
+                    String workingText = "";
+                    TextRange textRange = getTextRange();
+                    if (textRange != null) {
+                        Document document = LSPIJUtils.getDocument(this);
+                        CharSequence documentChars = document != null ? document.getCharsSequence() : null;
+                        CharSequence textChars;
+                        if (documentChars != null) {
+                            int startOffset = Math.max(textRange.getStartOffset(), 0);
+                            int endOffset = Math.min(textRange.getEndOffset(), documentChars.length());
+                            textChars = documentChars.subSequence(startOffset, endOffset);
+                        } else {
+                            textChars = null;
+                        }
+                        if (textChars != null) {
+                            workingText = textChars.toString();
+                        }
+                    }
+                    text = workingText;
+                }
+            }
+        }
+
+        return text;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ((o == null) || (getClass() != o.getClass())) return false;
+        LSPSemanticTokenPsiElement that = (LSPSemanticTokenPsiElement) o;
+        return Objects.equals(semanticToken, that.semanticToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(semanticToken);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenPsiElementManipulator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenPsiElementManipulator.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.AbstractElementManipulator;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * If not registered, an error is raised by the IDE about not being able to find an element manipulator. This is
+ * fundamentally a no-op and just returns the original element.
+ */
+public class LSPSemanticTokenPsiElementManipulator extends AbstractElementManipulator<LSPSemanticTokenPsiElement> {
+    @Override
+    @Nullable
+    public LSPSemanticTokenPsiElement handleContentChange(@NotNull LSPSemanticTokenPsiElement semanticTokenElement,
+                                                          @NotNull TextRange textRange,
+                                                          String newContent) throws IncorrectOperationException {
+        // We can safely ignore the change and return the original element here
+        return semanticTokenElement;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenPsiReference.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenPsiReference.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReferenceBase;
+import com.intellij.util.ArrayUtil;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.features.navigation.LSPGotoDeclarationHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * A PSI reference to a semantic token declaration that defers uses
+ * {@link LSPGotoDeclarationHandler#getGotoDeclarationTargets(PsiElement, int, Editor)} for deferred resolution.
+ */
+class LSPSemanticTokenPsiReference extends PsiReferenceBase<LSPSemanticTokenPsiElement> {
+
+    private final LSPSemanticToken semanticToken;
+
+    /**
+     * Creates a reference for the provided reference semantic token.
+     *
+     * @param semanticToken the semantic token
+     */
+    LSPSemanticTokenPsiReference(@NotNull LSPSemanticToken semanticToken) {
+        super(semanticToken.getElement());
+        this.semanticToken = semanticToken;
+    }
+
+    @Override
+    @Nullable
+    public PsiElement resolve() {
+        LSPSemanticTokenPsiElement element = getElement();
+        LSPSemanticTokenElementType elementType = semanticToken.getElementType();
+        if (elementType == LSPSemanticTokenElementType.REFERENCE) {
+            Editor editor = LSPIJUtils.editorForElement(element);
+            if (editor != null) {
+                PsiElement[] targets = LSPGotoDeclarationHandler.getGotoDeclarationTargets(element, element.getTextOffset());
+                return ArrayUtil.getFirstElement(targets);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    @NotNull
+    public TextRange getAbsoluteRange() {
+        //noinspection DataFlowIssue
+        return getElement().getTextRange();
+    }
+
+    @Override
+    public Object @NotNull [] getVariants() {
+        // We don't have enough information to return variants here
+        return EMPTY_ARRAY;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ((o == null) || (getClass() != o.getClass())) return false;
+        LSPSemanticTokenPsiReference that = (LSPSemanticTokenPsiReference) o;
+        return Objects.equals(semanticToken, that.semanticToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(semanticToken);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensContainer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensContainer.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.util.ThreeState;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Common interface for semantic tokens containers.
+ */
+interface LSPSemanticTokensContainer {
+    /**
+     * Whether or not the file view provider is enabled for semantic tokens.
+     *
+     * @return true if the file view provider is enabled for semantic tokens; otherwise false
+     */
+    boolean isEnabled();
+
+    /**
+     * Whether or not the semantic token at the offset is for a keyword.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a keyword; otherwise false
+     */
+    boolean isKeyword(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a operator.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a operator; otherwise false
+     */
+    boolean isOperator(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a string literal.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a string literal; otherwise false
+     */
+    boolean isStringLiteral(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a numeric literal.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a numeric literal; otherwise false
+     */
+    boolean isNumericLiteral(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a regular expression.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a regular expression; otherwise false
+     */
+    boolean isRegularExpression(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a comment.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a comment; otherwise false
+     */
+    boolean isComment(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a declaration or definition.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a declaration or definition; otherwise false
+     */
+    boolean isDeclaration(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a reference.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is for a reference; otherwise false
+     */
+    boolean isReference(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is of an unknown type.
+     *
+     * @param offset the offset
+     * @return true if the semantic token at the offset is of an unknown type; otherwise false
+     */
+    boolean isUnknown(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for an identifier.
+     *
+     * @param offset the offset
+     * @return {@link ThreeState#YES} if the semantic token at the offset is conclusively for an identifier;
+     * {@link ThreeState#NO} if the semantic token at the offset is conclusively <b>not</b> for an identifier;
+     * otherwise {@link ThreeState#UNSURE}
+     */
+    @NotNull
+    ThreeState isIdentifier(int offset);
+
+    /**
+     * Whether or not the semantic token at the offset is for a type declaration, definition, or reference.
+     *
+     * @param offset the offset
+     * @return {@link ThreeState#YES} if the semantic token at the offset is conclusively for a type;
+     * {@link ThreeState#NO} if the semantic token at the offset is conclusively <b>not</b> for a type;
+     * otherwise {@link ThreeState#UNSURE}
+     */
+    @NotNull
+    ThreeState isType(int offset);
+
+    /**
+     * Whether or not the offset is for whitespace.
+     *
+     * @param offset the offset
+     * @return true if the offset is for whitespace; otherwise false
+     */
+    boolean isWhitespace(int offset);
+
+    /**
+     * Returns the text range of the semantic token at the offset.
+     *
+     * @param offset the offset
+     * @return the text range of the semantic token at the offset, or null if there is no semantic token at the offset
+     */
+    @Nullable
+    TextRange getSemanticTokenTextRange(int offset);
+
+    /**
+     * Adds a semantic token to the file view provider.
+     *
+     * @param textRange      the semantic token's text range
+     * @param tokenType      the optional semantic token type, generally as one of {@link org.eclipse.lsp4j.SemanticTokenTypes},
+     *                       but a custom type can be specified
+     * @param tokenModifiers the optional semantic token modifiers, generally as a collection of
+     *                       {@link org.eclipse.lsp4j.SemanticTokenModifiers}, but custom modifiers can be specified
+     */
+    void addSemanticToken(@NotNull TextRange textRange,
+                          @Nullable String tokenType,
+                          @Nullable List<String> tokenModifiers);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProvider.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A {@link FileViewProvider} for LSP-backed files where information about elements can be derived from reported
+ * semantic tokens. The implementation can be whatever is appropriate for the file, but this provides a common
+ * interface by which the file view provider can be populated with and queried for semantic token information.
+ */
+public interface LSPSemanticTokensFileViewProvider extends FileViewProvider, LSPSemanticTokensContainer {
+    /**
+     * Returns the semantic tokens file view provider for the provided element if assignable and enabled.
+     *
+     * @param element the PSI element
+     * @return the semantic tokens file view provider if assignable and enabled; otherwise false
+     */
+    @Nullable
+    @Contract("null -> null")
+    static LSPSemanticTokensFileViewProvider getInstance(@Nullable PsiElement element) {
+        PsiFile file = element != null ? element.getContainingFile() : null;
+        FileViewProvider fileViewProvider = file != null ? file.getViewProvider() : null;
+        return ((fileViewProvider instanceof LSPSemanticTokensFileViewProvider semanticTokensFileViewProvider) &&
+                semanticTokensFileViewProvider.isEnabled()) ?
+                semanticTokensFileViewProvider :
+                null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderFactory.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.FileViewProviderFactory;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.SingleRootFileViewProvider;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A {@link FileViewProviderFactory} for LSP-backed files where information about elements can be derived from reported
+ * semantic tokens.
+ */
+public class LSPSemanticTokensFileViewProviderFactory implements FileViewProviderFactory {
+
+    @Override
+    @NotNull
+    public final FileViewProvider createFileViewProvider(@NotNull VirtualFile virtualFile,
+                                                         Language language,
+                                                         @NotNull PsiManager psiManager,
+                                                         boolean eventSystemEnabled) {
+        // Only create a semantic tokens-based view provider for files supported by a configured language server
+        if (LanguageServersRegistry.getInstance().isFileSupported(virtualFile, language)) {
+            return language != null ?
+                    // If there's a language, create a file view provider for it
+                    createFileViewProviderForLanguage(psiManager, virtualFile, eventSystemEnabled, language) :
+                    // Otherwise create one for the file type
+                    createFileViewProviderForFileType(psiManager, virtualFile, eventSystemEnabled);
+        }
+
+        // If not supported, use the standard file view provider for simple source files
+        return new SingleRootFileViewProvider(psiManager, virtualFile, eventSystemEnabled);
+    }
+
+    /**
+     * Creates a semantic tokens-based file view provider for a file with a specific language.
+     *
+     * @param psiManager         the PSI manager
+     * @param virtualFile        the virtual file
+     * @param eventSystemEnabled whether or not the event system is enabled
+     * @param language           the file's language
+     * @return the semantic tokens-based file view provider for the file and language
+     */
+    @NotNull
+    protected LSPSemanticTokensFileViewProvider createFileViewProviderForLanguage(@NotNull PsiManager psiManager,
+                                                                                           @NotNull VirtualFile virtualFile,
+                                                                                           boolean eventSystemEnabled,
+                                                                                  @NotNull Language language) {
+        return new LSPSemanticTokensSingleRootFileViewProvider(psiManager, virtualFile, eventSystemEnabled, language);
+    }
+
+    /**
+     * Creates a semantic tokens-based file view provider for a file without a specific language.
+     *
+     * @param psiManager         the PSI manager
+     * @param virtualFile        the virtual file
+     * @param eventSystemEnabled whether or not the event system is enabled
+     * @return the semantic tokens-based file view provider for the file
+     */
+    @NotNull
+    protected LSPSemanticTokensFileViewProvider createFileViewProviderForFileType(@NotNull PsiManager psiManager,
+                                                                                           @NotNull VirtualFile virtualFile,
+                                                                                  boolean eventSystemEnabled) {
+        return new LSPSemanticTokensSingleRootFileViewProvider(psiManager, virtualFile, eventSystemEnabled);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderHelper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderHelper.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.CachedValueProvider;
+import com.intellij.psi.util.CachedValuesManager;
+import com.intellij.util.ThreeState;
+import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.client.features.EditorBehaviorFeature;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helper class for {@link LSPSemanticTokensFileViewProvider} implementations to help fulfill its interface.
+ */
+public class LSPSemanticTokensFileViewProviderHelper implements LSPSemanticTokensContainer {
+
+    private final LSPSemanticTokensFileViewProvider fileViewProvider;
+
+    /**
+     * Creates a helper for the provided semantic tokens file view provider.
+     *
+     * @param fileViewProvider the semantic tokens file view provider
+     */
+    public LSPSemanticTokensFileViewProviderHelper(@NotNull LSPSemanticTokensFileViewProvider fileViewProvider) {
+        this.fileViewProvider = fileViewProvider;
+    }
+
+    @Nullable
+    private PsiFile getFile() {
+        // There should only be one PSI file
+        List<PsiFile> allFiles = fileViewProvider.getAllFiles();
+        PsiFile file = allFiles.size() == 1 ? ContainerUtil.getFirstItem(allFiles) : null;
+        return (file != null) && file.isValid() && EditorBehaviorFeature.enableSemanticTokensFileViewProvider(file) ? file : null;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return getFile() != null;
+    }
+
+    @Override
+    public boolean isKeyword(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.KEYWORD);
+    }
+
+    @Override
+    public boolean isOperator(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.OPERATOR);
+    }
+
+    @Override
+    public boolean isStringLiteral(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.STRING);
+    }
+
+    @Override
+    public boolean isNumericLiteral(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.NUMBER);
+    }
+
+    @Override
+    public boolean isRegularExpression(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.REGEXP);
+    }
+
+    @Override
+    public boolean isComment(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.COMMENT);
+    }
+
+    @Override
+    public boolean isDeclaration(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.DECLARATION);
+    }
+
+    @Override
+    public boolean isReference(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.REFERENCE);
+    }
+
+    @Override
+    public boolean isUnknown(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) && (semanticToken.getElementType() == LSPSemanticTokenElementType.UNKNOWN);
+    }
+
+    @NotNull
+    public ThreeState isIdentifier(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) ? semanticToken.isIdentifier() :
+                isWhitespace(offset) ? ThreeState.NO :
+                        ThreeState.UNSURE;
+    }
+
+    @Override
+    @NotNull
+    public ThreeState isType(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return (semanticToken != null) ? semanticToken.isType() : ThreeState.UNSURE;
+    }
+
+    @Override
+    public boolean isWhitespace(int offset) {
+        PsiFile file = getFile();
+        Document document = (file != null) && (offset >= 0) && (offset < file.getTextLength()) ? LSPIJUtils.getDocument(file) : null;
+        return (document != null) && Character.isWhitespace(document.getCharsSequence().charAt(offset));
+    }
+
+    @Nullable
+    @Override
+    public TextRange getSemanticTokenTextRange(int offset) {
+        LSPSemanticToken semanticToken = getSemanticToken(offset);
+        return semanticToken != null ? semanticToken.getTextRange() : null;
+    }
+
+    // Store the file's semantic tokens so that we have constant-time lookup of an element for a given offset
+    @Nullable
+    private Map<Integer, LSPSemanticToken> getSemanticTokensByOffset() {
+        PsiFile file = getFile();
+        if (file == null) return null;
+
+        // By caching the storage on the file this way, it's automatically evicted when the file changes
+        return CachedValuesManager.getCachedValue(file, new CachedValueProvider<>() {
+            @Override
+            @NotNull
+            public Result<Map<Integer, LSPSemanticToken>> compute() {
+                Map<Integer, LSPSemanticToken> semanticTokensByOffset = Collections.synchronizedMap(new HashMap<>());
+                return Result.create(semanticTokensByOffset, file);
+            }
+        });
+    }
+
+    @Override
+    public void addSemanticToken(@NotNull TextRange textRange,
+                                 @Nullable String tokenType,
+                                 @Nullable List<String> tokenModifiers) {
+        PsiFile file = getFile();
+        if (file == null) return;
+
+        Map<Integer, LSPSemanticToken> semanticTokensByOffset = getSemanticTokensByOffset();
+        if (semanticTokensByOffset != null) {
+            LSPSemanticToken semanticToken = new LSPSemanticToken(file, textRange, tokenType, tokenModifiers);
+
+            // Index the token for its text range
+            for (int offset = textRange.getStartOffset(); offset <= textRange.getEndOffset(); offset++) {
+                semanticTokensByOffset.put(offset, semanticToken);
+            }
+        }
+    }
+
+    /**
+     * Returns the semantic token for the offset.
+     *
+     * @param offset the offset
+     * @return the semantic token or null if no semantic token exists at the offset
+     */
+    @Nullable
+    LSPSemanticToken getSemanticToken(int offset) {
+        PsiFile file = getFile();
+        if (file == null) return null;
+
+        // If this file has semantic tokens, use them
+        Map<Integer, LSPSemanticToken> semanticTokensByOffset = getSemanticTokensByOffset();
+        if (!ContainerUtil.isEmpty(semanticTokensByOffset)) {
+            return semanticTokensByOffset.get(offset);
+        }
+        // Otherwise stub a semantic token for the entire file so that it won't highlight as a link on mouse hover
+        else {
+            // By caching the stub on the file this way, it's automatically evicted when the file changes
+            return CachedValuesManager.getCachedValue(file, new CachedValueProvider<>() {
+                @Override
+                @NotNull
+                public Result<LSPSemanticToken> compute() {
+                    LSPSemanticToken stubSemanticToken = new LSPSemanticToken(file, file.getTextRange(), null, null);
+                    return Result.create(stubSemanticToken, file);
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensSingleRootFileViewProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensSingleRootFileViewProvider.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.SingleRootFileViewProvider;
+import com.intellij.psi.impl.source.resolve.reference.impl.PsiMultiReference;
+import com.intellij.util.ThreeState;
+import com.intellij.util.containers.ContainerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Implementation of {@link LSPSemanticTokensFileViewProvider} where PSI files are based on {@link SingleRootFileViewProvider}.
+ */
+public class LSPSemanticTokensSingleRootFileViewProvider
+        extends SingleRootFileViewProvider
+        implements LSPSemanticTokensFileViewProvider {
+
+    private final LSPSemanticTokensFileViewProviderHelper helper;
+
+    /**
+     * Creates a new semantic tokens-based file view provider for a file with a specific language.
+     *
+     * @param manager            the PSI manager
+     * @param virtualFile        the virtual file
+     * @param eventSystemEnabled whether or not the event system is enabled
+     * @param language           the file's language
+     */
+    protected LSPSemanticTokensSingleRootFileViewProvider(@NotNull PsiManager manager,
+                                                          @NotNull VirtualFile virtualFile,
+                                                          boolean eventSystemEnabled,
+                                                          @NotNull Language language) {
+        super(manager, virtualFile, eventSystemEnabled, language);
+        this.helper = new LSPSemanticTokensFileViewProviderHelper(this);
+    }
+
+    /**
+     * Creates a new semantic tokens-based file view provider for a file without a specific language.
+     *
+     * @param manager            the PSI manager
+     * @param virtualFile        the virtual file
+     * @param eventSystemEnabled whether or not the event system is enabled
+     */
+    protected LSPSemanticTokensSingleRootFileViewProvider(@NotNull PsiManager manager,
+                                                          @NotNull VirtualFile virtualFile,
+                                                          boolean eventSystemEnabled) {
+        super(manager, virtualFile, eventSystemEnabled);
+        this.helper = new LSPSemanticTokensFileViewProviderHelper(this);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return helper.isEnabled();
+    }
+
+    @Override
+    public boolean isKeyword(int offset) {
+        return helper.isKeyword(offset);
+    }
+
+    @Override
+    public boolean isOperator(int offset) {
+        return helper.isOperator(offset);
+    }
+
+    @Override
+    public boolean isStringLiteral(int offset) {
+        return helper.isStringLiteral(offset);
+    }
+
+    @Override
+    public boolean isNumericLiteral(int offset) {
+        return helper.isNumericLiteral(offset);
+    }
+
+    @Override
+    public boolean isRegularExpression(int offset) {
+        return helper.isRegularExpression(offset);
+    }
+
+    @Override
+    public boolean isComment(int offset) {
+        return helper.isComment(offset);
+    }
+
+    @Override
+    public boolean isDeclaration(int offset) {
+        return helper.isDeclaration(offset);
+    }
+
+    @Override
+    public boolean isReference(int offset) {
+        return helper.isReference(offset);
+    }
+
+    @Override
+    public boolean isUnknown(int offset) {
+        return helper.isUnknown(offset);
+    }
+
+    @Override
+    @NotNull
+    public ThreeState isIdentifier(int offset) {
+        return helper.isIdentifier(offset);
+    }
+
+    @Override
+    @NotNull
+    public ThreeState isType(int offset) {
+        return helper.isType(offset);
+    }
+
+    @Override
+    public boolean isWhitespace(int offset) {
+        return helper.isWhitespace(offset);
+    }
+
+    @Override
+    @Nullable
+    public TextRange getSemanticTokenTextRange(int offset) {
+        return helper.getSemanticTokenTextRange(offset);
+    }
+
+    @Override
+    public void addSemanticToken(@NotNull TextRange textRange,
+                                 @Nullable String tokenType,
+                                 @Nullable List<String> tokenModifiers) {
+        helper.addSemanticToken(textRange, tokenType, tokenModifiers);
+    }
+
+    /**
+     * Returns the semantic token for the offset.
+     *
+     * @param offset the offset
+     * @return the semantic token or null if no semantic token exists at the offset
+     */
+    @Nullable
+    LSPSemanticToken getSemanticToken(int offset) {
+        return helper.getSemanticToken(offset);
+    }
+
+    @Nullable
+    protected PsiReference getSemanticTokenReference(int offset) {
+        LSPSemanticToken semanticToken = isEnabled() ? getSemanticToken(offset) : null;
+        LSPSemanticTokenElementType elementType = semanticToken != null ? semanticToken.getElementType() : null;
+        return elementType == LSPSemanticTokenElementType.REFERENCE ? new LSPSemanticTokenPsiReference(semanticToken) : null;
+    }
+
+    @Override
+    public PsiReference findReferenceAt(int offset) {
+        Set<PsiReference> references = new LinkedHashSet<>();
+        ContainerUtil.addIfNotNull(references, super.findReferenceAt(offset));
+        ContainerUtil.addIfNotNull(references, getSemanticTokenReference(offset));
+
+        if (references.isEmpty()) return null;
+        if (references.size() == 1) return ContainerUtil.getFirstItem(references);
+
+        PsiElement element = findElementAt(offset);
+        return element != null ? new PsiMultiReference(references.toArray(PsiReference.EMPTY_ARRAY), element) : null;
+    }
+
+    @Override
+    @Nullable
+    public PsiReference findReferenceAt(int offset, @NotNull Language language) {
+        Set<PsiReference> references = new LinkedHashSet<>();
+        ContainerUtil.addIfNotNull(references, super.findReferenceAt(offset, language));
+        ContainerUtil.addIfNotNull(references, getSemanticTokenReference(offset));
+
+        if (references.isEmpty()) return null;
+        if (references.size() == 1) return ContainerUtil.getFirstItem(references);
+
+        PsiElement element = findElementAt(offset, language);
+        return element != null ? new PsiMultiReference(references.toArray(PsiReference.EMPTY_ARRAY), element) : null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProvider.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.PsiReference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Semantic tokens-based file view provider for files with no inherent PSI tree where PSI element should correspond
+ * exactly to semantic tokens, e.g., plain text and TextMate files.
+ */
+final class LSPSemanticTokensStructurelessFileViewProvider extends LSPSemanticTokensSingleRootFileViewProvider {
+
+    LSPSemanticTokensStructurelessFileViewProvider(@NotNull PsiManager psiManager,
+                                                   @NotNull VirtualFile virtualFile,
+                                                   boolean eventSystemEnabled,
+                                                   @NotNull Language language) {
+        super(psiManager, virtualFile, eventSystemEnabled, language);
+    }
+
+    LSPSemanticTokensStructurelessFileViewProvider(@NotNull PsiManager psiManager,
+                                                   @NotNull VirtualFile virtualFile,
+                                                   boolean eventSystemEnabled) {
+        super(psiManager, virtualFile, eventSystemEnabled);
+    }
+
+    @Override
+    public boolean supportsIncrementalReparse(@NotNull Language rootLanguage) {
+        // These files do not support incremental reparse
+        if (isEnabled()) {
+            return false;
+        }
+        return super.supportsIncrementalReparse(rootLanguage);
+    }
+
+    // NOTE: These are really the core of what makes this all work. Basically when any external caller needs to find an
+    // element or reference for a given offset in the file, we use the semantic token information that was populated the
+    // last time that semantic tokens were returned by the language server to return an element at that offset (or not).
+    // In all cases, we take great care to delegate to the inherited behavior if we don't know for a fact that we
+    // can/should respond ourselves. This ensures that non-LSP4IJ files see no change in behavior.
+
+    @Nullable
+    private PsiElement getSemanticTokenElement(int offset) {
+        LSPSemanticToken semanticToken = isEnabled() ? getSemanticToken(offset) : null;
+        return semanticToken != null ? semanticToken.getElement() : null;
+    }
+
+    @Override
+    public PsiElement findElementAt(int offset) {
+        PsiElement element = getSemanticTokenElement(offset);
+        return element != null ? element : super.findElementAt(offset);
+    }
+
+    @Override
+    public PsiElement findElementAt(int offset, @NotNull Class<? extends Language> lang) {
+        PsiElement element = getSemanticTokenElement(offset);
+        return element != null ? element : super.findElementAt(offset, lang);
+    }
+
+    @Override
+    public PsiElement findElementAt(int offset, @NotNull Language language) {
+        PsiElement element = getSemanticTokenElement(offset);
+        return element != null ? element : super.findElementAt(offset, language);
+    }
+
+    @Override
+    public PsiReference findReferenceAt(int offset) {
+        PsiReference reference = getSemanticTokenReference(offset);
+        return reference != null ? reference : super.findReferenceAt(offset);
+    }
+
+    @Override
+    @Nullable
+    public PsiReference findReferenceAt(int offset, @NotNull Language language) {
+        PsiReference reference = getSemanticTokenReference(offset);
+        return reference != null ? reference : super.findReferenceAt(offset, language);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderFactory.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.FileViewProviderFactory;
+import com.intellij.psi.PsiManager;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A {@link FileViewProviderFactory} for files with no inherent PSI tree where PSI element should correspond exactly to
+ * semantic tokens, e.g., plain text and TextMate files.
+ */
+public final class LSPSemanticTokensStructurelessFileViewProviderFactory extends LSPSemanticTokensFileViewProviderFactory {
+
+    static final LSPSemanticTokensStructurelessFileViewProviderFactory INSTANCE = new LSPSemanticTokensStructurelessFileViewProviderFactory();
+
+    @Override
+    @NotNull
+    protected LSPSemanticTokensFileViewProvider createFileViewProviderForLanguage(@NotNull PsiManager psiManager,
+                                                                                  @NotNull VirtualFile virtualFile,
+                                                                                  boolean eventSystemEnabled,
+                                                                                  @NotNull Language language) {
+        return new LSPSemanticTokensStructurelessFileViewProvider(psiManager, virtualFile, eventSystemEnabled, language);
+    }
+
+    @Override
+    @NotNull
+    protected LSPSemanticTokensFileViewProvider createFileViewProviderForFileType(@NotNull PsiManager psiManager,
+                                                                                  @NotNull VirtualFile virtualFile,
+                                                                                  boolean eventSystemEnabled) {
+        return new LSPSemanticTokensStructurelessFileViewProvider(psiManager, virtualFile, eventSystemEnabled);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderRegistrar.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderRegistrar.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.openapi.fileTypes.FileNameMatcher;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.FileTypeEvent;
+import com.intellij.openapi.fileTypes.FileTypeListener;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.fileTypes.impl.AbstractFileType;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.ProjectActivity;
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.FileTypeFileViewProviders;
+import com.intellij.psi.FileViewProviderFactory;
+import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinitionListener;
+import kotlin.Unit;
+import kotlin.coroutines.Continuation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * We can't register plain text/abstract file type files by language or a single file type statically in plugin.xml, so
+ * register them dynamically.
+ */
+public class LSPSemanticTokensStructurelessFileViewProviderRegistrar {
+
+    private static Set<FileType> registeredAbstractFileTypes = Collections.synchronizedSet(new HashSet<>());
+
+    private static void registerAbstractFileTypes() {
+        // Determine the file type associations and filename matchers for language servers
+        Set<FileType> lspFileTypes = new HashSet<>();
+        Set<FileNameMatcher> lspFilenameMatchers = new HashSet<>();
+        for (LanguageServerDefinition languageServerDefinition : LanguageServersRegistry.getInstance().getServerDefinitions()) {
+            ContainerUtil.addAllNotNull(lspFileTypes, languageServerDefinition.getFileTypeMappings().keySet());
+            for (Pair<List<FileNameMatcher>, String> filenameMatcherMapping : languageServerDefinition.getFilenameMatcherMappings()) {
+                ContainerUtil.addAllNotNull(lspFilenameMatchers, filenameMatcherMapping.getFirst());
+            }
+        }
+
+        // Determine the abstract file types for those file types and filename matchers
+        Set<FileType> registerFileTypes = new LinkedHashSet<>();
+        for (FileType fileType : FileTypeManager.getInstance().getRegisteredFileTypes()) {
+            if (fileType instanceof AbstractFileType abstractFileType) {
+                if (lspFileTypes.contains(abstractFileType)) {
+                    registerFileTypes.add(abstractFileType);
+                } else {
+                    List<FileNameMatcher> filenameMatchers = FileTypeManager.getInstance().getAssociations(abstractFileType);
+                    if (ContainerUtil.intersects(lspFilenameMatchers, filenameMatchers)) {
+                        registerFileTypes.add(abstractFileType);
+                    }
+                }
+            }
+        }
+
+        // Use working copies to avoid potential dirty reads
+        Set<FileType> copyOfRegisteredAbstractFileTypes = new HashSet<>(registeredAbstractFileTypes);
+        Set<FileType> workingRegisteredAbstractFileTypes = new HashSet<>();
+
+        // Register file types to use our file view provider factory if necessary
+        if (!registerFileTypes.isEmpty()) {
+            for (FileType registerFileType : registerFileTypes) {
+                FileViewProviderFactory currentFactory = FileTypeFileViewProviders.INSTANCE.findSingle(registerFileType);
+                if (!(currentFactory instanceof LSPSemanticTokensStructurelessFileViewProviderFactory)) {
+                    FileTypeFileViewProviders.INSTANCE.addExplicitExtension(registerFileType, LSPSemanticTokensStructurelessFileViewProviderFactory.INSTANCE);
+                }
+                workingRegisteredAbstractFileTypes.add(registerFileType);
+            }
+        }
+
+        // Unregister any obsolete registrations
+        Collection<FileType> unregisterFileTypes = ContainerUtil.subtract(copyOfRegisteredAbstractFileTypes, workingRegisteredAbstractFileTypes);
+        if (!unregisterFileTypes.isEmpty()) {
+            for (FileType unregisterFileType : unregisterFileTypes) {
+                FileTypeFileViewProviders.INSTANCE.removeExplicitExtension(unregisterFileType, LSPSemanticTokensStructurelessFileViewProviderFactory.INSTANCE);
+            }
+        }
+
+        // If changed, update our retained file type/factory associations
+        if (!copyOfRegisteredAbstractFileTypes.equals(workingRegisteredAbstractFileTypes)) {
+            registeredAbstractFileTypes = workingRegisteredAbstractFileTypes;
+        }
+    }
+
+    // LISTENERS
+
+    // Register abstract file types when a project is opened
+    public static class ProjectOpenedListener implements ProjectActivity {
+        @Override
+        @Nullable
+        public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
+            // We can't register this listener in plugin.xml, so register it when the first project is opened
+            LanguageServerDefinitionsChangedListener.registerOnce();
+            registerAbstractFileTypes();
+            return null;
+        }
+
+    }
+
+    // Register abstract file types when file types change
+    public static class FileTypesChangedListener implements FileTypeListener {
+        @Override
+        public void fileTypesChanged(@NotNull FileTypeEvent event) {
+            registerAbstractFileTypes();
+        }
+    }
+
+    // Register abstract file types when language server definitions change
+    private static class LanguageServerDefinitionsChangedListener implements LanguageServerDefinitionListener {
+        private static volatile boolean addedLanguageServerDefinitionListener = false;
+
+        private static void registerOnce() {
+            if (!addedLanguageServerDefinitionListener) {
+                synchronized (LSPSemanticTokensStructurelessFileViewProviderRegistrar.class) {
+                    if (!addedLanguageServerDefinitionListener) {
+                        LanguageServersRegistry.getInstance().addLanguageServerDefinitionListener(new LanguageServerDefinitionsChangedListener());
+                        addedLanguageServerDefinitionListener = true;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void handleAdded(@NotNull LanguageServerAddedEvent event) {
+            registerAbstractFileTypes();
+        }
+
+        @Override
+        public void handleRemoved(@NotNull LanguageServerRemovedEvent event) {
+            registerAbstractFileTypes();
+        }
+
+        @Override
+        public void handleChanged(@NotNull LanguageServerChangedEvent event) {
+            registerAbstractFileTypes();
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
@@ -30,10 +30,11 @@ import com.redhat.devtools.lsp4ij.features.semanticTokens.DefaultSemanticTokensC
 import com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorsProvider;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
+import javax.swing.Icon;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -156,6 +157,13 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
      */
     public void setEnabled(boolean enabled, @Nullable Project project) {
         this.enabled = enabled;
+    }
+
+    @ApiStatus.Internal
+    public void removeAssociations() {
+        this.languageIdLanguageMappings.clear();
+        this.languageIdFileTypeMappings.clear();
+        this.languageIdFileNameMatcherMappings.clear();
     }
 
     public void registerAssociation(@NotNull Language language, @NotNull String languageId) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
@@ -53,7 +53,7 @@ public class ClientConfigurationSettings {
 
         /**
          * Whether or not the fix for <a href="https://youtrack.jetbrains.com/issue/IJPL-159454">IJPL-159454</a> is
-         * enabled. Default to true.
+         * enabled. Defaults to true.
          */
         public boolean enableEnterBetweenBracesFix = true;
 
@@ -62,6 +62,11 @@ public class ClientConfigurationSettings {
          * Defaults to true.
          */
         public boolean enableTextMateNestedBracesImprovements = true;
+
+        /**
+         * Whether or not the semantic tokens-based file view provider is enabled. Defaults to true.
+         */
+        public boolean enableSemanticTokensFileViewProvider = true;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedEditorBehaviorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedEditorBehaviorFeature.java
@@ -62,4 +62,11 @@ public class UserDefinedEditorBehaviorFeature extends EditorBehaviorFeature {
         // Note that this defaults to enabled for user-defined language server definitions
         return (editorSettings == null) || editorSettings.enableTextMateNestedBracesImprovements;
     }
+
+    @Override
+    public boolean isEnableSemanticTokensFileViewProvider(@NotNull PsiFile file) {
+        ClientConfigurationEditorSettings editorSettings = getEditorSettings();
+        // Note that this defaults to enabled for user-defined language server definitions
+        return (editorSettings == null) || editorSettings.enableSemanticTokensFileViewProvider;
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/ui/IconMapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ui/IconMapper.java
@@ -19,16 +19,16 @@ import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.fileTypes.UnknownFileType;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.util.ui.ColorIcon;
-import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionItemKind;
-import org.eclipse.lsp4j.MarkupContent;
-import org.eclipse.lsp4j.SymbolKind;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.LSPSemanticTokenType;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.LSPSemanticTokenTypes;
+import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.Color;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -157,6 +157,7 @@ public class IconMapper {
             case Variable:
                 return AllIcons.Nodes.Variable;
             case Struct:
+                // TODO: Should this be AllIcons.Nodes.Types?
                 return AllIcons.Json.Object;
             case Class:
                 return AllIcons.Nodes.Class;
@@ -210,6 +211,7 @@ public class IconMapper {
                 return AllIcons.Nodes.Variable;
             case Object:
             case Struct:
+                // TODO: Should this be AllIcons.Nodes.Types?
                 return AllIcons.Json.Object;
             case Array:
                 return AllIcons.Json.Array;
@@ -240,6 +242,59 @@ public class IconMapper {
             default:
                 return AllIcons.Nodes.EmptyNode;
         }
+    }
+
+    /**
+     * Returns the icon for the provided {@link SemanticTokenTypes} value if possible.
+     *
+     * @param tokenType the icon name as semantic token type value
+     * @return the corresponding icon, or null if no icon could be found
+     */
+    @Nullable
+    public static Icon getIcon(@Nullable String tokenType) {
+        if (tokenType != null) {
+            // If this is for a custom semantic token type that expresses an inheritance relationship, swap it out now
+            LSPSemanticTokenType lspSemanticTokenType = LSPSemanticTokenTypes.valueOf(tokenType);
+            if ((lspSemanticTokenType != null) && (lspSemanticTokenType.getInheritFrom() != null)) {
+                tokenType = lspSemanticTokenType.getInheritFrom();
+            }
+
+            switch (tokenType) {
+                case SemanticTokenTypes.Namespace:
+                    return AllIcons.Nodes.Package;
+                case SemanticTokenTypes.Type:
+                    return AllIcons.Nodes.Type;
+                case SemanticTokenTypes.Class:
+                    return AllIcons.Nodes.Class;
+                case SemanticTokenTypes.Enum:
+                    return AllIcons.Nodes.Enum;
+                case SemanticTokenTypes.Interface:
+                    return AllIcons.Nodes.Interface;
+                case SemanticTokenTypes.Struct:
+                    return AllIcons.Nodes.Type;
+                case SemanticTokenTypes.TypeParameter:
+                    return AllIcons.Nodes.Parameter;
+                case SemanticTokenTypes.Parameter:
+                    return AllIcons.Nodes.Parameter;
+                case SemanticTokenTypes.Variable:
+                    return AllIcons.Nodes.Variable;
+                case SemanticTokenTypes.Property:
+                    return AllIcons.Nodes.Property;
+                case SemanticTokenTypes.EnumMember:
+                    return AllIcons.Nodes.Field;
+                case SemanticTokenTypes.Function:
+                    return AllIcons.Nodes.Function;
+                case SemanticTokenTypes.Macro:
+                    return AllIcons.Nodes.Function;
+                case SemanticTokenTypes.Method:
+                    return AllIcons.Nodes.Method;
+                // Decorators are just annotations
+                case SemanticTokenTypes.Decorator:
+                    return AllIcons.Nodes.Annotationtype;
+                // TODO: SemanticTokenTypes.Event
+            }
+        }
+        return null;
     }
 
     private static @NotNull Icon load(String iconPath) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageElementDescriptionProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageElementDescriptionProvider.java
@@ -8,25 +8,88 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
+
 package com.redhat.devtools.lsp4ij.usages;
 
+import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.ElementDescriptionLocation;
 import com.intellij.psi.ElementDescriptionProvider;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.codeStyle.NameUtil;
+import com.intellij.usageView.UsageViewLongNameLocation;
+import com.intellij.usageView.UsageViewShortNameLocation;
+import com.intellij.usageView.UsageViewTypeLocation;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenDocumentationProvider;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenPsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * {@link ElementDescriptionProvider} implementation used to show "LSP Symbol" as target in the "Find Usages" view.
+ * {@link ElementDescriptionProvider} implementation used to show information about the target in the "Find Usages" view.
  */
 public class LSPUsageElementDescriptionProvider implements ElementDescriptionProvider {
     @Override
-    public @Nullable @NlsSafe String getElementDescription(@NotNull PsiElement element, @NotNull ElementDescriptionLocation location) {
-        if (element instanceof LSPUsageTriggeredPsiElement) {
+    @Nullable
+    @NlsSafe
+    public String getElementDescription(@NotNull PsiElement element, @NotNull ElementDescriptionLocation location) {
+        // Only for LSP4IJ-supported files
+        PsiFile file = element.getContainingFile();
+        if ((file == null) || !file.isValid() || !LSPFileSupport.hasSupport(file)) {
+            return null;
+        }
+
+        // Try to use the real element if possible
+        if (element instanceof LSPUsageTriggeredPsiElement usageTriggeredPsiElement) {
+            PsiElement realElement = usageTriggeredPsiElement.getRealElement();
+            if (realElement != null) {
+                element = realElement;
+            }
+        }
+
+        // Usage declaration type
+        if (location instanceof UsageViewTypeLocation) {
+            // See if we can get a better type
+            if (element instanceof LSPSemanticTokenPsiElement semanticTokenElement) {
+                String tokenType = semanticTokenElement.getType();
+                if (StringUtil.isNotEmpty(tokenType)) {
+                    return StringUtil.join(NameUtil.splitNameIntoWords(tokenType), String::toLowerCase, " ");
+                }
+            }
+
+            // If we couldn't derive a type, just use a placeholder
             return LanguageServerBundle.message("usage.description");
         }
+
+        // Usage declaration name
+        else if (location instanceof UsageViewLongNameLocation) {
+            // See if we can get a better description
+            if (element instanceof LSPSemanticTokenPsiElement semanticTokenElement) {
+                return semanticTokenElement.getName();
+            }
+
+            // Otherwise try to get the current word
+            Document document = LSPIJUtils.getDocument(element);
+            TextRange wordRange = document != null ? LSPIJUtils.getWordRangeAt(document, file, element.getTextOffset()) : null;
+            if (wordRange != null) {
+                return document.getText(wordRange);
+            }
+
+            // Otherwise just use a placeholder
+            return LanguageServerBundle.message("usage.description");
+        }
+
+        // If this is for Ctrl/Cmd+Mouse hover, try to get the element documentation from the documentation provider
+        else if (location instanceof UsageViewShortNameLocation) {
+            return LSPSemanticTokenDocumentationProvider.getDocumentation(element);
+        }
+
         return null;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTriggeredPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTriggeredPsiElement.java
@@ -8,14 +8,19 @@
  * Contributors:
  * Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
+
 package com.redhat.devtools.lsp4ij.usages;
 
+import com.intellij.navigation.ItemPresentation;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
 import com.redhat.devtools.lsp4ij.features.LSPPsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.Icon;
 import java.util.List;
 
 /**
@@ -38,5 +43,31 @@ public class LSPUsageTriggeredPsiElement extends LSPPsiElement {
 
     public void setLSPReferences(List<LocationData> references) {
         this.references = references;
+    }
+
+    @Nullable
+    public PsiElement getRealElement() {
+        return getContainingFile().findElementAt(getTextOffset());
+    }
+
+    @Override
+    @Nullable
+    public Icon getIcon(boolean open) {
+        return getRealElement() instanceof ItemPresentation itemPresentation ?
+                itemPresentation.getIcon(open) :
+                super.getIcon(open);
+    }
+
+    @Override
+    @Nullable
+    public String getLocationString() {
+        // If this is reference, show the location string of the target
+        PsiReference reference = getContainingFile().findReferenceAt(getTextOffset());
+        PsiElement target = reference != null ? reference.resolve() : null;
+        if (target instanceof LSPPsiElement lspElement) {
+            return lspElement.getLocationString();
+        }
+
+        return super.getLocationString();
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTypeProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageTypeProvider.java
@@ -15,6 +15,7 @@ import com.intellij.usages.UsageTarget;
 import com.intellij.usages.impl.rules.UsageType;
 import com.intellij.usages.impl.rules.UsageTypeProviderEx;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenPsiElement;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -46,18 +47,17 @@ public class LSPUsageTypeProvider implements UsageTypeProviderEx {
     @Override
     public UsageType getUsageType(PsiElement element, UsageTarget @NotNull [] targets) {
         if (element instanceof LSPUsagePsiElement usageElement) {
-            switch (usageElement.getKind()) {
-                case declarations:
-                    return DECLARATIONS_USAGE_TYPE;
-                case definitions:
-                    return DEFINITIONS_USAGE_TYPE;
-                case typeDefinitions:
-                    return TYPE_DEFINITIONS_USAGE_TYPE;
-                case references:
-                    return REFERENCES_USAGE_TYPE;
-                case implementations:
-                    return IMPLEMENTATIONS_USAGE_TYPE;
-            }
+            return switch (usageElement.getKind()) {
+                case declarations -> DECLARATIONS_USAGE_TYPE;
+                case definitions -> DEFINITIONS_USAGE_TYPE;
+                case typeDefinitions -> TYPE_DEFINITIONS_USAGE_TYPE;
+                case references -> REFERENCES_USAGE_TYPE;
+                case implementations -> IMPLEMENTATIONS_USAGE_TYPE;
+            };
+        }
+        // We can also have local usages to semantic token elements which are references
+        else if (element instanceof LSPSemanticTokenPsiElement) {
+            return REFERENCES_USAGE_TYPE;
         }
         return null;
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -291,7 +291,8 @@
         <!-- LSP textDocument/definition request support -->
         <gotoDeclarationHandler
                 id="LSPGotoDeclarationHandler"
-                implementation="com.redhat.devtools.lsp4ij.features.navigation.LSPGotoDeclarationHandler"/>
+                implementation="com.redhat.devtools.lsp4ij.features.navigation.LSPGotoDeclarationHandler"
+                order="first"/>
 
         <!-- LSP textDocument/documentLink request support -->
         <externalAnnotator
@@ -443,6 +444,31 @@
         <colorSettingsPage
                 implementation="com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorSettingsPage"/>
 
+        <!-- File view provider based on textDocument/semanticTokens -->
+        <!-- We can register a view provider factory for TextMate files based on the language -->
+        <lang.fileViewProviderFactory
+                language="textmate"
+                implementationClass="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokensStructurelessFileViewProviderFactory"/>
+        <lang.elementManipulator
+                forClass="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenPsiElement"
+                implementationClass="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenPsiElementManipulator"/>
+        <lang.documentationProvider
+                language=""
+                implementationClass="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenDocumentationProvider"/>
+
+        <!-- We cannot register one for plain text abstract file types, so we have to do that dynamically. Do so when a project is opened. -->
+        <postStartupActivity
+                implementation="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokensStructurelessFileViewProviderRegistrar$ProjectOpenedListener"/>
+    </extensions>
+
+    <applicationListeners>
+        <!-- Also do so when file type associations change -->
+        <listener
+                class="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokensStructurelessFileViewProviderRegistrar$FileTypesChangedListener"
+                topic="com.intellij.openapi.fileTypes.FileTypeListener"/>
+    </applicationListeners>
+
+    <extensions defaultExtensionNs="com.intellij">
         <!-- LSP textDocument/prepareTypeHierarchy request support -->
         <typeHierarchyProvider
                 language="TEXT"

--- a/src/main/resources/jsonSchema/clientSettings.schema.json
+++ b/src/main/resources/jsonSchema/clientSettings.schema.json
@@ -82,6 +82,12 @@
           "title": "Enable TextMate nested braces fix",
           "description": "Whether or not editor improvements for nested braces/brackets/parentheses in TextMate files are enabled.",
           "default": true
+        },
+        "enableSemanticTokensFileViewProvider": {
+          "type": "boolean",
+          "title": "Enable semantic tokens-based file view provider",
+          "description": "Whether or not the semantic tokens-based file view provider is enabled.",
+          "default": true
         }
       }
     },

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/CssSemanticTokensFileViewProviderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/CssSemanticTokensFileViewProviderTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPSemanticTokensFileViewProviderFixtureTestCase;
+
+import java.util.Map;
+
+/**
+ * Tests the semantic tokens-based file view provider for CSS, a plain text/abstract file type without semantic tokens support.
+ */
+public class CssSemanticTokensFileViewProviderTest extends LSPSemanticTokensFileViewProviderFixtureTestCase {
+
+    private static final String TEST_FILE_NAME = "test.css";
+
+    // language=css
+    private static final String TEST_FILE_BODY = """
+            /* Comment */
+            div {
+                content: "Test";
+            }
+            """;
+
+    public CssSemanticTokensFileViewProviderTest() {
+        super("*.css", "css");
+    }
+
+    public void testEnabled() {
+        assertViewProviderEnabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                // The CSS language server doesn't support semantic tokens
+                null,
+                null,
+                // Should only be one file-level token/element of unknown type; check the start/middle/end
+                Map.ofEntries(
+                        Map.entry(fileBody -> 0, isUnknown),
+                        Map.entry(fileBody -> TEST_FILE_BODY.length() / 2, isUnknown),
+                        Map.entry(fileBody -> TEST_FILE_BODY.length() - 1, isUnknown)
+                )
+        );
+    }
+
+    public void testDisabled() {
+        assertViewProviderDisabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/GoSemanticTokensFileViewProviderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/GoSemanticTokensFileViewProviderTest.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPSemanticTokensFileViewProviderFixtureTestCase;
+
+import java.util.Map;
+
+/**
+ * Tests the semantic tokens-based file view provider for Go, a TextMate file type.
+ */
+public class GoSemanticTokensFileViewProviderTest extends LSPSemanticTokensFileViewProviderFixtureTestCase {
+
+    private static final String TEST_FILE_NAME = "test.go";
+
+    // language=go
+    private static final String TEST_FILE_BODY = """
+            package test
+            
+            import "fmt"
+            
+            /* Block comment */
+            func main() {
+                // Line comment
+                var num = 10;
+            	fmt.Println("num = " + 10)
+            }
+            """;
+
+    // language=json
+    private static final String MOCK_SEMANTIC_TOKENS_PROVIDER_JSON = """
+            {
+              "legend": {
+                "tokenTypes": [
+                  "namespace",
+                  "type",
+                  "class",
+                  "enum",
+                  "interface",
+                  "struct",
+                  "typeParameter",
+                  "parameter",
+                  "variable",
+                  "property",
+                  "enumMember",
+                  "event",
+                  "function",
+                  "method",
+                  "macro",
+                  "keyword",
+                  "modifier",
+                  "comment",
+                  "string",
+                  "number",
+                  "regexp",
+                  "operator",
+                  "decorator",
+                  "label"
+                ],
+                "tokenModifiers": [
+                  "declaration",
+                  "definition",
+                  "readonly",
+                  "static"
+                ]
+              },
+              "range": true,
+              "full": true
+            }
+            """;
+
+    // language=json
+    private static final String MOCK_SEMANTIC_TOKENS_JSON = """
+            {
+              "resultId": "2025-02-21 14:10:40.6313279 -0600 CST m\\u003d+1.127429001",
+              "data": [
+                0,
+                0,
+                7,
+                15,
+                0,
+                0,
+                8,
+                4,
+                0,
+                0,
+                2,
+                0,
+                6,
+                15,
+                0,
+                0,
+                8,
+                3,
+                0,
+                0,
+                2,
+                0,
+                19,
+                17,
+                0,
+                1,
+                0,
+                4,
+                15,
+                0,
+                0,
+                5,
+                4,
+                12,
+                2,
+                1,
+                4,
+                15,
+                17,
+                0,
+                1,
+                4,
+                3,
+                15,
+                0,
+                0,
+                4,
+                3,
+                8,
+                2,
+                0,
+                6,
+                2,
+                19,
+                0,
+                1,
+                1,
+                3,
+                0,
+                0,
+                0,
+                4,
+                7,
+                12,
+                0,
+                0,
+                8,
+                8,
+                18,
+                0,
+                0,
+                9,
+                1,
+                21,
+                0,
+                0,
+                2,
+                2,
+                19,
+                0
+              ]
+            }
+            """;
+
+    public GoSemanticTokensFileViewProviderTest() {
+        super("*.go", "go");
+    }
+
+    public void testEnabled() {
+        assertViewProviderEnabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                MOCK_SEMANTIC_TOKENS_PROVIDER_JSON,
+                MOCK_SEMANTIC_TOKENS_JSON,
+                Map.ofEntries(
+                        // NOTE: This namespace token seems like it should be a declaration, but it doesn't include any modifiers
+                        Map.entry(fileBody -> fileBody.indexOf("test"), isTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("fmt"), isTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("/*"), isComment),
+                        Map.entry(fileBody -> fileBody.indexOf("main"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("//"), isComment),
+                        Map.entry(fileBody -> fileBody.indexOf("num"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("10"), isNumericLiteral),
+                        Map.entry(fileBody -> fileBody.indexOf("fmt."), isTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("Println"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("\"num"), isStringLiteral),
+                        Map.entry(fileBody -> fileBody.indexOf("10)"), isNumericLiteral)
+                )
+        );
+    }
+
+    public void testDisabled() {
+        assertViewProviderDisabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                MOCK_SEMANTIC_TOKENS_PROVIDER_JSON,
+                MOCK_SEMANTIC_TOKENS_JSON
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/JavaScriptSemanticTokensFileViewProviderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/JavaScriptSemanticTokensFileViewProviderTest.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPSemanticTokensFileViewProviderFixtureTestCase;
+
+import java.util.Map;
+
+/**
+ * Tests the semantic tokens-based file view provider for JavaScript, a plain text/abstract file type.
+ */
+public class JavaScriptSemanticTokensFileViewProviderTest extends LSPSemanticTokensFileViewProviderFixtureTestCase {
+
+    private static final String TEST_FILE_NAME = "test.js";
+
+    // language=javascript
+    private static final String TEST_FILE_BODY = """
+            /** Doc comment. */
+            export class Foo {
+                field;
+                get property() { return ''; };
+            
+                // Line comment
+                static bar() {
+                    console.log('Hello, world.');
+                    const declaration = Math.PI;
+                    console.log(declaration);
+                }
+            }
+            """;
+
+    // language=json
+    private static final String MOCK_SEMANTIC_TOKENS_PROVIDER_JSON = """
+            {
+              "legend": {
+                "tokenTypes": [
+                  "class",
+                  "enum",
+                  "interface",
+                  "namespace",
+                  "typeParameter",
+                  "type",
+                  "parameter",
+                  "variable",
+                  "enumMember",
+                  "property",
+                  "function",
+                  "member"
+                ],
+                "tokenModifiers": [
+                  "declaration",
+                  "static",
+                  "async",
+                  "readonly",
+                  "defaultLibrary",
+                  "local"
+                ]
+              },
+              "range": true,
+              "full": true
+            }
+            """;
+
+    // language=json
+    private static final String MOCK_SEMANTIC_TOKENS_JSON = """
+            {
+              "data": [
+                1,
+                13,
+                3,
+                0,
+                1,
+                1,
+                4,
+                5,
+                9,
+                1,
+                1,
+                8,
+                8,
+                9,
+                1,
+                3,
+                11,
+                3,
+                11,
+                3,
+                1,
+                8,
+                7,
+                7,
+                16,
+                0,
+                8,
+                3,
+                11,
+                16,
+                1,
+                14,
+                11,
+                7,
+                41,
+                0,
+                14,
+                4,
+                7,
+                16,
+                0,
+                5,
+                2,
+                9,
+                24,
+                1,
+                8,
+                7,
+                7,
+                16,
+                0,
+                8,
+                3,
+                11,
+                16,
+                0,
+                4,
+                11,
+                7,
+                40
+              ]
+            }
+            """;
+
+    public JavaScriptSemanticTokensFileViewProviderTest() {
+        super("*.js", "javascript");
+    }
+
+    public void testEnabled() {
+        assertViewProviderEnabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                MOCK_SEMANTIC_TOKENS_PROVIDER_JSON,
+                MOCK_SEMANTIC_TOKENS_JSON,
+                Map.ofEntries(
+                        Map.entry(fileBody -> fileBody.indexOf("Foo"), isTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("field"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("property"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("bar()"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("console.log('"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("log('"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("declaration"), isNonTypeDeclaration),
+                        // "Math" is declared as a variable and not a type
+                        Map.entry(fileBody -> fileBody.indexOf("Math"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("PI"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("console.log(d"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("log(d"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("declaration)"), isNonTypeReference)
+                )
+        );
+    }
+
+    public void testDisabled() {
+        assertViewProviderDisabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                MOCK_SEMANTIC_TOKENS_PROVIDER_JSON,
+                MOCK_SEMANTIC_TOKENS_JSON
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderRegistrarTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderRegistrarTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.fileTypes.impl.AbstractFileType;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.fixtures.LSPSemanticTokensFileViewProviderFixtureTestCase;
+import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests the semantic tokens-based file view provider registrar that associates the view provider factory with abstract
+ * file types used by language server definitions dynamically since it's not possible statically via plugin.xml.
+ */
+public class LSPSemanticTokensStructurelessFileViewProviderRegistrarTest extends LSPSemanticTokensFileViewProviderFixtureTestCase {
+
+    public LSPSemanticTokensStructurelessFileViewProviderRegistrarTest() {
+        super("*.css", "css");
+    }
+
+    public void testRegistrar() {
+        MockLanguageServer.INSTANCE.setTimeToProceedQueries(100);
+
+        // Create a test CSS file
+        PsiFile cssFile = myFixture.configureByText("test.css", "");
+
+        // Initialize the language server
+        Project project = cssFile.getProject();
+        try {
+            VirtualFile virtualFile = cssFile.getVirtualFile();
+            LanguageServiceAccessor.getInstance(project)
+                    .getLanguageServers(virtualFile, null, null)
+                    .get(5000, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        // Confirm that the CSS file uses our view provider
+        assertInstanceOf(cssFile.getViewProvider(), LSPSemanticTokensStructurelessFileViewProvider.class);
+
+        // And confirm that no other abstract file types do
+        FileType cssFileType = cssFile.getFileType();
+        PsiFileFactory fileFactory = PsiFileFactory.getInstance(project);
+        for (FileType fileType : FileTypeManager.getInstance().getRegisteredFileTypes()) {
+            if ((fileType instanceof AbstractFileType) && !Objects.equals(cssFileType, fileType)) {
+                PsiFile testFile = fileFactory.createFileFromText("test." + fileType.getDefaultExtension(), fileType, "");
+                assertFalse(testFile.getViewProvider() instanceof LSPSemanticTokensFileViewProvider);
+            }
+        }
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/TypeScriptSemanticTokensFileViewProviderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/TypeScriptSemanticTokensFileViewProviderTest.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider;
+
+import com.redhat.devtools.lsp4ij.fixtures.LSPSemanticTokensFileViewProviderFixtureTestCase;
+
+import java.util.Map;
+
+/**
+ * Tests the semantic tokens-based file view provider for TypeScript, a TextMate file type.
+ */
+public class TypeScriptSemanticTokensFileViewProviderTest extends LSPSemanticTokensFileViewProviderFixtureTestCase {
+
+    private static final String TEST_FILE_NAME = "test.ts";
+
+    // language=typescript
+    private static final String TEST_FILE_BODY = """
+            /** Doc comment. */
+            export class Foo {
+                field: number;
+                get property() { return ''; };
+            
+                // Line comment
+                static bar() {
+                    console.log('Hello, world.');
+                    const declaration = Math.PI;
+                    console.log(declaration);
+                }
+            }
+            """;
+
+    // language=json
+    private static final String MOCK_SEMANTIC_TOKENS_PROVIDER_JSON = """
+            {
+              "legend": {
+                "tokenTypes": [
+                  "class",
+                  "enum",
+                  "interface",
+                  "namespace",
+                  "typeParameter",
+                  "type",
+                  "parameter",
+                  "variable",
+                  "enumMember",
+                  "property",
+                  "function",
+                  "member"
+                ],
+                "tokenModifiers": [
+                  "declaration",
+                  "static",
+                  "async",
+                  "readonly",
+                  "defaultLibrary",
+                  "local"
+                ]
+              },
+              "range": true,
+              "full": true
+            }
+            """;
+
+    // language=json
+    private static final String MOCK_SEMANTIC_TOKENS_JSON = """
+            {
+              "data": [
+                1,
+                13,
+                3,
+                0,
+                1,
+                1,
+                4,
+                5,
+                9,
+                1,
+                1,
+                8,
+                8,
+                9,
+                1,
+                3,
+                11,
+                3,
+                11,
+                3,
+                1,
+                8,
+                7,
+                7,
+                16,
+                0,
+                8,
+                3,
+                11,
+                16,
+                1,
+                14,
+                11,
+                7,
+                41,
+                0,
+                14,
+                4,
+                7,
+                16,
+                0,
+                5,
+                2,
+                9,
+                24,
+                1,
+                8,
+                7,
+                7,
+                16,
+                0,
+                8,
+                3,
+                11,
+                16,
+                0,
+                4,
+                11,
+                7,
+                40
+              ]
+            }
+            """;
+
+    public TypeScriptSemanticTokensFileViewProviderTest() {
+        super("*.ts", "typescript");
+    }
+
+    public void testEnabled() {
+        assertViewProviderEnabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                MOCK_SEMANTIC_TOKENS_PROVIDER_JSON,
+                MOCK_SEMANTIC_TOKENS_JSON,
+                Map.ofEntries(
+                        Map.entry(fileBody -> fileBody.indexOf("Foo"), isTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("field"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("property"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("bar()"), isNonTypeDeclaration),
+                        Map.entry(fileBody -> fileBody.indexOf("console.log('"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("log('"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("declaration"), isNonTypeDeclaration),
+                        // "Math" is declared as a variable and not a type
+                        Map.entry(fileBody -> fileBody.indexOf("Math"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("PI"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("console.log(d"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("log(d"), isNonTypeReference),
+                        Map.entry(fileBody -> fileBody.indexOf("declaration)"), isNonTypeReference)
+                )
+        );
+    }
+
+    public void testDisabled() {
+        assertViewProviderDisabled(
+                TEST_FILE_NAME,
+                TEST_FILE_BODY,
+                MOCK_SEMANTIC_TOKENS_PROVIDER_JSON,
+                MOCK_SEMANTIC_TOKENS_JSON
+        );
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSemanticTokensFileViewProviderFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSemanticTokensFileViewProviderFixtureTestCase.java
@@ -1,0 +1,289 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.fixtures;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.util.ThreeState;
+import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenPsiElement;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokensFileViewProvider;
+import com.redhat.devtools.lsp4ij.mock.MockLanguageServer;
+import com.redhat.devtools.lsp4ij.server.definition.ClientConfigurableLanguageServerDefinition;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
+import com.redhat.devtools.lsp4ij.server.definition.launching.ClientConfigurationSettings;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Base test fixture for the semantic tokens-based file view provider.
+ */
+@SuppressWarnings("unused")
+public abstract class LSPSemanticTokensFileViewProviderFixtureTestCase extends LSPCodeInsightFixtureTestCase {
+
+    // Token type verifiers
+    protected static final Consumer<LSPSemanticTokenPsiElement> isKeyword = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isKeyword(offset),
+            false,
+            ThreeState.NO,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isOperator = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isOperator(offset),
+            false,
+            ThreeState.NO,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isStringLiteral = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isStringLiteral(offset),
+            false,
+            ThreeState.NO,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isNumericLiteral = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isNumericLiteral(offset),
+            false,
+            ThreeState.NO,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isRegularExpression = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isRegularExpression(offset),
+            false,
+            ThreeState.NO,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isComment = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isComment(offset),
+            false,
+            ThreeState.NO,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isTypeDeclaration = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isDeclaration(offset),
+            true,
+            ThreeState.YES,
+            ThreeState.YES
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isNonTypeDeclaration = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isDeclaration(offset),
+            true,
+            ThreeState.YES,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isTypeReference = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isReference(offset),
+            false,
+            ThreeState.YES,
+            ThreeState.YES
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isNonTypeReference = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isReference(offset),
+            false,
+            ThreeState.YES,
+            ThreeState.NO
+    );
+    protected static final Consumer<LSPSemanticTokenPsiElement> isUnknown = element -> assertSemanticToken(
+            element,
+            (fileViewProvider, offset) -> fileViewProvider.isUnknown(offset),
+            false,
+            ThreeState.UNSURE,
+            ThreeState.UNSURE
+    );
+
+    private interface TokenTypeVerifier {
+        boolean test(@NotNull LSPSemanticTokensFileViewProvider fileViewProvider, @NotNull Integer offset);
+    }
+
+    private static void assertSemanticToken(
+            @NotNull LSPSemanticTokenPsiElement element,
+            @NotNull TokenTypeVerifier tokenTypeVerifier,
+            boolean isNameIdentifier,
+            @NotNull ThreeState isIdentifier,
+            @NotNull ThreeState isType
+    ) {
+        LSPSemanticTokensFileViewProvider semanticTokensFileViewProvider = LSPSemanticTokensFileViewProvider.getInstance(element);
+        assertNotNull(semanticTokensFileViewProvider);
+        assertTrue(tokenTypeVerifier.test(semanticTokensFileViewProvider, element.getTextOffset()));
+        int offset = element.getTextOffset();
+        assertEquals(isNameIdentifier, element.getNameIdentifier() != null);
+        assertEquals(isIdentifier, semanticTokensFileViewProvider.isIdentifier(offset));
+        assertEquals(isType, semanticTokensFileViewProvider.isType(offset));
+        assertFalse(semanticTokensFileViewProvider.isWhitespace(offset));
+    }
+
+    protected LSPSemanticTokensFileViewProviderFixtureTestCase(@NotNull String fileNamePattern,
+                                                               @NotNull String languageId) {
+        super(fileNamePattern);
+        setLanguageId(languageId);
+        setClientConfigurable(true);
+    }
+
+    private PsiFile initialize(@NotNull String fileName,
+                               @NotNull String fileBody,
+                               @Nullable String mockSemanticTokensProviderJson,
+                               @Nullable String mockSemanticTokensJson,
+                               boolean enabled) {
+        MockLanguageServer.INSTANCE.setTimeToProceedQueries(100);
+
+        // Must both be non-null or null together
+        assertEquals(mockSemanticTokensProviderJson != null, mockSemanticTokensJson != null);
+
+        ServerCapabilities serverCapabilities = MockLanguageServer.defaultServerCapabilities();
+        SemanticTokensWithRegistrationOptions mockSemanticTokensProvider = mockSemanticTokensProviderJson != null ?
+                JSONUtils.getLsp4jGson().fromJson(mockSemanticTokensProviderJson, SemanticTokensWithRegistrationOptions.class) :
+                null;
+        serverCapabilities.setSemanticTokensProvider(mockSemanticTokensProvider);
+        MockLanguageServer.reset(() -> serverCapabilities);
+
+        SemanticTokens mockSemanticTokens = mockSemanticTokensJson != null ?
+                JSONUtils.getLsp4jGson().fromJson(mockSemanticTokensJson, SemanticTokens.class) :
+                null;
+        MockLanguageServer.INSTANCE.setSemanticTokens(mockSemanticTokens);
+
+        PsiFile file = myFixture.configureByText(fileName, fileBody);
+
+        // Initialize the language server
+        List<LanguageServerItem> languageServers = new LinkedList<>();
+        try {
+            Project project = file.getProject();
+            VirtualFile virtualFile = file.getVirtualFile();
+            ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
+                    .getLanguageServers(virtualFile, null, null)
+                    .get(5000, TimeUnit.MILLISECONDS));
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+        LanguageServerItem languageServer = ContainerUtil.getFirstItem(languageServers);
+        assertNotNull(languageServer);
+
+        // Enable or disable the view provider as requested
+        LanguageServerDefinition languageServerDefinition = languageServer.getServerDefinition();
+        assertInstanceOf(languageServerDefinition, ClientConfigurableLanguageServerDefinition.class);
+        ClientConfigurableLanguageServerDefinition configurableLanguageServerDefinition = (ClientConfigurableLanguageServerDefinition) languageServerDefinition;
+        ClientConfigurationSettings clientConfiguration = configurableLanguageServerDefinition.getLanguageServerClientConfiguration();
+        assertNotNull(clientConfiguration);
+        clientConfiguration.editor.enableSemanticTokensFileViewProvider = enabled;
+
+        // Force a highlighting pass to populate the view provider's semantic tokens
+        myFixture.doHighlighting();
+
+        return file;
+    }
+
+    protected void assertViewProviderEnabled(@NotNull String fileName,
+                                             @NotNull String fileBody,
+                                             @Nullable String mockSemanticTokensProviderJson,
+                                             @Nullable String mockSemanticTokensJson,
+                                             @NotNull Map<Function<String, Integer>, Consumer<LSPSemanticTokenPsiElement>> tokenVerifiers) {
+        PsiFile file = initialize(fileName, fileBody, mockSemanticTokensProviderJson, mockSemanticTokensJson, true);
+
+        // Confirm the token element types
+        for (Map.Entry<Function<String, Integer>, Consumer<LSPSemanticTokenPsiElement>> tokenVerifier : tokenVerifiers.entrySet()) {
+            Function<String, Integer> tokenSearchFunction = tokenVerifier.getKey();
+            Consumer<LSPSemanticTokenPsiElement> tokenElementVerifier = tokenVerifier.getValue();
+
+            Integer tokenOffset = tokenSearchFunction.apply(fileBody);
+            assertNotNull(tokenOffset);
+            assertSemanticTokenElement(file, tokenElementVerifier, tokenOffset);
+        }
+
+        // Verify all tokens including those that weren't explicitly specified via verifiers
+        int offset = 0;
+        while (offset < fileBody.length()) {
+            PsiElement element = file.findElementAt(offset);
+            if (element instanceof LSPSemanticTokenPsiElement semanticTokenElement) {
+                assertSemanticTokenElement(file, semanticTokenElement);
+                offset += element.getTextLength() + 1;
+            } else {
+                offset++;
+            }
+        }
+    }
+
+    protected void assertViewProviderDisabled(@NotNull String fileName,
+                                              @NotNull String fileBody,
+                                              @Nullable String mockSemanticTokensProviderJson,
+                                              @Nullable String mockSemanticTokensJson) {
+        PsiFile file = initialize(fileName, fileBody, mockSemanticTokensProviderJson, mockSemanticTokensJson, false);
+
+        // Verify that the file does not include any semantic token-based elements or references
+        for (int offset = 0; offset < fileBody.length(); offset++) {
+            PsiElement element = file.findElementAt(offset);
+            assertFalse(element instanceof LSPSemanticTokenPsiElement);
+            assertNull(file.findReferenceAt(offset));
+        }
+    }
+
+    private static void assertSemanticTokenElement(@NotNull PsiFile file,
+                                                   @NotNull Consumer<LSPSemanticTokenPsiElement> tokenElementVerifier,
+                                                   int offset) {
+        PsiElement element = file.findElementAt(offset);
+        assertInstanceOf(element, LSPSemanticTokenPsiElement.class);
+        assertSemanticTokenElement(file, (LSPSemanticTokenPsiElement) element, tokenElementVerifier);
+    }
+
+    private static void assertSemanticTokenElement(@NotNull PsiFile file,
+                                                   @NotNull LSPSemanticTokenPsiElement element) {
+        assertSemanticTokenElement(file, element, null);
+    }
+
+    private static void assertSemanticTokenElement(@NotNull PsiFile file,
+                                                   @NotNull LSPSemanticTokenPsiElement semanticTokenElement,
+                                                   @Nullable Consumer<LSPSemanticTokenPsiElement> tokenElementVerifier) {
+        // Verify the element type if appropriate
+        ASTNode semanticTokenNode = semanticTokenElement.getNode();
+        assertNotNull(semanticTokenNode);
+        IElementType tokenElementType = semanticTokenNode.getElementType();
+        assertInstanceOf(tokenElementType, IElementType.class);
+        if (tokenElementVerifier != null) {
+            tokenElementVerifier.accept(semanticTokenElement);
+        }
+
+        // Verify references are only present for reference elements
+        PsiReference reference = file.findReferenceAt(semanticTokenElement.getTextOffset());
+        LSPSemanticTokensFileViewProvider semanticTokensFileViewProvider = LSPSemanticTokensFileViewProvider.getInstance(semanticTokenElement);
+        assertNotNull(semanticTokensFileViewProvider);
+        if (semanticTokensFileViewProvider.isReference(semanticTokenElement.getTextOffset())) {
+            assertNotNull(reference);
+        } else {
+            assertNull(reference);
+        }
+    }
+}


### PR DESCRIPTION
This is a fresh PR/branch for #853 which, while clean to merge against main, isn't easy to merge via rebase in its current state. It is the exact same contents as that other PR/branch.