### PR TITLE
fix: Support `textDocument/diagnostics`

### DIFF
--- a/docs/LSPSupport.md
+++ b/docs/LSPSupport.md
@@ -30,6 +30,7 @@ Current state of [Language Features]( https://microsoft.github.io/language-serve
  * ✅ [textDocument/definition](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_definition) (see [implementation details](#go-to-definition))
  * ✅ [textDocument/documentHighlight](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight) (see [implementation details](#document-highlight))
  * ✅ [textDocument/publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics) (see [implementation details](#publish-diagnostics))
+ * ✅ [textDocument/diagnostic](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics) (see [implementation details](#pull-diagnostics))
  * ✅ [textDocument/documentLink](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentLink) (see [implementation details](#document-link))
  * ❌ [documentLink/resolve](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentLink_resolve).
  * ✅ [textDocument/hover](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover) (see [implementation details](#hover))
@@ -421,6 +422,14 @@ system to trigger these actions.
 Here is an example with the [Qute language server](https://github.com/redhat-developer/quarkus-ls/tree/master/qute.ls) reporting errors:
 
 ![textDocument/publishDiagnostics](./images/lsp-support/textDocument_publishDiagnostics.png)
+
+### Pull Diagnostics
+
+[textDocument/diagnostic](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics) 
+is consumed after a [textDocument/didOpen](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen) and [textDocument/didChange](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange)
+with debounce and refresh the LSP diagnostics  `externalAnnotator`.
+
+It doesn't support the related documents.
 
 ### Code Action
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -108,7 +108,15 @@ that you can select in the left panel via the checkboxes:
 
 ![LSP Semantic Tokens Inspector](./images/LSPSemanticTokensInspector.png)
 
-### Troubleshooting
+## Inspections
+
+You can click on `Inspect Code` hyperlink available on the `Project Errors` from the `Problems` view to 
+show all LSP diagnostics errors of your project:
+
+ - from opened files.
+ - from closed files, if your language server support it. 
+
+## Troubleshooting
 
 If the `Semantic Tokens` doesn't show the expected result, please check that:
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -189,6 +189,7 @@ class LSPFileListener implements FileEditorManagerListener, VirtualFileListener 
             DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams(Arrays.asList(changes));
             ls.getWorkspaceService()
                     .didChangeWatchedFiles(params);
+            return ls;
         });
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPRequestConstants.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPRequestConstants.java
@@ -26,6 +26,7 @@ public class LSPRequestConstants {
 
     public static final String TEXT_DOCUMENT_DECLARATION = "textDocument/declaration";
     public static final String TEXT_DOCUMENT_DEFINITION = "textDocument/definition";
+    public static final String TEXT_DOCUMENT_DIAGNOSTIC = "textDocument/diagnostic";
     public static final String TEXT_DOCUMENT_DOCUMENT_LINK = "textDocument/documentLink";
     public static final String TEXT_DOCUMENT_FOLDING_RANGE = "textDocument/foldingRange";
     public static final String TEXT_DOCUMENT_SELECTION_RANGE = "textDocument/selectionRange";

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
@@ -1432,9 +1432,6 @@ public class LSPClientFeatures implements Disposable, FileUriSupport {
                     getCodeActionFeature().getCodeActionCapabilityRegistry();
             // register 'textDocument/codeLens' capability
             case LSPRequestConstants.TEXT_DOCUMENT_CODE_LENS -> getCodeLensFeature().getCodeLensCapabilityRegistry();
-            // register 'textDocument/documentColor' capability
-            case LSPRequestConstants.TEXT_DOCUMENT_DOCUMENT_COLOR ->
-                    getDocumentColorFeature().getDocumentColorCapabilityRegistry();
             // register 'textDocument/completion' capability
             case LSPRequestConstants.TEXT_DOCUMENT_COMPLETION ->
                     getCompletionFeature().getCompletionCapabilityRegistry();
@@ -1444,6 +1441,12 @@ public class LSPClientFeatures implements Disposable, FileUriSupport {
             // register 'textDocument/definition' capability
             case LSPRequestConstants.TEXT_DOCUMENT_DEFINITION ->
                     getDefinitionFeature().getDefinitionCapabilityRegistry();
+            // register 'textDocument/diagnostic' capability
+            case LSPRequestConstants.TEXT_DOCUMENT_DIAGNOSTIC ->
+                    getDiagnosticFeature().getDiagnosticCapabilityRegistry();
+            // register 'textDocument/documentColor' capability
+            case LSPRequestConstants.TEXT_DOCUMENT_DOCUMENT_COLOR ->
+                    getDocumentColorFeature().getDocumentColorCapabilityRegistry();
             // register 'textDocument/documentHighlight' capability
             case LSPRequestConstants.TEXT_DOCUMENT_DOCUMENT_HIGHLIGHT ->
                     getDocumentHighlightFeature().getDocumentHighlightCapabilityRegistry();

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/refactoring/LSPRefactoringListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/refactoring/LSPRefactoringListener.java
@@ -43,6 +43,7 @@ public class LSPRefactoringListener implements RefactoringEventListener {
                                         RenameFilesParams params = context.params();
                                         ls.getWorkspaceService()
                                                 .didRenameFiles(params);
+                                        return ls;
                                     });
                                 }
                             });

--- a/src/main/java/com/redhat/devtools/lsp4ij/inspections/LSPLocalInspectionTool.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/inspections/LSPLocalInspectionTool.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.lsp4ij.features.inspection;
+package com.redhat.devtools.lsp4ij.inspections;
 
 /**
  * Default LSP local inspection tool which collect LSP doagnostics in

--- a/src/main/java/com/redhat/devtools/lsp4ij/inspections/LSPLocalInspectionToolBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/inspections/LSPLocalInspectionToolBase.java
@@ -11,7 +11,7 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.lsp4ij.features.inspection;
+package com.redhat.devtools.lsp4ij.inspections;
 
 import com.intellij.codeInspection.InspectionManager;
 import com.intellij.codeInspection.LocalInspectionTool;

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/ClientCapabilitiesFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/ClientCapabilitiesFactory.java
@@ -107,7 +107,7 @@ public class ClientCapabilitiesFactory {
     private static @NotNull TextDocumentClientCapabilities getTextDocumentClientCapabilities() {
         final var textDocumentClientCapabilities = new TextDocumentClientCapabilities();
 
-        // Publish diagnostics capabilities
+        // Support for 'textDocument/publishDiagnostics'
         final var publishDiagnosticsCapabilities = new PublishDiagnosticsCapabilities();
         publishDiagnosticsCapabilities.setDataSupport(Boolean.TRUE);
         publishDiagnosticsCapabilities.setCodeDescriptionSupport(Boolean.TRUE);
@@ -115,6 +115,12 @@ public class ClientCapabilitiesFactory {
         DiagnosticsTagSupport tagSupport = new DiagnosticsTagSupport(List.of(DiagnosticTag.Unnecessary, DiagnosticTag.Deprecated));
         publishDiagnosticsCapabilities.setTagSupport(tagSupport);
         textDocumentClientCapabilities.setPublishDiagnostics(publishDiagnosticsCapabilities);
+
+        // Support for 'textDocument/diagnostic'
+        final var diagnosticCapabilities = new DiagnosticCapabilities();
+        diagnosticCapabilities.setDynamicRegistration(Boolean.TRUE);
+        diagnosticCapabilities.setRelatedDocumentSupport(Boolean.FALSE);
+        textDocumentClientCapabilities.setDiagnostic(diagnosticCapabilities);
 
         // Code Action support
         final var codeAction = new CodeActionCapabilities(new CodeActionLiteralSupportCapabilities(

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/DiagnosticCapabilityRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/DiagnosticCapabilityRegistry.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.server.capabilities;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
+import org.eclipse.lsp4j.DiagnosticRegistrationOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Server capability registry for 'textDocument/diagnostic'.
+ */
+public class DiagnosticCapabilityRegistry extends TextDocumentServerCapabilityRegistry<DiagnosticRegistrationOptions> {
+
+    private static final @NotNull Predicate<@NotNull ServerCapabilities> SERVER_CAPABILITIES_PREDICATE = sc ->
+            sc.getDiagnosticProvider() != null;
+
+    public DiagnosticCapabilityRegistry(@NotNull LSPClientFeatures clientFeatures) {
+        super(clientFeatures);
+    }
+
+    class ExtendedDiagnosticRegistrationOptions extends DiagnosticRegistrationOptions implements ExtendedDocumentSelector.DocumentFilersProvider {
+        private transient ExtendedDocumentSelector documentSelector;
+
+        @Override
+        public List<ExtendedDocumentSelector.ExtendedDocumentFilter> getFilters() {
+            if (documentSelector == null) {
+                documentSelector = new ExtendedDocumentSelector(super.getDocumentSelector());
+            }
+            return documentSelector.getFilters();
+        }
+    }
+
+    @Override
+    protected @Nullable DiagnosticRegistrationOptions create(@NotNull JsonObject registerOptions) {
+        return JSONUtils.getLsp4jGson()
+                .fromJson(registerOptions,
+                        ExtendedDiagnosticRegistrationOptions.class);
+    }
+
+    /**
+     * Returns true if the language server can support diagnostic and false otherwise.
+     *
+     * @param file the Psi file.
+     * @return true if the language server can support diagnostic and false otherwise.
+     */
+    public boolean isDiagnosticSupported(@NotNull PsiFile file) {
+        return super.isSupported(file, SERVER_CAPABILITIES_PREDICATE);
+    }
+
+    /**
+     * Returns true if the language server can support diagnostic and false otherwise.
+     *
+     * @param file the Psi file.
+     * @return true if the language server can support diagnostic and false otherwise.
+     */
+    public boolean isDiagnosticSupported(@NotNull VirtualFile file) {
+        return super.isSupported(file, SERVER_CAPABILITIES_PREDICATE);
+    }
+
+    @Override
+    public @Nullable DiagnosticRegistrationOptions registerCapability(@NotNull JsonObject registerOptions) {
+        var options =  super.registerCapability(registerOptions);
+        // Force the pull diagnostic for all opened document
+        // - didOpen have not processed pull diagnostic
+        // - and if language server support it for now if textDocument/diagnostic has been dynamically registered.
+        for (var openedDocument :  getClientFeatures().getServerWrapper().getOpenedDocuments()) {
+            openedDocument.getSynchronizer().forcePullDiagnosticIfNeeded();
+        }
+        return options;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -282,7 +282,7 @@
                          enabledByDefault="true"
                          groupName="Language Servers"
                          displayName="Diagnostics"
-                         implementationClass="com.redhat.devtools.lsp4ij.features.inspection.LSPLocalInspectionTool"/>
+                         implementationClass="com.redhat.devtools.lsp4ij.inspections.LSPLocalInspectionTool"/>
 
         <!-- LSP textDocument/completion request support -->
         <typedHandler id="LSPCompletionTriggerTypedHandler"


### PR DESCRIPTION
fix: Support `textDocument/diagnostics`

Fixes #933