### PR TITLE
fix: Prospective fix for an `IndexOutOfBoundsException` (fixes #884)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockExtendWordSelectionHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPCodeBlockExtendWordSelectionHandler.java
@@ -57,7 +57,9 @@ public class LSPCodeBlockExtendWordSelectionHandler extends AbstractLSPExtendWor
         int currentLineStartOffset = document.getLineStartOffset(currentLineNumber);
         int currentLineEndOffset = document.getLineEndOffset(currentLineNumber);
         int effectiveOffset = Math.max(offset, currentLineStartOffset);
-        while ((effectiveOffset <= currentLineEndOffset) && Character.isWhitespace(editorText.charAt(effectiveOffset))) {
+        while ((effectiveOffset <= currentLineEndOffset) &&
+                (effectiveOffset < editorText.length()) &&
+                Character.isWhitespace(editorText.charAt(effectiveOffset))) {
             effectiveOffset++;
         }
 


### PR DESCRIPTION
While I haven't been able to reproduce this, the only way it could have happened is if `effectiveOffset` was incremented to be the same as `editorText.length()`, so I've made the logic defensive against that situation, terminating the loop before it reaches that point.