### PR TITLE
chore: declare empty config file for optional plugins.

### DIFF
--- a/src/main/resources/META-INF/plugin-telemetry.xml
+++ b/src/main/resources/META-INF/plugin-telemetry.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin-textmate.xml
+++ b/src/main/resources/META-INF/plugin-textmate.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -207,8 +207,8 @@
     </description>
 
     <depends>com.intellij.modules.platform</depends>
-    <depends optional="true">org.jetbrains.plugins.textmate</depends>
-    <depends optional="true">com.redhat.devtools.intellij.telemetry</depends>
+    <depends optional="true" config-file="plugin-textmate.xml">org.jetbrains.plugins.textmate</depends>
+    <depends optional="true" config-file="plugin-telemetry.xml">com.redhat.devtools.intellij.telemetry</depends>
     <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
     <idea-version since-build="233.*"/>


### PR DESCRIPTION
chore: declare empty config file for optional plugins.