### PR TITLE
docs: fix url for angelscript language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Here are some projects that use LSP4IJ:
  * [Clojure LSP Intellij](https://github.com/clojure-lsp/clojure-lsp-intellij)
  * [GroovyScript for IntelliJ](https://github.com/IntegerLimit/GroovyScriptPlugin)
  * [Redscript Intellij](https://github.com/pawrequest/redscript-intellij)
- * [AngelScript Language Server for IntelliJ](https://github.com/pawrequest/redscript-intellij)
+ * [AngelScript Language Server for IntelliJ](https://github.com/sashi0034/angel-intellij)
  * [RobotCode - Robot Framework Support](https://robotcode.io)
  * [IntelliJ-gno](https://github.com/gnoverse/intellij-gno)
 


### PR DESCRIPTION
I’ve just realized that the URL for my language server in my previous pull request (https://github.com/redhat-developer/lsp4ij/pull/875) appears to be incorrect. I sincerely apologize for the mistake.