### PR TITLE
fix: Integrate fixes from forked (Huly Code) LSP4IJ (null checking)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
@@ -54,8 +54,7 @@ public class DocumentContentSynchronizer implements DocumentListener, Disposable
 
     private int version = 0;
     private final List<TextDocumentContentChangeEvent> changeEvents;
-    @NotNull
-    private CompletableFuture<LanguageServer> didOpenFuture;
+    private @Nullable CompletableFuture<LanguageServer> didOpenFuture;
 
     private volatile Alarm debouncePullDiagnosticsAlarm = null;
     private boolean diagnosticNotPulledOnDidOpen;

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -631,7 +631,7 @@ public class LSPIJUtils {
             return null;
         }
         VirtualFile documentFile = findResourceFor(documentUri.toASCIIString());
-        return getDocument(documentFile);
+        return documentFile != null ? getDocument(documentFile) : null;
     }
 
     @Nullable

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElement.java
@@ -52,7 +52,7 @@ public class LSPPsiElement extends FakePsiElement {
         return file;
     }
 
-    @Nullable
+    @NotNull
     @Override
     public TextRange getTextRange() {
         return textRange;
@@ -92,8 +92,8 @@ public class LSPPsiElement extends FakePsiElement {
         return this;
     }
 
-    @NotNull
-    public char[] textToCharArray() {
+    @Override
+    public char @NotNull [] textToCharArray() {
         return getName().toCharArray();
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElementFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/LSPPsiElementFactory.java
@@ -130,6 +130,9 @@ public interface LSPPsiElementFactory<T extends LSPPsiElement> {
             return null;
         }
         PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+        if (psiFile == null) {
+            return null;
+        }
         TextRange textRange = LSPIJUtils.toTextRange(range, document, psiFile,true);
         if (textRange == null) {
             return null;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeBlockProvider/LSPCodeBlockProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeBlockProvider/LSPCodeBlockProvider.java
@@ -72,7 +72,7 @@ public class LSPCodeBlockProvider implements CodeBlockProvider {
             openBraceOffset = offset - 1;
             openBraceChar = documentChars.charAt(offset - 1);
             closeBraceChar = LSPIJEditorUtils.getCloseBraceCharacter(file, openBraceChar);
-        } else if (LSPIJEditorUtils.isCloseBraceCharacter(file, documentChars.charAt(offset))) {
+        } else if ((offset < documentLength) && LSPIJEditorUtils.isCloseBraceCharacter(file, documentChars.charAt(offset))) {
             closeBraceOffset = offset;
             closeBraceChar = documentChars.charAt(offset);
             openBraceChar = LSPIJEditorUtils.getOpenBraceCharacter(file, closeBraceChar);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/CodeLensData.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/CodeLensData.java
@@ -13,7 +13,6 @@ package com.redhat.devtools.lsp4ij.features.codeLens;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import org.eclipse.lsp4j.CodeLens;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -24,13 +23,13 @@ public class CodeLensData {
 
     private @NotNull CodeLens codeLens;
     private final @NotNull LanguageServerItem languageServer;
-    private @Nullable boolean toResolve;
+    private boolean toResolve;
     private CompletableFuture<CodeLens> resolveCodeLensFuture;
     private CodeLensDataResult result;
 
     public CodeLensData(@NotNull CodeLens codeLens,
                         @NotNull LanguageServerItem languageServer,
-                        @Nullable boolean toResolve) {
+                        boolean toResolve) {
         this.codeLens = codeLens;
         this.languageServer = languageServer;
         this.toResolve = toResolve;
@@ -44,7 +43,7 @@ public class CodeLensData {
         return languageServer;
     }
 
-    public @Nullable boolean isToResolve() {
+    public boolean isToResolve() {
         return toResolve;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
@@ -177,7 +177,9 @@ public class LSPCodeLensProvider implements CodeVisionProvider<Void> {
                                 CodeVisionEntry entry = codeLensFeature.createCodeVisionEntry(codeLens, providerId, context);
                                 if (entry != null) {
                                     TextRange textRange = LSPIJUtils.toTextRange(codeLens.getRange(), editor.getDocument(), null, true);
-                                    result.add(new Pair<>(textRange, entry));
+                                    if (textRange != null) {
+                                        result.add(new Pair<>(textRange, entry));
+                                    }
                                 }
                             }
                         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionProposalTools.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/CompletionProposalTools.java
@@ -92,10 +92,12 @@ public final class CompletionProposalTools {
                 return indentOptions;
             }
         }
-        Language language = provider.getBaseLanguage();
-        CommonCodeStyleSettings.IndentOptions indentOptions = settings.getLanguageIndentOptions(language);
-        if (indentOptions != null) {
-            return indentOptions;
+        if (provider != null) {
+            Language language = provider.getBaseLanguage();
+            CommonCodeStyleSettings.IndentOptions indentOptions = settings.getLanguageIndentOptions(language);
+            if (indentOptions != null) {
+                return indentOptions;
+            }
         }
         return settings.getIndentOptions();
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
@@ -21,7 +21,6 @@ import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
-import org.eclipse.lsp4j.Location;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,9 +45,9 @@ public class LSPGoToDeclarationAction extends AbstractLSPGoToAction {
 
     @Override
     protected CompletableFuture<List<LocationData>> getLocations(@NotNull PsiFile psiFile,
-                                                             @NotNull Document document,
-                                                             @NotNull Editor editor,
-                                                             int offset) {
+                                                                 @NotNull Document document,
+                                                                 @NotNull Editor editor,
+                                                                 int offset) {
         LSPDeclarationSupport declarationSupport = LSPFileSupport.getSupport(psiFile).getDeclarationSupport();
         var params = new LSPDeclarationParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> declarationsFuture = declarationSupport.getDeclarations(params);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticAnnotator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/diagnostics/LSPDiagnosticAnnotator.java
@@ -78,7 +78,9 @@ public class LSPDiagnosticAnnotator extends AbstractLSPExternalAnnotator<Boolean
         }
         URI fileUri = LSPIJUtils.toUri(file);
         Document document = LSPIJUtils.getDocument(file.getVirtualFile());
-
+        if (document == null) {
+            return;
+        }
         // Loop for language server which report diagnostics for the given file
         var servers = LanguageServiceAccessor.getInstance(file.getProject())
                 .getStartedServers();
@@ -98,7 +100,7 @@ public class LSPDiagnosticAnnotator extends AbstractLSPExternalAnnotator<Boolean
 
     private static void createAnnotation(@NotNull Diagnostic diagnostic,
                                          @NotNull Document document,
-                                         @Nullable PsiFile file,
+                                         @NotNull PsiFile file,
                                          @NotNull LSPDiagnosticsForServer diagnosticsForServer,
                                          @NotNull AnnotationHolder holder) {
         var clientFeatures = diagnosticsForServer.getClientFeatures();

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkAnnotator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkAnnotator.java
@@ -93,11 +93,14 @@ public class LSPDocumentLinkAnnotator extends AbstractLSPExternalAnnotator<List<
     }
 
     @Override
-    public void doApply(@NotNull PsiFile file, @NotNull List<DocumentLinkData> documentLinks, @NotNull AnnotationHolder holder) {
-        if (documentLinks.isEmpty()) {
+    public void doApply(@NotNull PsiFile file, @Nullable List<DocumentLinkData> documentLinks, @NotNull AnnotationHolder holder) {
+        if (documentLinks == null || documentLinks.isEmpty()) {
             return;
         }
         Document document = LSPIJUtils.getDocument(file.getVirtualFile());
+        if (document == null) {
+            return;
+        }
         for (var documentLink : documentLinks) {
             TextRange range = LSPIJUtils.toTextRange(documentLink.documentLink().getRange(), document);
             if (range != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
@@ -50,6 +50,9 @@ public class LSPDocumentLinkGotoDeclarationHandler implements GotoDeclarationHan
 
     @Override
     public PsiElement @Nullable [] getGotoDeclarationTargets(@Nullable PsiElement sourceElement, int offset, Editor editor) {
+        if (sourceElement == null) {
+            return PsiElement.EMPTY_ARRAY;
+        }
         PsiFile psiFile = sourceElement.getContainingFile();
         if (!LanguageServersRegistry.getInstance().isFileSupported(psiFile)) {
             return PsiElement.EMPTY_ARRAY;
@@ -87,7 +90,7 @@ public class LSPDocumentLinkGotoDeclarationHandler implements GotoDeclarationHan
                 for (DocumentLinkData documentLinkData : documentLinks) {
                     DocumentLink documentLink = documentLinkData.documentLink();
                     TextRange range = LSPIJUtils.toTextRange(documentLink.getRange(), document);
-                    if (range.contains(offset)) {
+                    if (range != null && range.contains(offset)) {
                         // The Ctrl+Click has been done in a LSP document link,try to open the document.
                         final String target = documentLink.getTarget();
                         if (target != null && !target.isEmpty()) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractLSPFormattingService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/AbstractLSPFormattingService.java
@@ -79,7 +79,9 @@ public abstract class AbstractLSPFormattingService extends AsyncDocumentFormatti
             Editor[] editors = LSPIJUtils.editorsForFile(psiFile.getVirtualFile(), psiFile.getProject());
             Editor editor = editors.length > 0 ? editors[0] : null;
             Document document = editor != null ? editor.getDocument() : LSPIJUtils.getDocument(psiFile.getVirtualFile());
-            formattingSupport.format(document, editor, formattingRange, formattingRequest);
+            if (document != null) {
+                formattingSupport.format(document, editor, formattingRange, formattingRequest);
+            }
         }
 
         @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingParams.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingParams.java
@@ -12,6 +12,7 @@ package com.redhat.devtools.lsp4ij.features.formatting;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -22,6 +23,6 @@ import org.jetbrains.annotations.Nullable;
  * @param textRange the text range and null otherwise.
  * @param document the document.
  */
-public record LSPFormattingParams(@Nullable Integer tabSize, @Nullable Boolean insertSpaces, @Nullable TextRange textRange, @Nullable Document document) {
+public record LSPFormattingParams(@Nullable Integer tabSize, @Nullable Boolean insertSpaces, @Nullable TextRange textRange, @NotNull Document document) {
 
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
@@ -86,7 +86,7 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
             // Ignore the error
             formattingRequest.onTextReady(formattingRequest.getDocumentText());
         } else {
-            formattingRequest.onError("LSP formatting error", error.getMessage() != null ? error.getMessage() :  error.getClass().getName());
+            formattingRequest.onError("LSP formatting error", error.getMessage() != null ? error.getMessage() : error.getClass().getName());
         }
     }
 
@@ -169,7 +169,8 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
     private @NotNull DocumentRangeFormattingParams createDocumentRangeFormattingParams(@Nullable Integer tabSize,
                                                                                        @Nullable Boolean insertSpaces,
                                                                                        @NotNull TextRange textRange,
-                                                                                       @NotNull Document document, LanguageServerItem languageServer) {
+                                                                                       @NotNull Document document,
+                                                                                       @NotNull LanguageServerItem languageServer) {
         DocumentRangeFormattingParams params = new DocumentRangeFormattingParams();
         params.setTextDocument(new TextDocumentIdentifier(FileUriSupport.getFileUri(getFile().getVirtualFile(), languageServer.getClientFeatures()).toASCIIString()));
         FormattingOptions options = new FormattingOptions();
@@ -180,10 +181,8 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
             options.setInsertSpaces(insertSpaces);
         }
         params.setOptions(options);
-        if (document != null) {
-            Range range = LSPIJUtils.toRange(textRange, document);
-            params.setRange(range);
-        }
+        Range range = LSPIJUtils.toRange(textRange, document);
+        params.setRange(range);
         return params;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyItemPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyItemPsiElement.java
@@ -29,7 +29,7 @@ public class LSPHierarchyItemPsiElement extends LSPPsiElement {
     private static final TextRange DUMMY_TEXT_RANGE = new TextRange(0,0);
     private final @Nullable Range range;
 
-    public LSPHierarchyItemPsiElement(@Nullable PsiFile file,
+    public LSPHierarchyItemPsiElement(@NotNull PsiFile file,
                                       @Nullable Range range,
                                       @NotNull String name) {
         super(file, DUMMY_TEXT_RANGE);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyNodeDescriptor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyNodeDescriptor.java
@@ -89,12 +89,16 @@ public abstract class LSPHierarchyNodeDescriptor<T> extends HierarchyNodeDescrip
 
     @Override
     public boolean canNavigate() {
-        return getPsiElement().getContainingFile() != null;
+        var element = getPsiElement();
+        return element != null && element.getContainingFile() != null;
     }
 
     @Override
     public void navigate(boolean requestFocus) {
         PsiElement element = getPsiElement();
+        if (element == null) {
+            return;
+        }
         VirtualFile file = element.getContainingFile().getVirtualFile();
         Range range = null;
         if(element instanceof LSPHierarchyItemPsiElement lspElement) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyProviderBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyProviderBase.java
@@ -47,7 +47,7 @@ public abstract class LSPHierarchyProviderBase implements HierarchyProvider {
             return null;
         }
 
-        if (ProjectIndexingManager.getInstance(project).isIndexingAll()) {
+        if (ProjectIndexingManager.isIndexingAll()) {
             return null;
         }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/hierarchy/LSPHierarchyTreeStructureBase.java
@@ -51,19 +51,21 @@ public abstract class LSPHierarchyTreeStructureBase<T> extends HierarchyTreeStru
         final List<LSPHierarchyNodeDescriptor> descriptors = new ArrayList<>();
         if (descriptor instanceof LSPHierarchyNodeDescriptor lspDescriptor) {
             final PsiElement element = lspDescriptor.getPsiElement();
-            PsiFile psiFile = element.getContainingFile();
-            if (lspDescriptor.isBase()) {
-                // fill with:
-                // - prepareCallHierarchy
-                // - prepareTypeHierarchy
-                int offset = element.getTextRange().getStartOffset();
-                Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());
-                buildRoot(lspDescriptor, psiFile, document, offset, descriptors);
-            } else {
-                // fill with:
-                // - callHierarchy/incomingCalls / callHierarchy/outgoingCalls
-                // - typeHierarchy/subtypes / typeHierarchy/supertypes
-                buildChildren(lspDescriptor, psiFile, (T) lspDescriptor.getHierarchyItem(), descriptors);
+            if (element != null) {
+                PsiFile psiFile = element.getContainingFile();
+                if (lspDescriptor.isBase()) {
+                    // fill with:
+                    // - prepareCallHierarchy
+                    // - prepareTypeHierarchy
+                    int offset = element.getTextRange().getStartOffset();
+                    Document document = LSPIJUtils.getDocument(psiFile.getVirtualFile());
+                    buildRoot(lspDescriptor, psiFile, document, offset, descriptors);
+                } else {
+                    // fill with:
+                    // - callHierarchy/incomingCalls / callHierarchy/outgoingCalls
+                    // - typeHierarchy/subtypes / typeHierarchy/supertypes
+                    buildChildren(lspDescriptor, psiFile, (T) lspDescriptor.getHierarchyItem(), descriptors);
+                }
             }
         }
         return ArrayUtil.toObjectArray(descriptors);
@@ -74,6 +76,9 @@ public abstract class LSPHierarchyTreeStructureBase<T> extends HierarchyTreeStru
                                           @Nullable Range range,
                                           @NotNull String name,
                                           @Nullable FileUriSupport fileUriSupport) {
+        if (uri == null) {
+            return null;
+        }
         VirtualFile file = FileUriSupport.findFileByUri(uri, fileUriSupport);
         if (file == null) {
             return null;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightPsiElement.java
@@ -34,7 +34,7 @@ public class LSPHighlightPsiElement extends LSPPsiElement {
         this.kind = kind;
     }
 
-    public DocumentHighlightKind getKind() {
+    public @NotNull DocumentHighlightKind getKind() {
         return kind;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
@@ -44,7 +44,10 @@ public class LSPGoToImplementationAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<LocationData>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
+    protected CompletableFuture<List<LocationData>> getLocations(@NotNull PsiFile psiFile,
+                                                                 @NotNull Document document,
+                                                                 @NotNull Editor editor,
+                                                                 int offset) {
         LSPImplementationSupport implementationSupport = LSPFileSupport.getSupport(psiFile).getImplementationSupport();
         var params = new LSPImplementationParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> implementationsFuture = implementationSupport.getImplementations(params);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/refactoring/LSPRenamePsiElementProcessor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/refactoring/LSPRenamePsiElementProcessor.java
@@ -151,16 +151,23 @@ public class LSPRenamePsiElementProcessor extends RenamePsiElementProcessor {
                                             @Nullable FileUriSupport fileUriSupport,
                                             @NotNull Project project) {
         VirtualFile file = FileUriSupport.findFileByUri(uri, fileUriSupport);
-        if (file != null) {
-            Document document = LSPIJUtils.getDocument(file);
-            PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
-            textEdits
-                    .forEach(textEdit -> {
-                        TextRange textRange = LSPIJUtils.toTextRange(textEdit.getRange(), document);
-                        var elt = new LSPRenamePsiElement(psiFile, textRange, textEdit);
-                        allRenames.put(elt, textEdit.getNewText());
-                    });
+        if (file == null) {
+            return;
         }
+        Document document = LSPIJUtils.getDocument(file);
+        if (document == null) {
+            return;
+        }
+        PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+        if (psiFile == null) {
+            return;
+        }
+        textEdits
+                .forEach(textEdit -> {
+                    TextRange textRange = LSPIJUtils.toTextRange(textEdit.getRange(), document);
+                    var elt = new LSPRenamePsiElement(psiFile, textRange, textEdit);
+                    allRenames.put(elt, textEdit.getNewText());
+                });
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
@@ -44,7 +44,10 @@ public class LSPGoToReferenceAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<LocationData>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
+    protected CompletableFuture<List<LocationData>> getLocations(@NotNull PsiFile psiFile,
+                                                                 @NotNull Document document,
+                                                                 @NotNull Editor editor,
+                                                                 int offset) {
         LSPReferenceSupport referenceSupport = LSPFileSupport.getSupport(psiFile).getReferenceSupport();
         var params = new LSPReferenceParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> referencesFuture = referenceSupport.getReferences(params);

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
@@ -44,7 +44,10 @@ public class LSPGoToTypeDefinitionAction extends AbstractLSPGoToAction {
     }
 
     @Override
-    protected CompletableFuture<List<LocationData>> getLocations(PsiFile psiFile, Document document, Editor editor, int offset) {
+    protected CompletableFuture<List<LocationData>> getLocations(@NotNull PsiFile psiFile,
+                                                                 @NotNull Document document,
+                                                                 @NotNull Editor editor,
+                                                                 int offset) {
         LSPTypeDefinitionSupport typeDefinitionSupport = LSPFileSupport.getSupport(psiFile).getTypeDefinitionSupport();
         var params = new LSPTypeDefinitionParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> typeDefinitionsFuture = typeDefinitionSupport.getTypeDefinitions(params);

--- a/src/main/java/com/redhat/devtools/lsp4ij/hint/LSPNavigationLinkHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/hint/LSPNavigationLinkHandler.java
@@ -41,7 +41,11 @@ public class LSPNavigationLinkHandler extends TooltipLinkHandler {
     @Override
     public boolean handleLink(@NotNull String fileUrl,
                               @NotNull Editor editor) {
-        return LSPIJUtils.openInEditor(fileUrl, null, true, true, null, editor.getProject());
+        var project = editor.getProject();
+        if (project == null) {
+            return false;
+        }
+        return LSPIJUtils.openInEditor(fileUrl, null, true, true, null, project);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSupport.java
@@ -170,8 +170,9 @@ public class LSPUsageSupport extends AbstractLSPDocumentFeatureSupport<LSPUsageS
     }
 
     private static BiFunction<? super List<? extends Location>, Throwable, ? extends List<LSPUsagePsiElement>> reportUsages2(
-            LanguageServerItem ls, Project project,
-            LSPUsagePsiElement.UsageKind usageKind) {
+            @NotNull LanguageServerItem ls,
+            @NotNull Project project,
+            @NotNull LSPUsagePsiElement.UsageKind usageKind) {
         return (locations, error) -> {
             if (error != null) {
                 return Collections.emptyList();
@@ -182,7 +183,8 @@ public class LSPUsageSupport extends AbstractLSPDocumentFeatureSupport<LSPUsageS
 
     @NotNull
     private static BiFunction<Either<List<? extends Location>, List<? extends LocationLink>>, Throwable, List<LSPUsagePsiElement>> reportUsages(
-            LanguageServerItem ls, @NotNull Project project,
+            @NotNull LanguageServerItem ls,
+            @NotNull Project project,
             @NotNull LSPUsagePsiElement.UsageKind usageKind) {
         return (locations, error) -> {
             if (error != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsagesManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsagesManager.java
@@ -73,6 +73,9 @@ public class LSPUsagesManager {
             default: {
                 // Open locations in a Popup
                 @Nullable Editor editor = dataContext.getData(CommonDataKeys.EDITOR);
+                if (editor == null) {
+                    return;
+                }
                 LocationData ref = locations.get(0);
                 LSPUsageTriggeredPsiElement element = toUsageTriggeredPsiElement(ref.location(), ref.languageServer().getClientFeatures(), project);
                 if (element != null) {


### PR DESCRIPTION
fix: Integrate fixes from forked (Huly Code) LSP4IJ (null checking)

See #959

This PR fixes Nullable annotations and some potential NullPointerException based on the Huly-Code fork of LSP4IJ