### PR TITLE
perf: too many call of DaemonCodeAnalyzer.getInstance(project).restart(file)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/ClosedDocument.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ClosedDocument.java
@@ -30,8 +30,11 @@ public class ClosedDocument extends LSPDocumentBase {
     private List<Diagnostic> diagnostics;
 
     @Override
-    public void updateDiagnostics(@NotNull List<Diagnostic> diagnostics) {
+    public boolean updateDiagnostics(@NotNull List<Diagnostic> diagnostics) {
+        boolean changed = isDiagnosticsChanged(this.diagnostics != null ? this.diagnostics : Collections.emptyList(), diagnostics);
         this.diagnostics = diagnostics;
+        return changed;
+
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPDocumentBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPDocumentBase.java
@@ -29,7 +29,7 @@ public abstract class LSPDocumentBase {
      *
      * @param diagnostics the new diagnostics.
      */
-    public abstract void updateDiagnostics(@NotNull List<Diagnostic> diagnostics);
+    public abstract boolean updateDiagnostics(@NotNull List<Diagnostic> diagnostics);
 
     /**
      * Returns the current diagnostics for the file reported by the language server.
@@ -37,4 +37,24 @@ public abstract class LSPDocumentBase {
      * @return the current diagnostics for the file reported by the language server.
      */
     public abstract Collection<Diagnostic> getDiagnostics();
+
+    /**
+     * Returns true if the old and new diagnostics list changed and false otherwise.
+     * @param oldDiagnostics old diagnostics
+     * @param newDiagnostics new diagnostics
+     * @return true if the old and new diagnostics list changed and false otherwise.
+     */
+    public static boolean isDiagnosticsChanged(@NotNull Collection<Diagnostic> oldDiagnostics,
+                                               @NotNull Collection<Diagnostic> newDiagnostics) {
+        if (oldDiagnostics.size() != newDiagnostics.size()) {
+            return true;
+        }
+        for(var d : newDiagnostics) {
+            if (!oldDiagnostics.contains(d)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/OpenedDocument.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/OpenedDocument.java
@@ -14,29 +14,36 @@
 package com.redhat.devtools.lsp4ij;
 
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.Alarm;
 import com.redhat.devtools.lsp4ij.features.diagnostics.LSPDiagnosticsForServer;
 import org.eclipse.lsp4j.Diagnostic;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 
 /**
  * LSP opened document for a given language server.
  *
  * @author Angelo ZERR
  */
-public class OpenedDocument extends LSPDocumentBase{
+public class OpenedDocument extends LSPDocumentBase {
+
+    private volatile Alarm refreshDiagnosticsAlarm = null;
 
     private final VirtualFile file;
 
     private final LSPDiagnosticsForServer diagnosticsForServer;
 
     private final DocumentContentSynchronizer synchronizer;
+    private long updatedDiagnosticsTime; // time when diagnostics has been updated
+    private long displayingDiagnosticsTime; // time when diagnostics has been displayed with the LSPDiagnosticAnnotator.
 
     public OpenedDocument(@NotNull LanguageServerItem languageServer,
                           @NotNull VirtualFile file,
-                          DocumentContentSynchronizer synchronizer) {
+                          @NotNull DocumentContentSynchronizer synchronizer) {
         this.file = file;
         this.synchronizer = synchronizer;
         this.diagnosticsForServer = new LSPDiagnosticsForServer(languageServer,file);
@@ -60,12 +67,43 @@ public class OpenedDocument extends LSPDocumentBase{
     }
 
     @Override
-    public void updateDiagnostics(@NotNull List<Diagnostic> diagnostics) {
-        diagnosticsForServer.update(diagnostics);
+    public boolean updateDiagnostics(@NotNull List<Diagnostic> diagnostics) {
+        updatedDiagnosticsTime = System.currentTimeMillis();
+        if (diagnosticsForServer.update(diagnostics)) {
+            // LSP diagnostics has changed
+            final PsiFile psiFile = LSPIJUtils.getPsiFile(file, diagnosticsForServer.getClientFeatures().getProject());
+            if (psiFile != null) {
+                // Trigger Intellij validation to execute
+                // {@link LSPDiagnosticAnnotator}.
+                // which translates LSP Diagnostics into Intellij Annotation
+                final long currentDisplayingDiagnosticsTime = getDisplayingDiagnosticsTime();
+                LSPFileSupport.getSupport(psiFile).restartDaemonCodeAnalyzerWithDebounce(() -> {
+                    if (!isDiagnosticsMustBeRefreshed(currentDisplayingDiagnosticsTime)) {
+                        throw new CancellationException();
+                    }
+                });
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override
     public Collection<Diagnostic> getDiagnostics() {
         return diagnosticsForServer.getDiagnostics();
+    }
+
+    public void markAsDisplayingDiagnostics() {
+        displayingDiagnosticsTime = System.currentTimeMillis();
+    }
+
+    boolean isDiagnosticsMustBeRefreshed(long displayingDiagnosticsTime) {
+        long lastDisplayingDiagnosticsTime = getDisplayingDiagnosticsTime();
+        return displayingDiagnosticsTime !=  lastDisplayingDiagnosticsTime// is diagnostics are already displayed with LSPDiagnosticAnnotator ?
+                || updatedDiagnosticsTime < lastDisplayingDiagnosticsTime; // is update of diagnostics has been done after the last display of diagnostics
+    }
+
+    long getDisplayingDiagnosticsTime() {
+        return displayingDiagnosticsTime;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -11,7 +11,6 @@
 package com.redhat.devtools.lsp4ij.client;
 
 import com.google.gson.JsonObject;
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.command.WriteCommandAction;
@@ -193,10 +192,11 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
                         VirtualFile file = openedDocument.getFile();
                         PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
                         if (psiFile != null) {
+                            var fileSupport = LSPFileSupport.getSupport(psiFile);
                             // Evict the semantic tokens cache
-                            LSPFileSupport.getSupport(psiFile).getSemanticTokensSupport().cancel();
+                            fileSupport.getSemanticTokensSupport().cancel();
                             // Refresh the UI
-                            DaemonCodeAnalyzer.getInstance(psiFile.getProject()).restart(psiFile);
+                            fileSupport.restartDaemonCodeAnalyzerWithDebounce();
                         }
                     }
                     return null;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensEditorFactoryListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensEditorFactoryListener.java
@@ -86,7 +86,7 @@ public class LSPCodeLensEditorFactoryListener implements EditorFactoryListener {
             }
 
             // Get valid LSP codelens future.
-            var resultFuture = codeLensSupport.getValidLSPFuture();
+            var resultFuture = codeLensSupport.getFuture();
             if (resultFuture != null && resultFuture.isDone()) {
                 var result = resultFuture.getNow(null);
                 if (result == null || !result.hasToResolve(context.getFirstViewportLine(), context.getLastViewportLine())) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticsForServer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticsForServer.java
@@ -16,6 +16,7 @@ package com.redhat.devtools.lsp4ij.features.diagnostics;
 import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPDocumentBase;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
@@ -61,13 +62,16 @@ public class LSPDiagnosticsForServer {
         return languageServer.getClientFeatures();
     }
     /**
-     * Update the new LSP published diagnosics.
+     * Update the new LSP published diagnostics.
      *
-     * @param diagnostics the new LSP published diagnosics
+     * @param diagnostics the new LSP published diagnostics
      */
-    public void update(@NotNull List<Diagnostic> diagnostics) {
+    public boolean update(@NotNull List<Diagnostic> diagnostics) {
+        Collection<Diagnostic> oldDiagnostic = this.diagnostics != null ? this.diagnostics.keySet() : Collections.emptySet();
+        boolean changed = LSPDocumentBase.isDiagnosticsChanged(oldDiagnostic, diagnostics);
         // initialize diagnostics map
         this.diagnostics = toMap(diagnostics, this.diagnostics);
+        return changed;
     }
 
     private Map<Diagnostic, LSPLazyCodeActions> toMap(@NotNull List<Diagnostic> diagnostics,

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPBreadcrumbsRefreshListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPBreadcrumbsRefreshListener.java
@@ -14,7 +14,6 @@
 
 package com.redhat.devtools.lsp4ij.features.documentSymbol;
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -26,6 +25,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.ui.components.breadcrumbs.Crumb;
 import com.intellij.xml.breadcrumbs.BreadcrumbListener;
 import com.intellij.xml.breadcrumbs.BreadcrumbsPanel;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
 import com.redhat.devtools.lsp4ij.ServerStatus;
@@ -109,7 +109,7 @@ public class LSPBreadcrumbsRefreshListener implements ProjectActivity, LanguageS
                 file.putUserData(NEEDS_RESTART, false);
                 // We must force the modification stamp to increment or sticky lines won't be recomputed
                 file.clearCaches();
-                ApplicationManager.getApplication().invokeLater(() -> DaemonCodeAnalyzer.getInstance(file.getProject()).restart(file));
+                ApplicationManager.getApplication().invokeLater(() -> LSPFileSupport.getSupport(file).restartDaemonCodeAnalyzerWithDebounce());
             }
         }
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
@@ -107,11 +107,9 @@ public class LSPSemanticTokensHighlightVisitor implements HighlightVisitor {
         CompletableFuture<SemanticTokensData> semanticTokensFuture = semanticTokensSupport.getSemanticTokens(params);
         try {
             waitUntilDone(semanticTokensFuture, file);
-        } catch (
-                PsiFileChangedException e) {
-            //TODO delete block when minimum required version is 2024.2
+        } catch (PsiFileChangedException e) {
             semanticTokensSupport.cancel();
-            throw e;
+            return null;
         } catch (CancellationException e) {
             // cancel the LSP requests textDocument/semanticTokens/full
             //semanticTokensSupport.cancel();

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/DeclarativeInlayHintsEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/DeclarativeInlayHintsEditorFeature.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.internal.editor;
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.codeInsight.hints.declarative.impl.DeclarativeInlayHintsPassFactory;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -49,7 +48,7 @@ public class DeclarativeInlayHintsEditorFeature implements EditorFeature {
                                   @NotNull List<Runnable> runnableList) {
         Runnable runnable = () -> {
             // Refresh the annotations, inlay hints both
-            DaemonCodeAnalyzer.getInstance(file.getProject()).restart(file);
+            LSPFileSupport.getSupport(file).restartDaemonCodeAnalyzerWithDebounce();
         };
         runnableList.add(runnable);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
@@ -12,7 +12,6 @@
 package com.redhat.devtools.lsp4ij.internal.editor;
 
 import com.google.common.collect.Sets;
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.ReadAction;
@@ -22,6 +21,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.concurrency.AppExecutorUtil;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -137,7 +137,7 @@ public class EditorFeatureManager implements Disposable {
                         // No opened editors associated from any language servers.
                         return;
                     }
-                    DaemonCodeAnalyzer.getInstance(project).restart(context.file());
+                    LSPFileSupport.getSupport(context.file()).restartDaemonCodeAnalyzerWithDebounce();
                     for (var runnable : context.runnables()) {
                         runnable.run();
                     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/InlayHintsEditorFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/InlayHintsEditorFeature.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.internal.editor;
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
@@ -90,7 +89,7 @@ public class InlayHintsEditorFeature implements EditorFeature {
                                   @NotNull List<Runnable> runnableList) {
         Runnable runnable = () -> {
             // Refresh the annotations, inlay hints both
-            DaemonCodeAnalyzer.getInstance(file.getProject()).restart(file);
+        	LSPFileSupport.getSupport(file).restartDaemonCodeAnalyzerWithDebounce();
         };
         runnableList.add(runnable);
     }


### PR DESCRIPTION
As soon as there is a publish/pull diagnostics, `DaemonCodeAnalyzer.getInstance(project).restart(file)` to refresh LSPDiagnosticAnnotator is called which can is bad for performance.

Most of the time, I noticed that LSPDiagnosticAnnotator is refreshed (if publish / pull diagnostic are fast) without having to call 
`DaemonCodeAnalyzer.getInstance(project).restart(file)`.

This PR avoids if possible to call `DaemonCodeAnalyzer.getInstance(project).restart(file)` by following those strategies:

 * if publish diagnostic doesn't change (ex: you are typing a lot of spaces in the same line), `DaemonCodeAnalyzer.getInstance(project).restart(file)`  is never called.
 *  debounce this call and cancel the call if the LSPDiagnosicAnnotator has already displayed the diagnostic
 *  use this debounce (which uses an Alarm and cancel the preview refresh) that Iare used for other LSP features like when we refresh breadcrumb, codevision, inlay hint, folding