### PR TITLE
fix: Do not create alarm without coroutineScope: com.redhat.devtools.lsp4ij.features.codeLens.UnresolvedCodeLensViewportContext.<init>(UnresolvedCodeLensViewportContext.java:37)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
@@ -34,7 +34,7 @@ public class UnresolvedCodeLensViewportContext implements Disposable  {
     private int firstViewportLine;
     private int lastViewportLine;
     private long modificationStamp;
-    private Alarm scrollStopAlarm = new Alarm();
+    private Alarm scrollStopAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
 
     /**
      * Initializes the context for managing unresolved code lens elements in a given editor.


### PR DESCRIPTION
fix: Do not create alarm without coroutineScope: com.redhat.devtools.lsp4ij.features.codeLens.UnresolvedCodeLensViewportContext.<init>(UnresolvedCodeLensViewportContext.java:37)