### PR TITLE
fix: Added (hard-coded) support for SourceKit LSP's `identifier` semantic token type which should be interpreted as being a declaration.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenType.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenType.java
@@ -23,6 +23,7 @@ public class LSPSemanticTokenType {
 
     private final String name;
     private final boolean identifier;
+    private final boolean declaration;
     private final boolean type;
     private final boolean keyword;
     private final String inheritFrom;
@@ -33,6 +34,7 @@ public class LSPSemanticTokenType {
      *
      * @param name              the name
      * @param identifier        whether or not the token represents an identifier
+     * @param declaration       whether or not the token represents a declaration
      * @param type              whether or not the token represents a type
      * @param keyword           whether or not the token represents a keyword
      * @param inheritFrom       an optional existing semantic token type from which this one should inherit its behavior
@@ -40,12 +42,14 @@ public class LSPSemanticTokenType {
      */
     LSPSemanticTokenType(@NotNull String name,
                          boolean identifier,
+                         boolean declaration,
                          boolean type,
                          boolean keyword,
                          @Nullable String inheritFrom,
                          @Nullable String textAttributesKey) {
         this.name = name;
         this.identifier = identifier;
+        this.declaration = declaration;
         this.type = type;
         this.keyword = keyword;
         this.inheritFrom = inheritFrom;
@@ -67,6 +71,14 @@ public class LSPSemanticTokenType {
     @ApiStatus.Internal
     public boolean isIdentifier() {
         return identifier;
+    }
+
+    /**
+     * Whether or not the semantic token should be interpreted as being a declaration.
+     */
+    @ApiStatus.Internal
+    public boolean isDeclaration() {
+        return declaration;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenTypes.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokenTypes.java
@@ -31,6 +31,7 @@ public class LSPSemanticTokenTypes {
             true,
             false,
             false,
+            false,
             null,
             SemanticTokensHighlightingColors.LABEL.getExternalName()
     );
@@ -41,14 +42,27 @@ public class LSPSemanticTokenTypes {
             true,
             false,
             false,
+            false,
             SemanticTokenTypes.Method,
+            null
+    );
+
+    // SourceKit "identifier" which should be considered a declaration
+    private static final LSPSemanticTokenType Identifier = new LSPSemanticTokenType(
+            "identifier",
+            true,
+            true,
+            false,
+            false,
+            SemanticTokenTypes.Variable,
             null
     );
 
     // All custom semantic token types
     private static final LSPSemanticTokenType[] values = new LSPSemanticTokenType[]{
             Label,
-            Member
+            Member,
+            Identifier
     };
 
     // An index for finding a custom semantic token type by its name

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticToken.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticToken.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.ThreeState;
 import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.features.semanticTokens.LSPSemanticTokenType;
 import com.redhat.devtools.lsp4ij.features.semanticTokens.LSPSemanticTokenTypes;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
@@ -61,7 +62,7 @@ class LSPSemanticToken {
                     SemanticTokenTypes.Decorator
             ),
             Arrays.stream(LSPSemanticTokenTypes.values())
-                    .map(t -> t.getName())
+                    .map(LSPSemanticTokenType::getName)
                     .collect(Collectors.toSet())
     );
 
@@ -86,8 +87,8 @@ class LSPSemanticToken {
                     SemanticTokenTypes.Decorator
             ),
             Arrays.stream(LSPSemanticTokenTypes.values())
-                    .filter(t -> t.isIdentifier())
-                    .map(t -> t.getName())
+                    .filter(LSPSemanticTokenType::isIdentifier)
+                    .map(LSPSemanticTokenType::getName)
                     .collect(Collectors.toSet())
     );
 
@@ -105,8 +106,8 @@ class LSPSemanticToken {
                     SemanticTokenTypes.Struct
             ),
             Arrays.stream(LSPSemanticTokenTypes.values())
-                    .filter(t -> t.isType())
-                    .map(t -> t.getName())
+                    .filter(LSPSemanticTokenType::isType)
+                    .map(LSPSemanticTokenType::getName)
                     .collect(Collectors.toSet())
     );
 
@@ -120,10 +121,16 @@ class LSPSemanticToken {
                     SemanticTokenTypes.Modifier
             ),
             Arrays.stream(LSPSemanticTokenTypes.values())
-                    .filter(t -> t.isKeyword())
-                    .map(t -> t.getName())
+                    .filter(LSPSemanticTokenType::isKeyword)
+                    .map(LSPSemanticTokenType::getName)
                     .collect(Collectors.toSet())
     );
+
+    // Semantic token types that should be interpreted as representing declarations
+    private static final Set<String> DECLARATION_TOKEN_TYPES = Arrays.stream(LSPSemanticTokenTypes.values())
+            .filter(LSPSemanticTokenType::isDeclaration)
+            .map(LSPSemanticTokenType::getName)
+            .collect(Collectors.toSet());
 
     // Semantic token modifiers that should be interpreted as representing declarations
     private static final Set<String> DECLARATION_TOKEN_MODIFIERS = Set.of(
@@ -222,7 +229,7 @@ class LSPSemanticToken {
         if (tokenType != null) {
             // If this is an identifier token, see if it's a declaration or a reference
             if (IDENTIFIER_TOKEN_TYPES.contains(tokenType)) {
-                return ContainerUtil.intersects(DECLARATION_TOKEN_MODIFIERS, tokenModifiers) ?
+                return DECLARATION_TOKEN_TYPES.contains(tokenType) || ContainerUtil.intersects(DECLARATION_TOKEN_MODIFIERS, tokenModifiers) ?
                         LSPSemanticTokenElementType.DECLARATION :
                         LSPSemanticTokenElementType.REFERENCE;
             }


### PR DESCRIPTION
This will need to be made configurable as part of #871.