### PR TITLE
fix: Only call codelens/resolve for codelens in viewport

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPFeatureSupport.java
@@ -73,6 +73,10 @@ public abstract class AbstractLSPFeatureSupport<Params, Result> {
         return isValidLSPFuture() ? future : null;
     }
 
+    public @Nullable CompletableFuture<Result> getFuture() {
+        return future;
+    }
+
     /**
      * Cancel previous LSP requests and load the LSP requests for all language servers applying to a given Psi file or project by using the given cancellation support.
      *

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensEditorFactoryListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensEditorFactoryListener.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.codeLens;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.event.EditorFactoryEvent;
+import com.intellij.openapi.editor.event.EditorFactoryListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+
+/**
+ * Listens to editor events and manages the context for unresolved code lenses.
+ * It updates the viewport lines and triggers the resolution and refresh of unresolved code lenses in the editor.
+ */
+public class LSPCodeLensEditorFactoryListener implements EditorFactoryListener {
+
+    // Key used to store and retrieve the unresolved code lens context for each editor
+    private static final Key<UnresolvedCodeLensViewportContext> CONTEXT_KEY = Key.create("unresolved.codelens.viewport.context");
+
+    /**
+     * Called when an editor is created.
+     * Checks if the editor's file is supported and attaches a scroll listener.
+     *
+     * @param event The event associated with the editor creation.
+     */
+    @Override
+    public void editorCreated(@NotNull EditorFactoryEvent event) {
+        Editor editor = event.getEditor();
+        Project project = editor.getProject();
+
+        if (project != null) {
+            // If the file is supported, attach a scroll listener to the editor
+            if (LanguageServersRegistry.getInstance().isFileSupported(editor.getVirtualFile(), project)) {
+                attachScrollListener(editor);
+            }
+        }
+    }
+
+    @Override
+    public void editorReleased(@NotNull EditorFactoryEvent event) {
+        Editor editor = event.getEditor();
+        UnresolvedCodeLensViewportContext context = editor.getUserData(CONTEXT_KEY);
+        if (context != null) {
+            context.dispose();
+            editor.putUserData(CONTEXT_KEY, null);
+        }
+    }
+
+    /**
+     * Attaches a listener to the editor's scrolling model to track the visible area changes.
+     * When the visible area changes, it updates the viewport context and triggers the resolution of code lenses.
+     *
+     * @param editor The editor to which the scroll listener is attached.
+     */
+    private static void attachScrollListener(@NotNull Editor editor) {
+        // Adding a listener for visible area changes
+        editor.getScrollingModel().addVisibleAreaListener((e) -> {
+            // Retrieve the code lens resolution context for the editor
+            UnresolvedCodeLensViewportContext context = getCodeLensResolveContext(e.getEditor());
+            context.updateViewportLines(e.getNewRectangle());
+
+            // Retrieve the PsiFile and check if code lens data is ready
+            PsiFile file = LSPIJUtils.getPsiFile(editor.getVirtualFile(), editor.getProject());
+            LSPCodeLensSupport codeLensSupport = LSPFileSupport.getSupport(file).getCodeLensSupport();
+            var data = codeLensSupport.getFuture();
+
+            // If data is available and done, resolve and refresh code lenses in the viewport
+            if (data != null && data.isDone()) {
+                final long modificationStamp = file.getModificationStamp();
+                final int firstViewportLine = context.getFirstViewportLine();
+                final int lastViewportLine = context.getLastViewportLine();
+                context.resolveAndRefreshUnresolvedCodeLensInViewport(data.getNow(Collections.emptyList()),
+                        file,
+                        firstViewportLine,
+                        lastViewportLine,
+                        modificationStamp);
+            }
+        });
+    }
+
+    /**
+     * Retrieves the unresolved code lens resolution context for the given editor.
+     * If no context exists, it synchronously creates and stores a new one.
+     *
+     * @param editor The editor for which the context is retrieved.
+     * @return The unresolved code lens viewport context for the editor.
+     */
+    @NotNull
+    public static UnresolvedCodeLensViewportContext getCodeLensResolveContext(@NotNull Editor editor) {
+        UnresolvedCodeLensViewportContext context = editor.getUserData(CONTEXT_KEY);
+        if (context != null) {
+            return context;
+        }
+        return createCodeLensResolveContextSync(editor);
+    }
+
+    /**
+     * Synchronously creates and stores a new unresolved code lens resolution context for the editor.
+     *
+     * @param editor The editor for which the context is created.
+     * @return The newly created unresolved code lens viewport context.
+     */
+    @NotNull
+    private synchronized static UnresolvedCodeLensViewportContext createCodeLensResolveContextSync(@NotNull Editor editor) {
+        UnresolvedCodeLensViewportContext context = editor.getUserData(CONTEXT_KEY);
+        if (context != null) {
+            return context;
+        }
+        context = new UnresolvedCodeLensViewportContext(editor);
+        editor.putUserData(CONTEXT_KEY, context);
+        return context;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
@@ -100,18 +100,16 @@ public class LSPCodeLensSupport extends AbstractLSPDocumentFeatureSupport<CodeLe
                             .stream()
                             .filter(LSPCodeLensSupport::isValidCodeLens)
                             .forEach(codeLens -> {
-                                CompletableFuture<CodeLens> resolvedCodeLensFuture = null;
                                 var codeLensFeature = languageServer.getClientFeatures().getCodeLensFeature();
-                                if (codeLens.getCommand() == null && codeLensFeature.isResolveCodeLensSupported(file)) {
+                                boolean toResolve = codeLens.getCommand() == null && codeLensFeature.isResolveCodeLensSupported(file);
                                     // - the codelens has no command, and the language server supports codeLens/resolve
                                     // prepare the future which resolves the codelens.
-                                    resolvedCodeLensFuture = cancellationSupport.execute(languageServer
+                                    /*resolvedCodeLensFuture = cancellationSupport.execute(languageServer
                                             .getTextDocumentService()
-                                            .resolveCodeLens(codeLens), languageServer, LSPRequestConstants.CODE_LENS_RESOLVE);
-                                }
-                                if (codeLensFeature.getText(codeLens) != null || resolvedCodeLensFuture != null) {
+                                            .resolveCodeLens(codeLens), languageServer, LSPRequestConstants.CODE_LENS_RESOLVE);*/
+                                if (codeLensFeature.getText(codeLens) != null || toResolve) {
                                     // The codelens content is filled or the codelens must be resolved
-                                    data.add(new CodeLensData(codeLens, languageServer, resolvedCodeLensFuture));
+                                    data.add(new CodeLensData(codeLens, languageServer, toResolve));
                                 }
                             });
                     return data;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.codeLens;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.VisualPosition;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager;
+import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureType;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+
+import static com.redhat.devtools.lsp4ij.features.codeLens.LSPCodeLensProvider.collectApplicableCodeLens;
+
+/**
+ * Manages the viewport for unresolved code lens elements, scheduling their resolution
+ * and refreshing the editor once the resolution is complete. This class tracks the
+ * currently visible lines and ensures efficient refreshing through debounce logic.
+ */
+public class UnresolvedCodeLensViewportContext implements Disposable  {
+
+    private static final long VIEWPORT_CHANGE_DELAY_MS = 500L; // Debounce delay before processing viewport changes
+
+    private final @NotNull Editor editor;
+    private int firstViewportLine;
+    private int lastViewportLine;
+    private @Nullable CompletableFuture<Void> pendingRefreshTask; // Tracks the currently scheduled refresh task
+
+    /**
+     * Initializes the context for managing unresolved code lens elements in a given editor.
+     *
+     * @param editor The associated editor instance.
+     */
+    public UnresolvedCodeLensViewportContext(@NotNull Editor editor) {
+        this.editor = editor;
+    }
+
+    /**
+     * Updates the range of visible lines in the viewport based on the given visible area.
+     *
+     * @param visibleArea The visible rectangle in the editor used to calculate the viewport line range.
+     */
+    public void updateViewportLines(@NotNull Rectangle visibleArea) {
+        int firstVisualLine = editor.yToVisualLine(visibleArea.y);
+        int lastVisualLine = editor.yToVisualLine(visibleArea.y + visibleArea.height);
+        firstViewportLine = editor.visualToLogicalPosition(new VisualPosition(firstVisualLine, 0)).line;
+        lastViewportLine = editor.visualToLogicalPosition(new VisualPosition(lastVisualLine, 0)).line;
+    }
+
+    /**
+     * Gets the first visible line in the editor's viewport.
+     *
+     * @return The first visible line number.
+     */
+    public int getFirstViewportLine() {
+        return firstViewportLine;
+    }
+
+    /**
+     * Gets the last visible line in the editor's viewport.
+     *
+     * @return The last visible line number.
+     */
+    public int getLastViewportLine() {
+        return lastViewportLine;
+    }
+
+    /**
+     * Resolves unresolved code lens elements in the current viewport and refreshes the editor accordingly.
+     * If a previous refresh task is pending, it will be cancelled before scheduling a new one.
+     *
+     * @param data             The unresolved code lens data to resolve.
+     * @param file             The associated PSI file containing the code.
+     * @param firstViewportLine The first visible line in the editor's viewport.
+     * @param lastViewportLine  The last visible line in the editor's viewport.
+     * @param modificationStamp The timestamp used for version tracking of the code file.
+     */
+    public void resolveAndRefreshUnresolvedCodeLensInViewport(@NotNull List<CodeLensData> data,
+                                                              @NotNull PsiFile file,
+                                                              int firstViewportLine,
+                                                              int lastViewportLine,
+                                                              long modificationStamp) {
+        if (pendingRefreshTask != null) {
+            pendingRefreshTask.cancel(true); // Cancel any pending refresh task
+        }
+
+        pendingRefreshTask = delayedExecution(VIEWPORT_CHANGE_DELAY_MS)
+                .thenRun(() -> {
+                    if (isSameViewportRange(firstViewportLine, lastViewportLine)) {
+                        resolveAndRefreshVisibleCodeLens(data, file, firstViewportLine, lastViewportLine, modificationStamp);
+                    }
+                });
+    }
+
+    /**
+     * Delays the execution for a specified time before proceeding with the next operation,
+     * periodically checking for cancellation requests.
+     *
+     * @param timeout The delay time in milliseconds before the operation is executed.
+     * @return A CompletableFuture that completes after the specified delay.
+     */
+    private static CompletableFuture<Void> delayedExecution(long timeout) {
+        return CompletableFutures.computeAsync(cancelChecker -> {
+            long start = System.currentTimeMillis();
+            while (System.currentTimeMillis() - start < timeout) {
+                cancelChecker.checkCanceled();
+                try {
+                    Thread.sleep(5); // Sleep in small intervals to allow cancellation checks
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new CancellationException(); // Ensure cancellation exception is thrown when interrupted
+                }
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Resolves the code lens elements visible in the editor's current viewport and triggers a refresh.
+     *
+     * @param data             The unresolved code lens data.
+     * @param file             The associated PSI file.
+     * @param firstViewportLine The first visible line in the viewport.
+     * @param lastViewportLine  The last visible line in the viewport.
+     * @param modificationStamp The modification timestamp for version control.
+     */
+    private void resolveAndRefreshVisibleCodeLens(@NotNull List<CodeLensData> data,
+                                                  @NotNull PsiFile file,
+                                                  int firstViewportLine,
+                                                  int lastViewportLine,
+                                                  long modificationStamp) {
+        // Collect the unresolved code lens elements that are visible within the current viewport range
+        @Nullable CompletableFuture<Void> allResolve =
+                collectApplicableCodeLens(data, null, editor);
+        if (allResolve != null) {
+            // After resolving the code lens, refresh only the elements within the current viewport range
+            allResolve
+                    .thenRun(() -> {
+                        if (isSameViewportRange(firstViewportLine, lastViewportLine)) {
+                            // The viewport hasn't changed (no scrolling occurred), so we proceed to refresh
+                            EditorFeatureManager.getInstance(editor.getProject())
+                                    .refreshEditorFeatureWhenAllDone(new HashSet<>(Arrays.asList(allResolve)),
+                                            modificationStamp, file, EditorFeatureType.CODE_VISION);
+                        }
+                    });
+        }
+    }
+
+    /**
+     * Checks if the current viewport range matches the given range.
+     *
+     * @param firstViewportLine The first visible line of the viewport to check.
+     * @param lastViewportLine  The last visible line of the viewport to check.
+     * @return True if the viewport range is unchanged, false otherwise.
+     */
+    private boolean isSameViewportRange(int firstViewportLine, int lastViewportLine) {
+        return firstViewportLine == getFirstViewportLine() && lastViewportLine == getLastViewportLine();
+    }
+
+    @Override
+    public void dispose() {
+        if (pendingRefreshTask != null) {
+            if (!pendingRefreshTask.isDone()) {
+                pendingRefreshTask.cancel(true);
+            }
+            pendingRefreshTask = null;
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
@@ -88,7 +88,7 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
                                 var psiElement = LSPUsagesManager.toPsiElement(ref.location(), ref.languageServer().getClientFeatures(), LSPUsagePsiElement.UsageKind.references, project);
                                 if (psiElement != null) {
                                     VirtualFile psiElementFile = LSPIJUtils.getFile(psiElement);
-                                    if ((psiElementFile != null) && searchScope.contains(psiElementFile)) {
+                                    if (psiElementFile != null) {
                                         processor.process(new UsageInfo2UsageAdapter(new UsageInfo(psiElement)));
                                     }
                                 }
@@ -115,9 +115,8 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
                     if (usages != null) {
                         List<LSPUsagePsiElement> filteredUsages = new ArrayList<>(usages);
                         filteredUsages.removeIf(usage -> ContainerUtil.exists(usages, otherUsage -> {
-                            // Remove any usages that aren't included in the search scope
                             VirtualFile usageFile = LSPIJUtils.getFile(usage);
-                            if ((usageFile == null) || !searchScope.contains(usageFile)) {
+                            if ((usageFile == null) /*||*!searchScope.contains(usageFile)*/) {
                                 return true;
                             }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -331,12 +331,17 @@
 
         <!-- LSP textDocument/codeLens request support -->
         <codeInsight.codeVisionProviderFactory
+                id="DummyCodeVisionProviderFactory"
                 implementation="com.redhat.devtools.lsp4ij.features.codeLens.DummyCodeVisionProviderFactory"/>
         <config.codeVisionGroupSettingProvider
+                id="LSPCodeLensSettingsProvider"
                 implementation="com.redhat.devtools.lsp4ij.features.codeLens.LSPCodeLensSettingsProvider"/>
         <codeInsight.codeVisionProvider
                 id="LSPCodeLensProvider"
                 implementation="com.redhat.devtools.lsp4ij.features.codeLens.LSPCodeLensProvider"/>
+        <editorFactoryListener
+                id="LSPCodeLensEditorFactoryListener"
+                implementation="com.redhat.devtools.lsp4ij.features.codeLens.LSPCodeLensEditorFactoryListener" />
 
         <!-- LSP textDocument/inlayHint requests support -->
         <codeInsight.declarativeInlayProviderFactory


### PR DESCRIPTION
fix: Only call codelens/resolve for codelens in viewport

Fixes #141