### PR TITLE
perf: cancel LSP documentSymbol+semanticTokens only when file has changed

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensSupport.java
@@ -41,9 +41,6 @@ public class LSPCodeLensSupport extends AbstractLSPDocumentFeatureSupport<CodeLe
     }
 
     public CompletableFuture<CodeLensDataResult> getCodeLenses(@NotNull CodeLensParams params) {
-        if (!super.checkValid()) {
-            super.cancel();
-        }
         return super.getFeatureData(params);
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
@@ -15,17 +15,17 @@ import com.intellij.ide.structureView.StructureViewModelBase;
 import com.intellij.ide.structureView.StructureViewTreeElement;
 import com.intellij.ide.structureView.impl.common.PsiTreeElementBase;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.ArrayUtil;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.Icon;
+import javax.swing.*;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -93,12 +93,12 @@ public class LSPDocumentSymbolStructureViewModel extends StructureViewModelBase 
             try {
                 waitUntilDone(documentSymbolFuture, psiFile);
             } catch (
-                    ProcessCanceledException e) { //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                    PsiFileChangedException e) { //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
                 documentSymbolSupport.cancel();
                 throw e;
             } catch (CancellationException e) {
-                documentSymbolSupport.cancel();
-                return Collections.emptyList();
+                //documentSymbolSupport.cancel();
+                throw e;
             } catch (ExecutionException e) {
                 return Collections.emptyList();
             }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
@@ -13,7 +13,6 @@ package com.redhat.devtools.lsp4ij.features.semanticTokens;
 
 import com.intellij.codeInsight.daemon.impl.HighlightVisitor;
 import com.intellij.codeInsight.daemon.impl.analysis.HighlightInfoHolder;
-import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.source.tree.LeafElement;
@@ -22,6 +21,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.client.ExecuteLSPFeatureStatus;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.internal.SimpleLanguageUtils;
 import org.eclipse.lsp4j.SemanticTokensParams;
 import org.jetbrains.annotations.ApiStatus;
@@ -108,14 +108,14 @@ public class LSPSemanticTokensHighlightVisitor implements HighlightVisitor {
         try {
             waitUntilDone(semanticTokensFuture, file);
         } catch (
-                ProcessCanceledException e) {//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
+                PsiFileChangedException e) {
             //TODO delete block when minimum required version is 2024.2
             semanticTokensSupport.cancel();
-            return null;
+            throw e;
         } catch (CancellationException e) {
             // cancel the LSP requests textDocument/semanticTokens/full
-            semanticTokensSupport.cancel();
-            return null;
+            //semanticTokensSupport.cancel();
+            throw e;
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/semanticTokens/full' request", e);
             return null;


### PR DESCRIPTION
perf: cancel LSP documentSymbol+semanticTokens only when file has changed