### PR TITLE
fix: "Code | Inspect Code" does not report syntax errors

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/ClosedDocument.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ClosedDocument.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * LSP closed document for a given language server.
+ *
+ * @author Angelo ZERR
+ */
+public class ClosedDocument extends LSPDocumentBase {
+
+    private List<Diagnostic> diagnostics;
+
+    @Override
+    public void updateDiagnostics(@NotNull List<Diagnostic> diagnostics) {
+        this.diagnostics = diagnostics;
+    }
+
+    @Override
+    public Collection<Diagnostic> getDiagnostics() {
+        return diagnostics != null ? diagnostics : Collections.emptyList();
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPDocumentBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPDocumentBase.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij;
+
+import org.eclipse.lsp4j.Diagnostic;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Base class for LSP opened/closed document for a given language server.
+ */
+public abstract class LSPDocumentBase {
+
+    /**
+     * Update the diagnostics
+     *
+     * @param diagnostics the new diagnostics.
+     */
+    public abstract void updateDiagnostics(@NotNull List<Diagnostic> diagnostics);
+
+    /**
+     * Returns the current diagnostics for the file reported by the language server.
+     *
+     * @return the current diagnostics for the file reported by the language server.
+     */
+    public abstract Collection<Diagnostic> getDiagnostics();
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -107,7 +107,7 @@ class LSPFileListener implements FileEditorManagerListener, VirtualFileListener 
         VirtualFile file = event.getFile();
         URI uri = languageServerWrapper.toUri(file);
         if (uri != null) {
-            LSPVirtualFileData documentListener = languageServerWrapper.connectedDocuments.get(uri);
+            OpenedDocument documentListener = languageServerWrapper.openedDocuments.get(uri);
             if (documentListener != null) {
                 // 1. Send a textDocument/didSave for the saved file
                 documentListener.getSynchronizer().documentSaved();

--- a/src/main/java/com/redhat/devtools/lsp4ij/OpenedDocument.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/OpenedDocument.java
@@ -16,15 +16,17 @@ package com.redhat.devtools.lsp4ij;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.features.diagnostics.LSPDiagnosticsForServer;
 import org.eclipse.lsp4j.Diagnostic;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
- * LSP data stored in {@link VirtualFile} which are used by some LSP operations.
+ * LSP opened document for a given language server.
  *
  * @author Angelo ZERR
  */
-public class LSPVirtualFileData {
+public class OpenedDocument extends LSPDocumentBase{
 
     private final VirtualFile file;
 
@@ -32,7 +34,9 @@ public class LSPVirtualFileData {
 
     private final DocumentContentSynchronizer synchronizer;
 
-    public LSPVirtualFileData(LanguageServerItem languageServer, VirtualFile file, DocumentContentSynchronizer synchronizer) {
+    public OpenedDocument(@NotNull LanguageServerItem languageServer,
+                          @NotNull VirtualFile file,
+                          DocumentContentSynchronizer synchronizer) {
         this.file = file;
         this.synchronizer = synchronizer;
         this.diagnosticsForServer = new LSPDiagnosticsForServer(languageServer,file);
@@ -55,7 +59,13 @@ public class LSPVirtualFileData {
         return diagnosticsForServer;
     }
 
-    public void updateDiagnostics(List<Diagnostic> diagnostics) {
+    @Override
+    public void updateDiagnostics(@NotNull List<Diagnostic> diagnostics) {
         diagnosticsForServer.update(diagnostics);
+    }
+
+    @Override
+    public Collection<Diagnostic> getDiagnostics() {
+        return diagnosticsForServer.getDiagnostics();
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -150,7 +150,7 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     }
 
     private void refreshCodeLensForAllOpenedFiles() {
-        for (var fileData : wrapper.getConnectedFiles()) {
+        for (var fileData : wrapper.getOpenedFiles()) {
             VirtualFile file = fileData.getFile();
             EditorFeatureManager.getInstance(getProject())
                     .refreshEditorFeature(file, EditorFeatureType.CODE_VISION, true);
@@ -168,7 +168,7 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     }
 
     private void refreshInlayHintsForAllOpenedFiles() {
-        for (var fileData : wrapper.getConnectedFiles()) {
+        for (var fileData : wrapper.getOpenedFiles()) {
             VirtualFile file = fileData.getFile();
             EditorFeatureManager efm = EditorFeatureManager.getInstance(getProject());
             efm.refreshEditorFeature(file, EditorFeatureType.INLAY_HINT, true);
@@ -189,7 +189,7 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     private void refreshSemanticTokensForAllOpenedFiles() {
         // Received request 'workspace/semanticTokens/refresh
         ReadAction.nonBlocking((Callable<Void>) () -> {
-                    for (var fileData : wrapper.getConnectedFiles()) {
+                    for (var fileData : wrapper.getOpenedFiles()) {
                         VirtualFile file = fileData.getFile();
                         PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
                         if (psiFile != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDiagnosticFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPDiagnosticFeature.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.client.features;
 
 import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.AnnotationBuilder;
 import com.intellij.lang.annotation.AnnotationHolder;
@@ -30,6 +31,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+
+import static com.redhat.devtools.lsp4ij.features.inspection.LSPLocalInspectionTool.ID;
 
 /**
  * LSP diagnostic feature.
@@ -64,10 +67,11 @@ public class LSPDiagnosticFeature extends AbstractLSPDocumentFeature {
 
     /**
      * Create an IntelliJ annotation in the given holder by using given LSP diagnostic and fixes.
+     *
      * @param diagnostic the LSP diagnostic.
-     * @param document the document.
-     * @param fixes the fixes coming from LSP CodeAction.
-     * @param holder the annotation holder where annotation must be registered.
+     * @param document   the document.
+     * @param fixes      the fixes coming from LSP CodeAction.
+     * @param holder     the annotation holder where annotation must be registered.
      */
     public void createAnnotation(@NotNull Diagnostic diagnostic,
                                  @NotNull Document document,
@@ -131,6 +135,20 @@ public class LSPDiagnosticFeature extends AbstractLSPDocumentFeature {
     @Nullable
     public HighlightSeverity getHighlightSeverity(@NotNull Diagnostic diagnostic) {
         return SeverityMapping.toHighlightSeverity(diagnostic.getSeverity());
+    }
+
+    /**
+     * Returns the IntelliJ {@link ProblemHighlightType} from the given diagnostic and null otherwise.
+     *
+     * <p>
+     * If null is returned, the diagnostic will be ignored.
+     * </p>
+     *
+     * @param diagnostic the LSP diagnostic.
+     * @return the IntelliJ {@link ProblemHighlightType} from the given diagnostic and null otherwise.
+     */
+    public ProblemHighlightType getProblemHighlightType(Diagnostic diagnostic) {
+        return SeverityMapping.toProblemHighlightType(diagnostic.getSeverity());
     }
 
     /**
@@ -252,5 +270,29 @@ public class LSPDiagnosticFeature extends AbstractLSPDocumentFeature {
     @Override
     public void setServerCapabilities(@Nullable ServerCapabilities serverCapabilities) {
         // Do nothing
+    }
+
+    /**
+     * Returns true if the local inspection tool is application for the given file and false otherwise.
+     *
+     * @param file       the file which must be inspected.
+     * @param inspection the local inspection tool.
+     * @return true if the local inspection tool is application for the given file and false otherwise.
+     */
+    public boolean isInspectionApplicableFor(@NotNull PsiFile file,
+                                             @NotNull LocalInspectionTool inspection) {
+        return ID.equals(inspection.getID());
+    }
+
+    /**
+     * Returns true if the local inspection tool is application for the given diagnostic and false otherwise.
+     *
+     * @param diagnostic the diagnostic which could be cover by the local inspection tool.
+     * @param inspection the local inspection tool.
+     * @return true if the local inspection tool is application for the given diagnostic and false otherwise.
+     */
+    public boolean isInspectionApplicableFor(@NotNull Diagnostic diagnostic,
+                                             @NotNull LocalInspectionTool inspection) {
+        return true;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticAnnotator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticAnnotator.java
@@ -22,7 +22,7 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
-import com.redhat.devtools.lsp4ij.LSPVirtualFileData;
+import com.redhat.devtools.lsp4ij.OpenedDocument;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPExternalAnnotator;
@@ -72,12 +72,12 @@ public class LSPDiagnosticAnnotator extends AbstractLSPExternalAnnotator<Boolean
         var servers = LanguageServiceAccessor.getInstance(file.getProject())
                 .getStartedServers();
         for (var ls : servers) {
-            LSPVirtualFileData data = ls.getLSPVirtualFileData(fileUri);
+            OpenedDocument data = ls.getOpenedDocument(fileUri);
             if (data != null) {
                 // The file is mapped with the current language server
                 var ds = data.getDiagnosticsForServer();
                 // Loop for LSP diagnostics to transform it to Intellij annotation.
-                for (Diagnostic diagnostic : ds.getDiagnostics()) {
+                for (Diagnostic diagnostic : data.getDiagnostics()) {
                     ProgressManager.checkCanceled();
                     createAnnotation(diagnostic, document, file, ds, holder);
                 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticsForServer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticsForServer.java
@@ -45,12 +45,13 @@ public class LSPDiagnosticsForServer {
 
     private final LanguageServerItem languageServer;
 
-    private final VirtualFile file;
+    private final @Nullable VirtualFile file;
 
     // Map which contains all current diagnostics (as key) and future which load associated quick fixes (as value)
     private Map<Diagnostic, LSPLazyCodeActions> diagnostics;
 
-    public LSPDiagnosticsForServer(LanguageServerItem languageServer, VirtualFile file) {
+    public LSPDiagnosticsForServer(@NotNull LanguageServerItem languageServer,
+                                   @Nullable VirtualFile file) {
         this.languageServer = languageServer;
         this.file = file;
         this.diagnostics = Collections.emptyMap();
@@ -64,12 +65,12 @@ public class LSPDiagnosticsForServer {
      *
      * @param diagnostics the new LSP published diagnosics
      */
-    public void update(List<Diagnostic> diagnostics) {
+    public void update(@NotNull List<Diagnostic> diagnostics) {
         // initialize diagnostics map
         this.diagnostics = toMap(diagnostics, this.diagnostics);
     }
 
-    private Map<Diagnostic, LSPLazyCodeActions> toMap(List<Diagnostic> diagnostics,
+    private Map<Diagnostic, LSPLazyCodeActions> toMap(@NotNull List<Diagnostic> diagnostics,
                                                       Map<Diagnostic, LSPLazyCodeActions> existingDiagnostics) {
         // Collect quick fixes from LSP code action
         Map<Diagnostic, LSPLazyCodeActions> map = new HashMap<>(diagnostics.size());
@@ -99,6 +100,7 @@ public class LSPDiagnosticsForServer {
                 diagnosticsGroupByCoveredRange.add(data);
             }
         }
+
         // Associate each diagnostic with the list of code actions to load for a given range
         for (DiagnosticData data : diagnosticsGroupByCoveredRange) {
             var action = new LSPLazyCodeActions(data.diagnostics(), file, languageServer);
@@ -132,7 +134,7 @@ public class LSPDiagnosticsForServer {
      *
      * @return the current diagnostics for the file reported by the language server.
      */
-    public Set<Diagnostic> getDiagnostics() {
+    public Collection<Diagnostic> getDiagnostics() {
         return diagnostics.keySet();
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/SeverityMapping.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/SeverityMapping.java
@@ -16,6 +16,7 @@ package com.redhat.devtools.lsp4ij.features.diagnostics;
 import com.intellij.codeHighlighting.HighlightDisplayLevel;
 import com.intellij.codeInsight.daemon.HighlightDisplayKey;
 import com.intellij.codeInspection.InspectionProfile;
+import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.HighlightSeverity;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +35,31 @@ public class SeverityMapping {
     }
 
     /**
+     * Maps language server's {@link DiagnosticSeverity} to Intellij's {@link ProblemHighlightType}
+     *
+     * @param severity the {@link DiagnosticSeverity} to map
+     * @return the matching {@link ProblemHighlightType}
+     */
+    public static @NotNull ProblemHighlightType toProblemHighlightType(@Nullable DiagnosticSeverity severity) {
+        if (severity == null) {
+            return ProblemHighlightType.ERROR;
+        }
+        switch (severity) {
+            case Warning:
+                return ProblemHighlightType.WARNING;
+            case Hint:
+            case Information:
+                // Annotation is not shown when ProblemHighlightType.Information severity is used
+                // ProblemHighlightType.WEAK_WARNING is used in this case.
+                return ProblemHighlightType.WEAK_WARNING;
+            default:
+                return ProblemHighlightType.ERROR;
+        }
+    }
+
+    /**
      * Maps language server's {@link DiagnosticSeverity} to Intellij's {@link HighlightSeverity}
+     *
      * @param severity the {@link DiagnosticSeverity} to map
      * @return the matching {@link HighlightSeverity}
      */
@@ -82,11 +107,12 @@ public class SeverityMapping {
 
     /**
      * Returns {@link DiagnosticSeverity} as lower case, or <code>none</code> if severity is <code>null</code>.
+     *
      * @param severity the {@link DiagnosticSeverity} to transform as {@link String}
      * @return {@link DiagnosticSeverity} as lower case, or <code>none</code> if severity is <code>null</code>.
      */
     public static @NotNull String toString(@Nullable DiagnosticSeverity severity) {
-        return (severity == null)? NONE_SEVERITY : severity.name().toLowerCase(Locale.ROOT);
+        return (severity == null) ? NONE_SEVERITY : severity.name().toLowerCase(Locale.ROOT);
     }
 
     public static DiagnosticSeverity getSeverity(String inspectionId, InspectionProfile profile) {
@@ -104,4 +130,5 @@ public class SeverityMapping {
     private static boolean isInspectionEnabled(@NotNull String inspectionId, @NotNull InspectionProfile profile) {
         return profile.isToolEnabled(HighlightDisplayKey.find(inspectionId));
     }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inspection/LSPLocalInspectionTool.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inspection/LSPLocalInspectionTool.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.inspection;
+
+/**
+ * Default LSP local inspection tool which collect LSP doagnostics in
+ *
+ * <ul>
+ *     <li>'Language Servers' group name (tree root)</li>
+ *     <li>'Diagnostics' display name (child root)</li>
+ * </ul>
+ */
+public class LSPLocalInspectionTool extends LSPLocalInspectionToolBase {
+
+    public static final String ID = "LSPLocalInspectionTool";
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inspection/LSPLocalInspectionToolBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inspection/LSPLocalInspectionToolBase.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.inspection;
+
+import com.intellij.codeInspection.InspectionManager;
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPDocumentBase;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
+import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
+import com.redhat.devtools.lsp4ij.features.LSPPsiElement;
+import org.eclipse.lsp4j.Diagnostic;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Base class for LSP inspection tool.
+ */
+public abstract class LSPLocalInspectionToolBase extends LocalInspectionTool {
+
+    @Override
+    public ProblemDescriptor @Nullable [] checkFile(@NotNull PsiFile file, @NotNull InspectionManager manager, boolean isOnTheFly) {
+        if (!acceptFile(file, manager, isOnTheFly)) {
+            return ProblemDescriptor.EMPTY_ARRAY;
+        }
+
+        // Collect started servers which supports this inspection tool.
+        List<LanguageServerWrapper> servers = new ArrayList<>();
+        LanguageServiceAccessor.getInstance(file.getProject())
+                .processLanguageServers(file, ls -> {
+                    var diagnosticFeatures = ls.getClientFeatures().getDiagnosticFeature();
+                    if (diagnosticFeatures.isEnabled(file)
+                            && diagnosticFeatures.isSupported(file)
+                            && diagnosticFeatures.isInspectionApplicableFor(file, this)) {
+                        servers.add(ls);
+                    }
+                });
+        if (servers.isEmpty()) {
+            return ProblemDescriptor.EMPTY_ARRAY;
+        }
+
+        // Several started servers are applicable for this inspection tool
+        URI fileUri = LSPIJUtils.toUri(file);
+        Document document = LSPIJUtils.getDocument(file.getVirtualFile());
+
+        List<ProblemDescriptor> problemDescriptors = new ArrayList<>();
+        // Loop for language server which report diagnostics for the given file
+        for (var ls : servers) {
+            // Get the opened/closed document of the server which hosts the published diagnostics
+            LSPDocumentBase lspDocument = getOpenedOrClosedDocument(ls, fileUri);
+            if (lspDocument != null) {
+                // Loop for LSP diagnostics to transform it to Intellij problem descriptor.
+                for (Diagnostic diagnostic : lspDocument.getDiagnostics()) {
+                    var clientFeatures = ls.getClientFeatures();
+                    var diagnosticFeature = clientFeatures.getDiagnosticFeature();
+                    // check if diagnostic is application for this inspection tool
+                    if (diagnosticFeature.isInspectionApplicableFor(diagnostic, this)) {
+                        ProblemHighlightType problemHighlightType = diagnosticFeature.getProblemHighlightType(diagnostic);
+                        if (problemHighlightType != null) {
+                            // Create the Intellij problem descriptor
+                            String message = diagnosticFeature.getMessage(diagnostic);
+                            PsiElement psiElement = new LSPPsiElement(file, LSPIJUtils.toTextRange(diagnostic.getRange(), document, file, true)) {
+                                @Override
+                                public boolean isPhysical() {
+                                    return true;
+                                }
+                            };
+                            var problemDescriptor = manager.createProblemDescriptor(
+                                    psiElement,
+                                    message,
+                                    false,
+                                    problemHighlightType,
+                                    isOnTheFly
+                            );
+                            problemDescriptors.add(problemDescriptor);
+                        }
+                    }
+                }
+            }
+        }
+        return problemDescriptors.toArray(ProblemDescriptor.EMPTY_ARRAY);
+    }
+
+    private static @Nullable LSPDocumentBase getOpenedOrClosedDocument(LanguageServerWrapper ls, URI fileUri) {
+        var openedDocument = ls.getOpenedDocument(fileUri);
+        if (openedDocument != null) {
+            return openedDocument;
+        }
+        return ls.getClosedDocument(fileUri, false);
+    }
+
+    protected boolean acceptFile(@NotNull PsiFile file,
+                                 @NotNull InspectionManager manager,
+                                 boolean isOnTheFly) {
+        if (isOnTheFly) {
+            return false;
+        }
+        List<PsiFile> files = file.getViewProvider().getAllFiles();
+        if (files.size() > 1 && files.indexOf(file) > 0) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/TextDocumentServerCapabilityRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/TextDocumentServerCapabilityRegistry.java
@@ -58,7 +58,7 @@ public abstract class TextDocumentServerCapabilityRegistry<T extends TextDocumen
         }
         if (editorFeatureType != null) {
             // Refresh codelens, inlay hints, folding, etc according to the register/unregister capability.
-            for (var fileData : clientFeatures.getServerWrapper().getConnectedFiles()) {
+            for (var fileData : clientFeatures.getServerWrapper().getOpenedFiles()) {
                 VirtualFile file = fileData.getFile();
                 EditorFeatureManager.getInstance(clientFeatures.getProject())
                         .refreshEditorFeature(file, editorFeatureType, true);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -277,6 +277,12 @@
                 id="LSPDiagnosticAnnotator"
                 language=""
                 implementationClass="com.redhat.devtools.lsp4ij.features.diagnostics.LSPDiagnosticAnnotator"/>
+        <localInspection id="LSPLocalInspectionTool"
+                         language=""
+                         enabledByDefault="true"
+                         groupName="Language Servers"
+                         displayName="Diagnostics"
+                         implementationClass="com.redhat.devtools.lsp4ij.features.inspection.LSPLocalInspectionTool"/>
 
         <!-- LSP textDocument/completion request support -->
         <typedHandler id="LSPCompletionTriggerTypedHandler"

--- a/src/main/resources/inspectionDescriptions/LSPLocalInspectionTool.html
+++ b/src/main/resources/inspectionDescriptions/LSPLocalInspectionTool.html
@@ -1,0 +1,5 @@
+<html lang="en">
+<body>
+Show <a href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic">LSP Diagnostic</a>.
+</body>
+</html>


### PR DESCRIPTION
"Code | Inspect Code" does not report syntax errors

Fixes #476

With this PR whenyou click on `Inspect Code` hyperlink:

![image](https://github.com/user-attachments/assets/6fd02629-0a03-4159-938d-328a250d3165)

It execute the local inspectionand show LSP result:

![image](https://github.com/user-attachments/assets/4c8bbd0b-e3e2-4123-8117-9cc54d87d8b2)
