### PR TITLE
feat: Restoring external references search as an opt-in feature that's disabled by default.

### DIFF
--- a/docs/LSPSupport.md
+++ b/docs/LSPSupport.md
@@ -135,6 +135,31 @@ This menu action either opens the reference in a popup or navigates to the refer
 
 [textDocument/references](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_references) is used also via [Find Usages](./UserGuide.md#find-usages) to show references.
 
+#### External References
+
+LSP4IJ supports integration of externally-added references to language server-derived symbols when appropriate. External
+references are those that are added client-side by either the same plugin or by other installed plugins, e.g., in a
+polyglot environment where symbols in one language can be referenced in other languages.
+
+When enabled, this ensures that external references are included in **Find Usages** results and during symbol rename
+operations. This feature is _disabled by default_ but can be enabled for a custom language server implementation by
+overriding `LSPReferencesFeature#processExternalReferences(PsiFile)` to return `true`, or for a user-defined language
+server definition, by setting `references.processExternalReferences` to `true` in client configuration, e.g.:
+
+```json
+{
+  "references": {
+    "processExternalReferences": true
+  }
+}
+```
+
+This feature should **only** be enabled if you are **explicitly** aware of plugins that might be contributing 
+client-side external references to a language server's symbols. Note that enabling this feature will result in a
+textual search, albeit indexed, of the search scope for the symbol name for which references have been requested.
+This can result in longer overall references search times in larger projects and/or where the language server is
+supplementary to first-class IDE language support.  
+
 ### Implementation
 
 The [textDocument/implementation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_implementation) is consumed with:

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPReferencesFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPReferencesFeature.java
@@ -62,5 +62,16 @@ public class LSPReferencesFeature extends AbstractLSPDocumentFeature {
             referencesCapabilityRegistry.setServerCapabilities(serverCapabilities);
         }
     }
