### PR TITLE
perf: use PsiFile instead of using VirtualFile

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -65,11 +65,14 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements ProjectM
     }
 
     private static void connectToLanguageServer(@NotNull VirtualFile file, @NotNull Project project) {
-        // Force the start of all languages servers mapped with the given file
-        // Server capabilities filter is set to null to avoid waiting
-        // for the start of the server when server capabilities are checked
-        LanguageServiceAccessor.getInstance(project)
-                .getLanguageServers(file, null, null);
+        PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+        if (psiFile != null) {
+            // Force the start of all languages servers mapped with the given file
+            // Server capabilities filter is set to null to avoid waiting
+            // for the start of the server when server capabilities are checked
+            LanguageServiceAccessor.getInstance(project)
+                    .getLanguageServers(psiFile, null, null);
+        }
     }
 
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJEditorUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJEditorUtils.java
@@ -400,7 +400,7 @@ public final class LSPIJEditorUtils {
         @Nullable
         private static LSPClientFeatures getClientFeatures(@NotNull PsiFile file) {
             CompletableFuture<List<LanguageServerItem>> languageServersFuture = LanguageServiceAccessor.getInstance(file.getProject()).getLanguageServers(
-                    file.getVirtualFile(),
+                    file,
                     clientFeatures -> StringUtil.isNotEmpty(clientFeatures.getLineCommentPrefix(file)) ||
                                       StringUtil.isNotEmpty(clientFeatures.getBlockCommentPrefix(file)) ||
                                       StringUtil.isNotEmpty(clientFeatures.getBlockCommentSuffix(file)),

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -566,6 +566,16 @@ public class LSPIJUtils {
 
 
     /**
+     * Returns the virtual file corresponding to the PSI file.
+     *
+     * @param psiFile the PSI file
+     * @return the virtual file, or {@code null} if the file exists only in memory.
+     */
+    public static @Nullable VirtualFile getFile(@NotNull PsiFile psiFile) {
+       return psiFile.getVirtualFile();
+    }
+
+    /**
      * Returns the virtual file corresponding to the PSI element.
      *
      * @param element the PSI element
@@ -573,7 +583,7 @@ public class LSPIJUtils {
      */
     public static @Nullable VirtualFile getFile(@NotNull PsiElement element) {
         PsiFile psFile = element.getContainingFile();
-        return psFile != null ? psFile.getVirtualFile() : null;
+        return psFile != null ? getFile(psFile) : null;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
@@ -31,19 +31,8 @@ import com.redhat.devtools.lsp4ij.internal.SimpleLanguageUtils;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import com.redhat.devtools.lsp4ij.launching.ServerMappingSettings;
 import com.redhat.devtools.lsp4ij.launching.UserDefinedLanguageServerSettings;
-import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
-import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinitionListener;
-import com.redhat.devtools.lsp4ij.server.definition.LanguageServerFileAssociation;
-import com.redhat.devtools.lsp4ij.server.definition.ServerFileNamePatternMapping;
-import com.redhat.devtools.lsp4ij.server.definition.ServerFileTypeMapping;
-import com.redhat.devtools.lsp4ij.server.definition.ServerLanguageMapping;
-import com.redhat.devtools.lsp4ij.server.definition.ServerMapping;
-import com.redhat.devtools.lsp4ij.server.definition.extension.ExtensionLanguageServerDefinition;
-import com.redhat.devtools.lsp4ij.server.definition.extension.FileNamePatternMappingExtensionPointBean;
-import com.redhat.devtools.lsp4ij.server.definition.extension.FileTypeMappingExtensionPointBean;
-import com.redhat.devtools.lsp4ij.server.definition.extension.LanguageMappingExtensionPointBean;
-import com.redhat.devtools.lsp4ij.server.definition.extension.SemanticTokensColorsProviderExtensionPointBean;
-import com.redhat.devtools.lsp4ij.server.definition.extension.ServerExtensionPointBean;
+import com.redhat.devtools.lsp4ij.server.definition.*;
+import com.redhat.devtools.lsp4ij.server.definition.extension.*;
 import com.redhat.devtools.lsp4ij.server.definition.launching.UserDefinedLanguageServerDefinition;
 import com.redhat.devtools.lsp4ij.usages.LSPFindUsagesProvider;
 import org.jetbrains.annotations.ApiStatus;
@@ -286,13 +275,13 @@ public class LanguageServersRegistry {
     /**
      * @param language the language
      * @param fileType the file type.
-     * @param file
+     * @param fileName the file name
      * @return the {@link LanguageServerDefinition}s <strong>directly</strong> associated to the given content-type.
      * This does <strong>not</strong> include the one that match transitively as per content-type hierarchy
      */
-    List<LanguageServerFileAssociation> findLanguageServerDefinitionFor(final @Nullable Language language, @Nullable FileType fileType, @NotNull VirtualFile file) {
+    List<LanguageServerFileAssociation> findLanguageServerDefinitionFor(final @Nullable Language language, @Nullable FileType fileType, @NotNull String fileName) {
         return fileAssociations.stream()
-                .filter(mapping -> mapping.match(language, fileType, file.getName()))
+                .filter(mapping -> mapping.match(language, fileType, fileName))
                 .collect(Collectors.toList());
     }
 
@@ -475,7 +464,7 @@ public class LanguageServersRegistry {
         settings.setMappings(request.mappings());
 
         if (nameChanged || commandChanged || userEnvironmentVariablesChanged || includeSystemEnvironmentVariablesChanged ||
-            mappingsChanged || configurationContentChanged || initializationOptionsContentChanged) {
+                mappingsChanged || configurationContentChanged || initializationOptionsContentChanged) {
             // Notifications
             LanguageServerDefinitionListener.LanguageServerChangedEvent event = new LanguageServerDefinitionListener.LanguageServerChangedEvent(
                     request.project(),
@@ -523,7 +512,9 @@ public class LanguageServersRegistry {
         if (file == null) {
             return false;
         }
-        return isFileSupported(file.getVirtualFile(), file.getProject());
+        Language language = file.getLanguage();
+        FileType fileType = file.getFileType();
+        return isFileSupported(language, fileType, file.getName(), null, file, file.getProject());
     }
 
     /**
@@ -539,15 +530,25 @@ public class LanguageServersRegistry {
         }
         Language language = LSPIJUtils.getFileLanguage(file, project);
         FileType fileType = file.getFileType();
+        return isFileSupported(language, fileType, file.getName(), file, null, project);
+    }
+
+    private boolean isFileSupported(@Nullable Language language,
+                                    @Nullable FileType fileType,
+                                    @NotNull String filename,
+                                    @Nullable VirtualFile file,
+                                    @Nullable PsiFile psiFile,
+                                    @NotNull Project project) {
         if (fileAssociations
                 .stream()
-                .anyMatch(mapping -> mapping.match(language, fileType, file.getName()))) {
-            if (!file.isInLocalFileSystem()) {
-                if (file instanceof LightVirtualFile) {
+                .anyMatch(mapping -> mapping.match(language, fileType, filename))) {
+            VirtualFile f = file != null ? file : psiFile.getVirtualFile();
+            if (!f.isInLocalFileSystem()) {
+                if (f instanceof LightVirtualFile) {
                     return false;
                 }
-                PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
-                if (psiFile != null && !psiFile.isPhysical()) {
+                PsiFile pf = psiFile != null ? psiFile : LSPIJUtils.getPsiFile(file, project);
+                if (pf != null && !pf.isPhysical()) {
                     return false;
                 }
             }

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServiceAccessor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServiceAccessor.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager;
@@ -153,11 +154,13 @@ public class LanguageServiceAccessor implements Disposable {
                                                           @NotNull Project project) {
         VirtualFile[] files = FileEditorManager.getInstance(project).getOpenFiles();
         for (VirtualFile file : files) {
-            sendDidOpenAndRefreshEditorFeatureFor(file, serverDefinition);
+            // TODO : revisit that
+            PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+            sendDidOpenAndRefreshEditorFeatureFor(psiFile, serverDefinition);
         }
     }
 
-    private void sendDidOpenAndRefreshEditorFeatureFor(@NotNull VirtualFile file,
+    private void sendDidOpenAndRefreshEditorFeatureFor(@NotNull PsiFile file,
                                                        @NotNull LanguageServerDefinition serverDefinition) {
         ReadAction.nonBlocking(() -> {
                     // Try to send a textDocument/didOpen notification if the file is associated to the language server definition
@@ -185,13 +188,13 @@ public class LanguageServiceAccessor implements Disposable {
      * @param filter the filter.
      * @return true if the given file matches one of started language server with the given filter and false otherwise.
      */
-    public boolean hasAny(@NotNull VirtualFile file,
+    public boolean hasAny(@NotNull PsiFile file,
                           @NotNull Predicate<LanguageServerWrapper> filter) {
         var startedServers = getStartedServers();
         if (startedServers.isEmpty()) {
             return false;
         }
-        MatchedLanguageServerDefinitions mappings = getMatchedLanguageServerDefinitions(file, project, true);
+        MatchedLanguageServerDefinitions mappings = getMatchedLanguageServerDefinitions(file, true);
         if (mappings == MatchedLanguageServerDefinitions.NO_MATCH) {
             return false;
         }
@@ -243,19 +246,19 @@ public class LanguageServiceAccessor implements Disposable {
     }
 
     @NotNull
-    public CompletableFuture<@NotNull List<LanguageServerItem>> getLanguageServers(@NotNull VirtualFile file,
+    public CompletableFuture<@NotNull List<LanguageServerItem>> getLanguageServers(@NotNull PsiFile file,
                                                                                    @Nullable Predicate<LSPClientFeatures> beforeStartingServerFilter,
                                                                                    @Nullable Predicate<LSPClientFeatures> afterStartingServerFilter) {
         return getLanguageServers(file, beforeStartingServerFilter, afterStartingServerFilter, null);
     }
 
     @NotNull
-    CompletableFuture<@NotNull List<LanguageServerItem>> getLanguageServers(@NotNull VirtualFile file,
+    CompletableFuture<@NotNull List<LanguageServerItem>> getLanguageServers(@NotNull PsiFile psiFile,
                                                                             @Nullable Predicate<LSPClientFeatures> beforeStartingServerFilter,
                                                                             @Nullable Predicate<LSPClientFeatures> afterStartingServerFilter,
                                                                             @Nullable LanguageServerDefinition matchServerDefinition) {
         // Collect started (or not) language servers which matches the given file.
-        CompletableFuture<Collection<LanguageServerWrapper>> matchedServers = getMatchedLanguageServersWrappers(file, matchServerDefinition, beforeStartingServerFilter);
+        CompletableFuture<Collection<LanguageServerWrapper>> matchedServers = getMatchedLanguageServersWrappers(psiFile, matchServerDefinition, beforeStartingServerFilter);
         var matchedServersNow= matchedServers.getNow(Collections.emptyList());
         if (matchedServers.isDone() && matchedServersNow.isEmpty()) {
             // None language servers matches the given file
@@ -269,7 +272,8 @@ public class LanguageServiceAccessor implements Disposable {
         // LSP document listener to manage didOpen, didChange, etc.
         boolean writeAccessAllowed = ApplicationManager.getApplication().isWriteAccessAllowed();
         boolean readAccessAllowed = ApplicationManager.getApplication().isReadAccessAllowed();
-        Document document = readAccessAllowed || (!writeAccessAllowed) ? LSPIJUtils.getDocument(file) : null;
+        Document document = readAccessAllowed || (!writeAccessAllowed) ? LSPIJUtils.getDocument(psiFile) : null;
+        var file = psiFile.getVirtualFile();
 
         // Try to get document, languageId information (used by didOpen) for each matched language server wrapper
         // since here we should be in Read Action allowed
@@ -356,10 +360,10 @@ public class LanguageServiceAccessor implements Disposable {
 
     @NotNull
     private CompletableFuture<Collection<LanguageServerWrapper>> getMatchedLanguageServersWrappers(
-            @NotNull VirtualFile file,
+            @NotNull PsiFile file,
             @Nullable LanguageServerDefinition matchServerDefinition,
             @Nullable Predicate<LSPClientFeatures> beforeStartingServerFilter) {
-        MatchedLanguageServerDefinitions mappings = getMatchedLanguageServerDefinitions(file, project, false);
+        MatchedLanguageServerDefinitions mappings = getMatchedLanguageServerDefinitions(file, false);
         if (mappings == MatchedLanguageServerDefinitions.NO_MATCH) {
             // There are no mapping for the given file
             return CompletableFuture.completedFuture(Collections.emptyList());
@@ -393,12 +397,12 @@ public class LanguageServiceAccessor implements Disposable {
     /**
      * Get or create a language server wrapper for the given server definitions and add then to the given  matched servers.
      *
-     * @param file                       the file.
+     * @param psiFile                       the file.
      * @param serverDefinitions          the server definitions.
      * @param matchedServers             the list to update with get/created language server.
      * @param beforeStartingServerFilter
      */
-    private void collectLanguageServersFromDefinition(@Nullable VirtualFile file,
+    private void collectLanguageServersFromDefinition(@Nullable PsiFile psiFile,
                                                       @NotNull Set<LanguageServerDefinition> serverDefinitions,
                                                       @NotNull Set<LanguageServerWrapper> matchedServers,
                                                       @Nullable Predicate<LSPClientFeatures> beforeStartingServerFilter) {
@@ -408,7 +412,7 @@ public class LanguageServiceAccessor implements Disposable {
                 // Loop for started language servers
                 for (var startedServer : startedServers) {
                     if (startedServer.getServerDefinition().equals(serverDefinition)
-                            && (file == null || startedServer.canOperate(file))
+                            && (psiFile == null || startedServer.canOperate(psiFile.getVirtualFile()))
                             && (beforeStartingServerFilter == null || beforeStartingServerFilter.test(startedServer.getClientFeatures()))) {
                         // A started language server match the file, use it
                         matchedServers.add(startedServer);
@@ -466,26 +470,25 @@ public class LanguageServiceAccessor implements Disposable {
     /**
      * Returns the matched language server definitions for the given file.
      *
-     * @param file        the file.
-     * @param fileProject the file project.
+     * @param psiFile        the file.
      * @param ignoreMatch true if {@link DocumentMatcher} must be ignored when mapping matches the given file and false otherwise.
      * @return the matched language server definitions for the given file.
      */
-    private MatchedLanguageServerDefinitions getMatchedLanguageServerDefinitions(@NotNull VirtualFile file,
-                                                                                 @NotNull Project fileProject,
+    private MatchedLanguageServerDefinitions getMatchedLanguageServerDefinitions(@NotNull PsiFile psiFile,
                                                                                  boolean ignoreMatch) {
 
+        var file = psiFile.getVirtualFile();
         Set<LanguageServerDefinition> syncMatchedDefinitions = null;
         Set<LanguageServerFileAssociation> asyncMatchedDefinitions = null;
 
         // look for running language servers via content-type
         Queue<Object> languages = new LinkedList<>();
         Set<Object> processedContentTypes = new HashSet<>();
-        Language language = LSPIJUtils.getFileLanguage(file, project);
+        Language language = psiFile.getLanguage();
         if (language != null) {
             languages.add(language);
         }
-        FileType fileType = file.getFileType();
+        FileType fileType = psiFile.getFileType();
         languages.add(fileType);
 
         while (!languages.isEmpty()) {
@@ -502,7 +505,7 @@ public class LanguageServiceAccessor implements Disposable {
             }
             // Loop for server/language mapping
             for (LanguageServerFileAssociation mapping : LanguageServersRegistry.getInstance()
-                    .findLanguageServerDefinitionFor(currentLanguage, currentFileType, file)) {
+                    .findLanguageServerDefinitionFor(currentLanguage, currentFileType, file.getName())) {
                 if (mapping == null || !mapping.isEnabled(project) || (syncMatchedDefinitions != null && syncMatchedDefinitions.contains(mapping.getServerDefinition()))) {
                     // the mapping is disabled
                     // or the server definition has been already added
@@ -514,7 +517,7 @@ public class LanguageServiceAccessor implements Disposable {
                     }
                     syncMatchedDefinitions.add(mapping.getServerDefinition());
                 } else {
-                    if (mapping.shouldBeMatchedAsynchronously(fileProject)) {
+                    if (mapping.shouldBeMatchedAsynchronously(project)) {
                         // Async mapping
                         // Mapping must be done asynchronously because the match of DocumentMatcher of the mapping need to be done asynchronously
                         // This usecase comes from for instance when custom match need to collect classes from the Java project and requires read only action.
@@ -524,7 +527,7 @@ public class LanguageServiceAccessor implements Disposable {
                         asyncMatchedDefinitions.add(mapping);
                     } else {
                         // Sync mapping
-                        if (match(file, fileProject, mapping)) {
+                        if (match(file, project, mapping)) {
                             if (syncMatchedDefinitions == null) {
                                 syncMatchedDefinitions = new HashSet<>();
                             }
@@ -543,7 +546,7 @@ public class LanguageServiceAccessor implements Disposable {
                 async = CompletableFuture.allOf(asyncMatchedDefinitions
                                 .stream()
                                 .map(mapping -> mapping
-                                        .matchAsync(file, fileProject)
+                                        .matchAsync(file, project)
                                         .thenApply(result -> {
                                             if (result) {
                                                 serverDefinitions.add(mapping.getServerDefinition());

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/EditorBehaviorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/EditorBehaviorFeature.java
@@ -121,7 +121,7 @@ public class EditorBehaviorFeature {
      */
     public static boolean enableStringLiteralImprovements(@NotNull PsiFile file) {
         return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
-                file.getVirtualFile(),
+                file,
                 ls -> ls.getClientFeatures().getEditorBehaviorFeature().isEnableStringLiteralImprovements(file)
         );
     }
@@ -135,7 +135,7 @@ public class EditorBehaviorFeature {
      */
     public static boolean enableStatementTerminatorImprovements(@NotNull PsiFile file) {
         return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
-                file.getVirtualFile(),
+                file,
                 ls -> ls.getClientFeatures().getEditorBehaviorFeature().isEnableStatementTerminatorImprovements(file)
         );
     }
@@ -149,7 +149,7 @@ public class EditorBehaviorFeature {
      */
     public static boolean enableEnterBetweenBracesFix(@NotNull PsiFile file) {
         return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
-                file.getVirtualFile(),
+                file,
                 ls -> ls.getClientFeatures().getEditorBehaviorFeature().isEnableEnterBetweenBracesFix(file)
         );
     }
@@ -164,7 +164,7 @@ public class EditorBehaviorFeature {
      */
     public static boolean enableTextMateNestedBracesImprovements(@NotNull PsiFile file) {
         return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
-                file.getVirtualFile(),
+                file,
                 ls -> ls.getClientFeatures().getEditorBehaviorFeature().isEnableTextMateNestedBracesImprovements(file)
         );
     }
@@ -177,7 +177,7 @@ public class EditorBehaviorFeature {
      */
     public static boolean enableSemanticTokensFileViewProvider(@NotNull PsiFile file) {
         return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
-                file.getVirtualFile(),
+                file,
                 ls -> ls.getClientFeatures().getEditorBehaviorFeature().isEnableSemanticTokensFileViewProvider(file)
         );
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/indexing/ProjectIndexingStrategyBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/indexing/ProjectIndexingStrategyBase.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.client.indexing;
 
 import com.intellij.openapi.project.Project;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureManager;
 import com.redhat.devtools.lsp4ij.internal.editor.EditorFeatureType;
@@ -96,10 +97,10 @@ public abstract class ProjectIndexingStrategyBase {
             while (!manager.filesToRefresh.isEmpty()) {
                 var files = new HashSet<>(manager.filesToRefresh);
                 for (var file : files) {
-
+                    var psiFile = LSPIJUtils.getPsiFile(file, manager.project);
                     // Try to send a textDocument/didOpen notification if the file is associated to the language server definition
                     LanguageServiceAccessor.getInstance(manager.project)
-                            .getLanguageServers(file, null, null)
+                            .getLanguageServers(psiFile, null, null)
                             .thenAccept(servers -> {
                                 // textDocument/didOpen notification has been sent
                                 if (servers.isEmpty()) {
@@ -109,7 +110,7 @@ public abstract class ProjectIndexingStrategyBase {
                                 // Refresh all features (code vision, inlay hints, folding,etc)
                                 // of editors which edit the current file.
                                 EditorFeatureManager.getInstance(manager.project)
-                                        .refreshEditorFeature(file, EditorFeatureType.ALL, true);
+                                        .refreshEditorFeature(psiFile, EditorFeatureType.ALL, true);
 
                             });
                 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPDocumentFeatureSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPDocumentFeatureSupport.java
@@ -80,7 +80,7 @@ public abstract class AbstractLSPDocumentFeatureSupport<Params, Result> extends 
                                                                   @Nullable Predicate<LSPClientFeatures> beforeStartingServerFilter,
                                                                   @Nullable Predicate<LSPClientFeatures> afterStartingServerFilter) {
         return LanguageServiceAccessor.getInstance(file.getProject())
-                .getLanguageServers(file.getVirtualFile(),
+                .getLanguageServers(file,
                         beforeStartingServerFilter,
                         afterStartingServerFilter);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPGoToAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/AbstractLSPGoToAction.java
@@ -129,7 +129,7 @@ public abstract class AbstractLSPGoToAction extends AnAction {
         }
         // Check if the file can support the feature
         return LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> canSupportFeature(ls.getClientFeatures(), file));
+                .hasAny(file, ls -> canSupportFeature(ls.getClientFeatures(), file));
     }
 
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/UnresolvedCodeLensViewportContext.java
@@ -97,7 +97,7 @@ public class UnresolvedCodeLensViewportContext implements Disposable {
                 // The viewport hasn't changed (no scrolling occurred) there are some codelens to resolve and file has not changed
                 // , so we proceed to refresh
                 EditorFeatureManager.getInstance(editor.getProject()).
-                        refreshEditorFeature(file.getVirtualFile(), EditorFeatureType.CODE_VISION, false);
+                        refreshEditorFeature(file, EditorFeatureType.CODE_VISION, false);
             }
         }, VIEWPORT_CHANGE_DELAY_MS);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionTriggerTypedHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionTriggerTypedHandler.java
@@ -62,14 +62,14 @@ public class LSPCompletionTriggerTypedHandler extends TypedHandlerDelegate {
     @ApiStatus.Internal
     public static boolean hasLanguageServerSupportingCompletionTriggerCharacters(char charTyped, Project project, PsiFile file) {
         return LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures()
+                .hasAny(file, ls -> ls.getClientFeatures()
                         .getCompletionFeature()
                         .isCompletionTriggerCharactersSupported(file, String.valueOf(charTyped)));
     }
 
     private static boolean hasLanguageServerSupportingSignatureTriggerCharacters(char charTyped, Project project, PsiFile file) {
         return LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures()
+                .hasAny(file, ls -> ls.getClientFeatures()
                                 .getSignatureHelpFeature()
                                 .isSignatureTriggerCharactersSupported(file, String.valueOf(charTyped)));
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPBreadcrumbsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPBreadcrumbsProvider.java
@@ -19,7 +19,6 @@ import com.intellij.lang.Language;
 import com.intellij.lang.LanguageUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Conditions;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider;
@@ -30,7 +29,7 @@ import com.redhat.devtools.lsp4ij.features.documentSymbol.LSPDocumentSymbolStruc
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.Icon;
+import javax.swing.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,9 +50,8 @@ public class LSPBreadcrumbsProvider implements BreadcrumbsProvider {
     private boolean isSupported(@NotNull PsiElement element) {
         Project project = element.getProject();
         PsiFile file = element.getContainingFile();
-        VirtualFile virtualFile = file.getVirtualFile();
         return LanguageServiceAccessor.getInstance(project).hasAny(
-                virtualFile,
+                file,
                 // The breadcrumbs feature must be enabled and supported for the file's language server
                 ls -> ls.getClientFeatures().getBreadcrumbsFeature().isEnabled(file) &&
                         ls.getClientFeatures().getBreadcrumbsFeature().isSupported(file)

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractLSPFormattingService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractLSPFormattingService.java
@@ -115,7 +115,7 @@ public abstract class AbstractLSPFormattingService extends AsyncDocumentFormatti
         }
         Project project = file.getProject();
         return LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> canSupportFormatting(ls, file));
+                .hasAny(file, ls -> canSupportFormatting(ls, file));
     }
 
     private boolean canSupportFormatting(LanguageServerWrapper ls, PsiFile file) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPClientSideOnTypeFormattingTypedHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPClientSideOnTypeFormattingTypedHandler.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.util.containers.ContainerUtil;
@@ -131,10 +130,8 @@ public class LSPClientSideOnTypeFormattingTypedHandler extends TypedHandlerDeleg
             return null;
         }
         Project project = file.getProject();
-        VirtualFile virtualFile = file.getVirtualFile();
-
         CompletableFuture<@NotNull List<LanguageServerItem>> future = LanguageServiceAccessor.getInstance(project)
-                .getLanguageServers(virtualFile,
+                .getLanguageServers(file,
                 // Client-side on-type formatting shouldn't trigger a language server to start
                 f -> f.getFormattingFeature().isEnabled(file),
                 f -> f.getFormattingFeature().isFormattingSupported(file)
@@ -335,7 +332,7 @@ public class LSPClientSideOnTypeFormattingTypedHandler extends TypedHandlerDeleg
 
     private static boolean hasLanguageServerSupportingOnlyFormatting(@NotNull PsiFile file) {
         return LanguageServiceAccessor.getInstance(file.getProject())
-                .hasAny(file.getVirtualFile(), ls -> {
+                .hasAny(file, ls -> {
                     var clientFeatures = ls.getClientFeatures();
                     return clientFeatures.getFormattingFeature().isEnabled(file) &&
                             clientFeatures.getFormattingFeature().isSupported(file) &&

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPEditorImprovementsTypedHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPEditorImprovementsTypedHandler.java
@@ -97,7 +97,7 @@ public class LSPEditorImprovementsTypedHandler extends TypedHandlerDelegate {
 
     private static boolean isStatementTerminatorCharacter(@NotNull PsiFile file, char charTyped) {
         return LanguageServiceAccessor.getInstance(file.getProject()).hasAny(
-                file.getVirtualFile(),
+                file,
                 ls -> ls.getClientFeatures().getStatementTerminatorCharacters(file).indexOf(charTyped) > -1
         );
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPServerSideOnTypeFormattingHelper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPServerSideOnTypeFormattingHelper.java
@@ -109,7 +109,7 @@ final class LSPServerSideOnTypeFormattingHelper {
 
     private static boolean hasLanguageServerSupportingOnTypeFormatting(@NotNull PsiFile file) {
         return LanguageServiceAccessor.getInstance(file.getProject())
-                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures()
+                .hasAny(file, ls -> ls.getClientFeatures()
                         .getOnTypeFormattingFeature()
                         .isSupported(file));
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/refactoring/LSPRenamePsiElementProcessor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/refactoring/LSPRenamePsiElementProcessor.java
@@ -76,7 +76,7 @@ public class LSPRenamePsiElementProcessor extends RenamePsiElementProcessor {
         CancellationSupport cancellationSupport = new CancellationSupport();
         var willRenameFilesFuture =
                 LanguageServiceAccessor.getInstance(project)
-                        .getLanguageServers(file.getVirtualFile(),
+                        .getLanguageServers(file,
                                 null,
                                 f -> f.getRenameFeature().isWillRenameFilesSupported(file))
                         .thenComposeAsync(languageServerItems -> {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/rename/LSPRenameHandler.java
@@ -181,7 +181,7 @@ public class LSPRenameHandler implements RenameHandler, TitledHandler {
         // At this step we consider that language servers are started, we just wait for 200ms
         // to avoid freezing the UI
         if (LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures().getRenameFeature().isRenameSupported(file))) {
+                .hasAny(file, ls -> ls.getClientFeatures().getRenameFeature().isRenameSupported(file))) {
             // There is at least one language server providing rename support for the file.
             try {
                 searchingRenameHandlers = true;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPExtendWordSelectionHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPExtendWordSelectionHandler.java
@@ -14,11 +14,9 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.containers.ContainerUtil;
-import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,12 +42,11 @@ public class LSPExtendWordSelectionHandler extends AbstractLSPExtendWordSelectio
         // These should all be safely non-null now
         Project project = element.getProject();
         PsiFile file = element.getContainingFile();
-        VirtualFile virtualFile = LSPIJUtils.getFile(element);
 
         // Only if textDocument/selectionRange is supported for the file
         //noinspection DataFlowIssue
         return LanguageServiceAccessor.getInstance(project)
-                .hasAny(virtualFile, ls -> ls.getClientFeatures().getSelectionRangeFeature().isSelectionRangeSupported(file));
+                .hasAny(file, ls -> ls.getClientFeatures().getSelectionRangeFeature().isSelectionRangeSupported(file));
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
@@ -79,7 +79,7 @@ public class LSPWorkspaceImplementationsSearch extends QueryExecutorBase<PsiElem
 
         // Check if the file can support the feature
         if (!LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures().getImplementationFeature().isImplementationSupported(file))) {
+                .hasAny(file, ls -> ls.getClientFeatures().getImplementationFeature().isImplementationSupported(file))) {
             return;
         }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceTypeDeclarationProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceTypeDeclarationProvider.java
@@ -30,7 +30,6 @@ import com.redhat.devtools.lsp4ij.features.typeDefinition.LSPTypeDefinitionParam
 import com.redhat.devtools.lsp4ij.features.typeDefinition.LSPTypeDefinitionSupport;
 import com.redhat.devtools.lsp4ij.ui.LSP4IJUiUtils;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
-import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -84,7 +83,7 @@ public class LSPWorkspaceTypeDeclarationProvider implements TypeDeclarationPlace
         }
 
         if (!LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures().getTypeDefinitionFeature().isTypeDefinitionSupported(file))) {
+                .hasAny(file, ls -> ls.getClientFeatures().getTypeDefinitionFeature().isTypeDefinitionSupported(file))) {
             return null;
         }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPExternalReferencesFinder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPExternalReferencesFinder.java
@@ -105,7 +105,7 @@ public final class LSPExternalReferencesFinder {
         // Determine whether or not to search/match in a case-sensitive manner based on client configuration
         Project project = file.getProject();
         boolean caseSensitive = LanguageServiceAccessor.getInstance(project)
-                .hasAny(file.getVirtualFile(), ls -> ls.getClientFeatures().isCaseSensitive(file));
+                .hasAny(file, ls -> ls.getClientFeatures().isCaseSensitive(file));
 
         if (progressIndicator != null) {
             progressIndicator.setText("Finding usages of '" + wordText + "'");

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
@@ -65,14 +65,9 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
                 return;
             }
 
-            VirtualFile virtualFile = file.getVirtualFile();
-            if (virtualFile == null) {
-                return;
-            }
-
             Project project = element.getProject();
             if (!LanguageServiceAccessor.getInstance(project).hasAny(
-                    virtualFile,
+                    file,
                     l -> l.getClientFeatures().getUsageFeature().isSupported(file)
             )) {
                 return;

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractTypeScriptEditorImprovementsTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractTypeScriptEditorImprovementsTest.java
@@ -46,7 +46,7 @@ abstract class AbstractTypeScriptEditorImprovementsTest extends LSPCodeInsightFi
             Project project = myFixture.getProject();
             PsiFile file = myFixture.getFile();
             ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderRegistrarTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokensStructurelessFileViewProviderRegistrarTest.java
@@ -15,7 +15,6 @@ import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.fileTypes.impl.AbstractFileType;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
@@ -44,9 +43,8 @@ public class LSPSemanticTokensStructurelessFileViewProviderRegistrarTest extends
         // Initialize the language server
         Project project = cssFile.getProject();
         try {
-            VirtualFile virtualFile = cssFile.getVirtualFile();
             LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(virtualFile, null, null)
+                    .getLanguageServers(cssFile, null, null)
                     .get(5000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPBreadcrumbsProviderFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPBreadcrumbsProviderFixtureTestCase.java
@@ -13,7 +13,6 @@ package com.redhat.devtools.lsp4ij.fixtures;
 
 import com.google.gson.reflect.TypeToken;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.breadcrumbs.BreadcrumbsProvider;
@@ -63,9 +62,8 @@ public abstract class LSPBreadcrumbsProviderFixtureTestCase extends LSPCodeInsig
         List<LanguageServerItem> languageServers = new LinkedList<>();
         try {
             Project project = file.getProject();
-            VirtualFile virtualFile = file.getVirtualFile();
             ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(virtualFile, null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPClientSideOnTypeFormattingFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPClientSideOnTypeFormattingFixtureTestCase.java
@@ -111,7 +111,7 @@ public abstract class LSPClientSideOnTypeFormattingFixtureTestCase extends LSPCo
         List<LanguageServerItem> languageServers = new LinkedList<>();
         try {
             ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCodeBlockProviderFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCodeBlockProviderFixtureTestCase.java
@@ -62,7 +62,7 @@ public abstract class LSPCodeBlockProviderFixtureTestCase extends LSPCodeInsight
         // Initialize the language server
         try {
             LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionClientConfigFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPCompletionClientConfigFixtureTestCase.java
@@ -89,7 +89,7 @@ public abstract class LSPCompletionClientConfigFixtureTestCase extends LSPCodeIn
         List<LanguageServerItem> languageServers = new LinkedList<>();
         try {
             ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFoldingRangeFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFoldingRangeFixtureTestCase.java
@@ -92,7 +92,7 @@ public abstract class LSPFoldingRangeFixtureTestCase extends LSPCodeInsightFixtu
         // Initialize the language server
         try {
             LanguageServiceAccessor.getInstance(file.getProject())
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPFormattingFixtureTestCase.java
@@ -62,7 +62,7 @@ public abstract class LSPFormattingFixtureTestCase extends LSPCodeInsightFixture
         // to avoid having some block when ReadAction#compute is required (ex: call of LSP4IJUtils#getDocument).
         try {
             LanguageServiceAccessor.getInstance(file.getProject())
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPRenameFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPRenameFixtureTestCase.java
@@ -192,7 +192,7 @@ public abstract class LSPRenameFixtureTestCase extends LSPCodeInsightFixtureTest
             // we wait for some ms.
             try {
                 LanguageServiceAccessor.getInstance(file.getProject())
-                        .getLanguageServers(file.getVirtualFile(), null, null)
+                        .getLanguageServers(file, null, null)
                         .get(5000, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionRangeFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionRangeFixtureTestCase.java
@@ -61,7 +61,7 @@ public abstract class LSPSelectionRangeFixtureTestCase extends LSPCodeInsightFix
         // Initialize the language server
         try {
             LanguageServiceAccessor.getInstance(file.getProject())
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionersFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSelectionersFixtureTestCase.java
@@ -72,7 +72,7 @@ public abstract class LSPSelectionersFixtureTestCase extends LSPCodeInsightFixtu
         // Initialize the language server
         try {
             LanguageServiceAccessor.getInstance(file.getProject())
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSemanticTokensFileViewProviderFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPSemanticTokensFileViewProviderFixtureTestCase.java
@@ -13,7 +13,6 @@ package com.redhat.devtools.lsp4ij.fixtures;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiReference;
@@ -183,9 +182,8 @@ public abstract class LSPSemanticTokensFileViewProviderFixtureTestCase extends L
         List<LanguageServerItem> languageServers = new LinkedList<>();
         try {
             Project project = file.getProject();
-            VirtualFile virtualFile = file.getVirtualFile();
             ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(virtualFile, null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             fail(e.getMessage());

--- a/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPServerSideOnTypeFormattingFixtureTestCase.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/fixtures/LSPServerSideOnTypeFormattingFixtureTestCase.java
@@ -91,7 +91,7 @@ public abstract class LSPServerSideOnTypeFormattingFixtureTestCase extends LSPCo
         List<LanguageServerItem> languageServers = new LinkedList<>();
         try {
             ContainerUtil.addAllNotNull(languageServers, LanguageServiceAccessor.getInstance(project)
-                    .getLanguageServers(file.getVirtualFile(), null, null)
+                    .getLanguageServers(file, null, null)
                     .get(5000, TimeUnit.MILLISECONDS));
         } catch (Exception e) {
             fail(e.getMessage());


### PR DESCRIPTION
perf: use PsiFile instead of using VirtualFile

As we have almost access to PsiFile when language servers are collected, this PR uses now PsiFile:

 * it simplifies the code
 * when file language must be collected, it avoids getting a ReadAction which avoid some freeze.

It is a big change, but as LanguageServiceAccessor is marked as internal, nobody should be impacted.