### PR TITLE
fix: Default TextMate enter-between-braces behavior test expectation fixes for 2024.1+

### DIFF
--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptCustomLanguageServerEditorImprovementsTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptCustomLanguageServerEditorImprovementsTest.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.testFramework.EditorTestUtil;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 
 /**
  * These verify that editor improvements are disabled by default in custom (i.e., non-user-defined) language servers.
@@ -124,13 +125,23 @@ public class TypeScriptCustomLanguageServerEditorImprovementsTest extends Abstra
         int bracketsOffset = fileBody.indexOf("[]") + 1;
         caretModel.moveToOffset(bracketsOffset);
         EditorTestUtil.performTypingAction(editor, '\n');
-        String enterBetweenBracketsFileBody = """
-                export class Foo {
-                    values = [
-                    <caret>];
-                    bar() {}
-                }
-                """;
+        String enterBetweenBracketsFileBody =
+                // NOTE: Once 2023.3 is no longer supported, this can use only the first expected value
+                LSPIJUtils.isVersionAtLeast(2024, 1) ?
+                        """
+                                export class Foo {
+                                    values = [
+                                        <caret>];
+                                    bar() {}
+                                }
+                                """ :
+                        """
+                                export class Foo {
+                                    values = [
+                                    <caret>];
+                                    bar() {}
+                                }
+                                """;
         assertEquals(enterBetweenBracketsFileBody.replace(CARET, ""), document.getText());
         assertEquals(enterBetweenBracketsFileBody.indexOf(CARET), caretModel.getOffset());
 
@@ -139,14 +150,25 @@ public class TypeScriptCustomLanguageServerEditorImprovementsTest extends Abstra
         int parensOffset = fileBody.indexOf("()") + 1;
         caretModel.moveToOffset(parensOffset);
         EditorTestUtil.performTypingAction(editor, '\n');
-        String enterBetweenParensFileBody = """
-                export class Foo {
-                    values = [
-                    ];
-                    bar(
-                    <caret>) {}
-                }
-                """;
+        String enterBetweenParensFileBody =
+                // NOTE: Once 2023.3 is no longer supported, this can use only the first expected value
+                LSPIJUtils.isVersionAtLeast(2024, 1) ?
+                        """
+                                export class Foo {
+                                    values = [
+                                        ];
+                                    bar(
+                                        <caret>) {}
+                                }
+                                """ :
+                        """
+                                export class Foo {
+                                    values = [
+                                    ];
+                                    bar(
+                                    <caret>) {}
+                                }
+                                """;
         assertEquals(enterBetweenParensFileBody.replace(CARET, ""), document.getText());
         assertEquals(enterBetweenParensFileBody.indexOf(CARET), caretModel.getOffset());
 
@@ -155,15 +177,27 @@ public class TypeScriptCustomLanguageServerEditorImprovementsTest extends Abstra
         int bracesOffset = fileBody.indexOf("{}") + 1;
         caretModel.moveToOffset(bracesOffset);
         EditorTestUtil.performTypingAction(editor, '\n');
-        String enterBetweenBracesFileBody = """
-                export class Foo {
-                    values = [
-                    ];
-                    bar(
-                    ) {
-                    <caret>}
-                }
-                """;
+        String enterBetweenBracesFileBody =
+                // NOTE: Once 2023.3 is no longer supported, this can use only the first expected value
+                LSPIJUtils.isVersionAtLeast(2024, 1) ?
+                        """
+                                export class Foo {
+                                    values = [
+                                        ];
+                                    bar(
+                                        ) {
+                                            <caret>}
+                                }
+                                """ :
+                        """
+                                export class Foo {
+                                    values = [
+                                    ];
+                                    bar(
+                                    ) {
+                                    <caret>}
+                                }
+                                """;
         assertEquals(enterBetweenBracesFileBody.replace(CARET, ""), document.getText());
         assertEquals(enterBetweenBracesFileBody.indexOf(CARET), caretModel.getOffset());
     }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptEditorImprovementsTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/formatting/TypeScriptEditorImprovementsTest.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.testFramework.EditorTestUtil;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
 import com.redhat.devtools.lsp4ij.server.definition.launching.ClientConfigurationSettings;
 import org.jetbrains.annotations.NotNull;
@@ -507,13 +508,22 @@ public class TypeScriptEditorImprovementsTest extends AbstractTypeScriptEditorIm
         caretModel.moveToOffset(bracketsOffset);
         EditorTestUtil.performTypingAction(editor, '\n');
         String enterBetweenBracketsFileBody = adjustIndent(
-                """
-                        export class Foo {
-                            values = [
-                            <caret>];
-                            bar() {}
-                        }
-                        """,
+                // NOTE: Once 2023.3 is no longer supported, this can use only the first expected value
+                LSPIJUtils.isVersionAtLeast(2024, 1) ?
+                        """
+                                export class Foo {
+                                    values = [
+                                        <caret>];
+                                    bar() {}
+                                }
+                                """ :
+                        """
+                                export class Foo {
+                                    values = [
+                                    <caret>];
+                                    bar() {}
+                                }
+                                """,
                 useTabCharacter
         );
         assertEquals(enterBetweenBracketsFileBody.replace(CARET, ""), document.getText());
@@ -525,14 +535,24 @@ public class TypeScriptEditorImprovementsTest extends AbstractTypeScriptEditorIm
         caretModel.moveToOffset(parensOffset);
         EditorTestUtil.performTypingAction(editor, '\n');
         String enterBetweenParensFileBody = adjustIndent(
-                """
-                        export class Foo {
-                            values = [
-                            ];
-                            bar(
-                            <caret>) {}
-                        }
-                        """,
+                // NOTE: Once 2023.3 is no longer supported, this can use only the first expected value
+                LSPIJUtils.isVersionAtLeast(2024, 1) ?
+                        """
+                                export class Foo {
+                                    values = [
+                                        ];
+                                    bar(
+                                        <caret>) {}
+                                }
+                                """ :
+                        """
+                                export class Foo {
+                                    values = [
+                                    ];
+                                    bar(
+                                    <caret>) {}
+                                }
+                                """,
                 useTabCharacter
         );
         assertEquals(enterBetweenParensFileBody.replace(CARET, ""), document.getText());
@@ -544,15 +564,26 @@ public class TypeScriptEditorImprovementsTest extends AbstractTypeScriptEditorIm
         caretModel.moveToOffset(bracesOffset);
         EditorTestUtil.performTypingAction(editor, '\n');
         String enterBetweenBracesFileBody = adjustIndent(
-                """
-                        export class Foo {
-                            values = [
-                            ];
-                            bar(
-                            ) {
-                            <caret>}
-                        }
-                        """,
+                // NOTE: Once 2023.3 is no longer supported, this can use only the first expected value
+                LSPIJUtils.isVersionAtLeast(2024, 1) ?
+                        """
+                                export class Foo {
+                                    values = [
+                                        ];
+                                    bar(
+                                        ) {
+                                            <caret>}
+                                }
+                                """ :
+                        """
+                                export class Foo {
+                                    values = [
+                                    ];
+                                    bar(
+                                    ) {
+                                    <caret>}
+                                }
+                                """,
                 useTabCharacter
         );
         assertEquals(enterBetweenBracesFileBody.replace(CARET, ""), document.getText());


### PR DESCRIPTION
The default TextMate enter-between-braces behavior differs between 2023.3 and 2024.1+. In 2023.3, typing enter between braces/brackets/parens such as:

```
values: [<typeEnterHere>]
```

would result in:

```
values: [
]
```
wheres in 2024.1-2025.1 (and presumably going forward), it results in:

```
values: [
    ]
```

That was causing a few tests that confirm the default TextMate enter-between-braces behavior when the enhanced enter-between-braces handler is disabled to fail.

I've updated these test expectations so that it's based on the host IDE version. Once 2023.3 support is dropped from LSP4IJ, this branching logic based on host IDE version can be removed and the 2024.1+ test expectations can be used.