### PR TITLE
perf: don't send didOpen on IJ fileOpened

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -16,7 +16,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
-import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.lifecycle.LanguageServerLifecycleManager;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,12 +42,12 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements ProjectM
         // to avoid starting language server in the EDT Thread which could freeze IJ.
         // Wait for indexing is finished and read action is enabled
         // --> force the start of all languages servers mapped with the given file when indexing is finished and read action is allowed
-        ProjectIndexingManager
+        /*ProjectIndexingManager
                 .waitForIndexingAll()
                 .thenApplyAsync(unused -> {
                     connectToLanguageServer(file, project);
                     return null;
-                });
+                });*/
     }
 
     @Override


### PR DESCRIPTION
perf: don't send didOpen on IJ fileOpened

When IJ startup with several tab editor (file opened previously):

![image](https://github.com/user-attachments/assets/dea05b3f-e418-46e1-9357-fea7990ff8d4)

LSP4IJ start language server and send didopen on IJ fileOpened listener which is bad for performance because in this sample, it will start 3 language servers (Swift SourceKit LSP, TypeScript LS and Scala Metla LS). 

Here TypeScript LS will generate codelens, folding etc for name.js  and person.ts although those editor are not visible.

The start of the language server and didOpen send, codelens, etc must be done only when editor is visible (when user click on the editor tab).

Here the result of this PR when IJ startup, only Scala LS is started:

![image](https://github.com/user-attachments/assets/8091cdb9-08c6-4d8e-acc2-c79cb64f84a1)

This PR improve a lot the performance when IJ startup.

Here the resut when name.js tab is clicked:

![image](https://github.com/user-attachments/assets/5d6a6463-a3b9-4471-8043-d03c4997f0bd)

It start TypeScript LS and there is just one didOpen, codelens etc only for the name.js and not for the person.ts.