### PR TITLE
fix: Prospective fix for a deadlock observed by a user helping to test the semantic tokens enhancements.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderHelper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderHelper.java
@@ -24,10 +24,9 @@ import com.redhat.devtools.lsp4ij.client.features.EditorBehaviorFeature;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Helper class for {@link LSPSemanticTokensFileViewProvider} implementations to help fulfill its interface.
@@ -153,7 +152,7 @@ public class LSPSemanticTokensFileViewProviderHelper implements LSPSemanticToken
             @Override
             @NotNull
             public Result<Map<Integer, LSPSemanticToken>> compute() {
-                Map<Integer, LSPSemanticToken> semanticTokensByOffset = Collections.synchronizedMap(new HashMap<>());
+                Map<Integer, LSPSemanticToken> semanticTokensByOffset = new ConcurrentHashMap<>();
                 return Result.create(semanticTokensByOffset, file);
             }
         });


### PR DESCRIPTION
Changed a synchronized hashmap that is shown by a user-provided thread dump to be causing (or at least likely contributing to) a deadlock to be a concurrent hashmap with a much more forgiving locking model. If this doesn't resolve the issue, we likely need to try an unsynchronized hashmap to see if that resolves the deadlock, then determine the correct safe concurrency model for that data.