-    
+
+    /**
+     * Determines whether or not client-side external references should be processed for LSP4IJ symbols in the
+     * specified file.
+     *
+     * @param file the file
+     * @return true if client-side external references should be processed; otherwise false
+     */
+    public boolean processExternalReferences(@NotNull PsiFile file) {
+        // Default to disabled
+        return false;
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
@@ -168,6 +168,16 @@ public class ClientConfigurationSettings {
     }
 
     /**
+     * Client-side references settings.
+     */
+    public static class ClientConfigurationReferencesSettings {
+        /**
+         * Whether or not client-side external references should be processed.
+         */
+        public boolean processExternalReferences = false;
+    }
+
+    /**
      * Client-side workspace symbol settings.
      */
     public static class ClientConfigurationWorkspaceSymbolSettings {
@@ -221,6 +231,11 @@ public class ClientConfigurationSettings {
      * Client-side format settings.
      */
     public @NotNull ClientConfigurationFormatSettings format = new ClientConfigurationFormatSettings();
+
+    /**
+     * Client-side references settings.
+     */
+    public @NotNull ClientConfigurationReferencesSettings references = new ClientConfigurationReferencesSettings();
 
     /**
      * Client-side workspace symbol settings.

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedClientFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedClientFeatures.java
@@ -30,6 +30,7 @@ public class UserDefinedClientFeatures extends LSPClientFeatures {
         // Use the extended feature implementations
         setCompletionFeature(new UserDefinedCompletionFeature());
         setFormattingFeature(new UserDefinedFormattingFeature());
+        setReferencesFeature(new UserDefinedReferencesFeature());
         setWorkspaceSymbolFeature(new UserDefinedWorkspaceSymbolFeature());
         setBreadcrumbsFeature(new UserDefinedBreadcrumbsFeature());
         setEditorBehaviorFeature(new UserDefinedEditorBehaviorFeature(this));

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedReferencesFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedReferencesFeature.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package com.redhat.devtools.lsp4ij.server.definition.launching;
+
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.client.features.LSPReferencesFeature;
+import com.redhat.devtools.lsp4ij.server.definition.ClientConfigurableLanguageServerDefinition;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Adds client-side references configuration features.
+ */
+public class UserDefinedReferencesFeature extends LSPReferencesFeature {
+
+    @Override
+    public boolean processExternalReferences(@NotNull PsiFile file) {
+        ClientConfigurableLanguageServerDefinition serverDefinition = (ClientConfigurableLanguageServerDefinition) getClientFeatures().getServerDefinition();
+        ClientConfigurationSettings clientConfiguration = serverDefinition.getLanguageServerClientConfiguration();
+        return clientConfiguration != null ? clientConfiguration.references.processExternalReferences : super.processExternalReferences(file);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPExternalReferencesFinder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPExternalReferencesFinder.java
@@ -70,22 +70,29 @@ public final class LSPExternalReferencesFinder {
                                                  int offset,
                                                  @NotNull SearchScope searchScope,
                                                  @NotNull Processor<PsiReference> processor) {
-        VirtualFile virtualFile = file.getVirtualFile();
-        if (virtualFile != null) {
-            Document document = LSPIJUtils.getDocument(virtualFile);
-            TextRange wordTextRange = document != null ? LSPIJUtils.getWordRangeAt(document, file, offset) : null;
-            if (wordTextRange != null) {
-                LSPPsiElement wordElement = new LSPPsiElement(file, wordTextRange);
-                String wordText = wordElement.getText();
-                if (StringUtil.isNotEmpty(wordText)) {
-                    processExternalReferences(
-                            file,
-                            wordText,
-                            wordTextRange,
-                            searchScope,
-                            ProgressManager.getInstance().getProgressIndicator(),
-                            processor
-                    );
+        // Only if enabled by at least one of the file's language servers
+        Project project = file.getProject();
+        if (LanguageServiceAccessor.getInstance(project).hasAny(
+                file,
+                ls -> ls.getClientFeatures().getReferencesFeature().processExternalReferences(file)
+        )) {
+            VirtualFile virtualFile = file.getVirtualFile();
+            if (virtualFile != null) {
+                Document document = LSPIJUtils.getDocument(virtualFile);
+                TextRange wordTextRange = document != null ? LSPIJUtils.getWordRangeAt(document, file, offset) : null;
+                if (wordTextRange != null) {
+                    LSPPsiElement wordElement = new LSPPsiElement(file, wordTextRange);
+                    String wordText = wordElement.getText();
+                    if (StringUtil.isNotEmpty(wordText)) {
+                        processExternalReferences(
+                                file,
+                                wordText,
+                                wordTextRange,
+                                searchScope,
+                                ProgressManager.getInstance().getProgressIndicator(),
+                                processor
+                        );
+                    }
                 }
             }
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
@@ -140,16 +140,13 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
                 LOGGER.error("Error while collection LSP Usages", e);
             }
 
-            // TODO : as this external reference process can be very slow (for our IJ Quarkus);
-            // the call of processExternalReferences is commented.
-            //  Reactivate it just for some language servers (by using an lsp client featurees)
             // For completeness' sake, also collect external usages to LSP (pseudo-)elements
-            /*LSPExternalReferencesFinder.processExternalReferences(
+            LSPExternalReferencesFinder.processExternalReferences(
                     file,
                     element.getTextOffset(),
                     searchScope,
                     reference -> processor.process(new UsageInfo2UsageAdapter(new UsageInfo(reference)))
-            );*/
+            );
         });
     }
 

--- a/src/main/resources/jsonSchema/clientSettings.schema.json
+++ b/src/main/resources/jsonSchema/clientSettings.schema.json
@@ -192,6 +192,19 @@
         }
       }
     },
+    "references": {
+      "type": "object",
+      "title": "Client-side references configuration",
+      "additionalProperties": false,
+      "properties": {
+        "processExternalReferences": {
+          "type": "boolean",
+          "title": "Process external references",
+          "description": "Whether or not client-side external references should be processed for symbols from this language server.",
+          "default": false
+        }
+      }
+    },
     "workspaceSymbol": {
       "type": "object",
       "title": "Client-side workspace symbol configuration",


### PR DESCRIPTION
Hopefully this one should be quite straightforward, but I'll add a few comments in the PR itself.

Here's an example of **Find Usages** with the feature flag disabled per its default setting:

![image](https://github.com/user-attachments/assets/160cf174-7ea3-4d86-93e8-3d90a4cac979)

and here it is explicitly enabled via client config picking up an external reference to TypeScript in an HTML file:

![image](https://github.com/user-attachments/assets/6c34e44f-5b3e-48b4-b2ba-d6d272b8176b)