### PR TITLE
fix: do some performance improvement

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServiceAccessor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServiceAccessor.java
@@ -267,8 +267,8 @@ public class LanguageServiceAccessor implements Disposable {
         // We get the Document instance now, to avoid creating a new Read Action thread to get it from the file.
         // The document instance is only used when the file is opened, to add
         // LSP document listener to manage didOpen, didChange, etc.
-        boolean writeAccessAllowed = !ApplicationManager.getApplication().isWriteAccessAllowed();
-        boolean readAccessAllowed = !ApplicationManager.getApplication().isWriteAccessAllowed();
+        boolean writeAccessAllowed = ApplicationManager.getApplication().isWriteAccessAllowed();
+        boolean readAccessAllowed = ApplicationManager.getApplication().isReadAccessAllowed();
         Document document = readAccessAllowed || (!writeAccessAllowed) ? LSPIJUtils.getDocument(file) : null;
 
         // Try to get document, languageId information (used by didOpen) for each matched language server wrapper

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
@@ -26,7 +26,7 @@ import java.awt.*;
  * and refreshing the editor once the resolution is complete. This class tracks the
  * currently visible lines and ensures efficient refreshing through debounce logic.
  */
-public class UnresolvedCodeLensViewportContext implements Disposable  {
+public class UnresolvedCodeLensViewportContext implements Disposable {
 
     private static final long VIEWPORT_CHANGE_DELAY_MS = 500L; // Debounce delay before processing viewport changes
 
@@ -34,7 +34,7 @@ public class UnresolvedCodeLensViewportContext implements Disposable  {
     private int firstViewportLine;
     private int lastViewportLine;
     private long modificationStamp;
-    private Alarm scrollStopAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
+    private volatile Alarm scrollStopAlarm = null;
 
     /**
      * Initializes the context for managing unresolved code lens elements in a given editor.
@@ -79,8 +79,8 @@ public class UnresolvedCodeLensViewportContext implements Disposable  {
      * Resolves unresolved code lens elements in the current viewport and refreshes the editor accordingly.
      * If a previous refresh task is pending, it will be cancelled before scheduling a new one.
      *
-     * @param result             The unresolved code lens data to resolve.
-     * @param file             The associated PSI file containing the code.
+     * @param result            The unresolved code lens data to resolve.
+     * @param file              The associated PSI file containing the code.
      * @param firstViewportLine The first visible line in the editor's viewport.
      * @param lastViewportLine  The last visible line in the editor's viewport.
      */
@@ -88,6 +88,7 @@ public class UnresolvedCodeLensViewportContext implements Disposable  {
                                   @NotNull PsiFile file,
                                   int firstViewportLine,
                                   int lastViewportLine) {
+        var scrollStopAlarm = getScrollStopAlarm();
         scrollStopAlarm.cancelAllRequests();
         scrollStopAlarm.addRequest(() -> {
             if (isSameViewportRange(firstViewportLine, lastViewportLine)
@@ -96,9 +97,20 @@ public class UnresolvedCodeLensViewportContext implements Disposable  {
                 // The viewport hasn't changed (no scrolling occurred) there are some codelens to resolve and file has not changed
                 // , so we proceed to refresh
                 EditorFeatureManager.getInstance(editor.getProject()).
-                    refreshEditorFeature(file.getVirtualFile(), EditorFeatureType.CODE_VISION, false);
+                        refreshEditorFeature(file.getVirtualFile(), EditorFeatureType.CODE_VISION, false);
             }
         }, VIEWPORT_CHANGE_DELAY_MS);
+    }
+
+    private Alarm getScrollStopAlarm() {
+        if (scrollStopAlarm == null) {
+            synchronized (this) {
+                if (scrollStopAlarm == null) {
+                    scrollStopAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
+                }
+            }
+        }
+        return scrollStopAlarm;
     }
 
     /**
@@ -114,14 +126,11 @@ public class UnresolvedCodeLensViewportContext implements Disposable  {
 
     @Override
     public void dispose() {
-        if (scrollStopAlarm != null) {
-            scrollStopAlarm.cancelAllRequests();
-            scrollStopAlarm = null;
-        }
     }
 
     /**
      * Returns true if the file content has changed and false otherwise.
+     *
      * @param file the file.
      * @return true if the file content has changed and false otherwise.
      */

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
@@ -60,8 +59,8 @@ public class LSPColorProvider extends AbstractLSPInlayHintsProvider {
         CompletableFuture<List<ColorData>> future = colorSupport.getColors(params);
 
         try {
-            // Wait until the future while 200ms and stop the wait if there are some ProcessCanceledException.
-            waitUntilDone(future, psiFile, 200);
+            // Wait until the future is done and stop the wait if there are some ProcessCanceledException.
+            waitUntilDone(future, psiFile);
             if (isDoneNormally(future)) {
 
                 // Collect color information
@@ -79,10 +78,6 @@ public class LSPColorProvider extends AbstractLSPInlayHintsProvider {
                                         toPresentation(list, factory))
                         );
             }
-        } catch (TimeoutException ignore) {
-            // the future which collects all textDocument/documentColor for all servers is not finished
-            // add it to the pending futures to refresh again the UI when this future will be finished.
-            pendingFutures.add(future);
         } catch (ProcessCanceledException ignore) {//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
             //TODO delete block when minimum required version is 2024.2
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPServerSideOnTypeFormattingHelper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPServerSideOnTypeFormattingHelper.java
@@ -18,7 +18,8 @@ import com.intellij.psi.PsiFile;
 import com.intellij.util.containers.ContainerUtil;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
-import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
@@ -58,8 +59,11 @@ final class LSPServerSideOnTypeFormattingHelper {
     static boolean applyOnTypeFormatting(char charTyped,
                                          @NotNull Editor editor,
                                          @NotNull PsiFile file) {
-        if (!LanguageServersRegistry.getInstance().isFileSupported(file)) {
-            // The file is not associated to a language server
+        if (ProjectIndexingManager.isIndexingAll()) {
+            return false;
+        }
+        if (!hasLanguageServerSupportingOnTypeFormatting(file)) {
+            // The file is not associated to a language server which supports on type formatting
             return false;
         }
         // If so, issue a request for on-type formatting
@@ -102,4 +106,12 @@ final class LSPServerSideOnTypeFormattingHelper {
         LSPIJUtils.applyEdits(editor, document, textEdits);
         return true;
     }
+
+    private static boolean hasLanguageServerSupportingOnTypeFormatting(@NotNull PsiFile file) {
+        return LanguageServiceAccessor.getInstance(file.getProject())
+                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures()
+                        .getOnTypeFormattingFeature()
+                        .isSupported(file));
+    }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderHelper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensFileViewProviderHelper.java
@@ -21,6 +21,7 @@ import com.intellij.util.ThreeState;
 import com.intellij.util.containers.ContainerUtil;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.client.features.EditorBehaviorFeature;
+import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,7 +56,7 @@ public class LSPSemanticTokensFileViewProviderHelper implements LSPSemanticToken
 
     @Override
     public boolean isEnabled() {
-        return getFile() != null;
+        return !ProjectIndexingManager.isIndexingAll() && getFile() != null;
     }
 
     @Override


### PR DESCRIPTION
fix: do some performance improvement:

 * avoid executing on type formatting (client, server side) when project are indexing otherwise it freezes the editor when you type something.
 * remove the wait with timeout in LSPColorProvider (I already did that for inlay hint) because otherwise there are too many refresh of the editor. /cc @FalsePattern 