### PR TITLE
fix: normalize path of breakpoint

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/breakpoints/DAPBreakpointHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/breakpoints/DAPBreakpointHandler.java
@@ -17,7 +17,6 @@ import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.breakpoints.XBreakpoint;
 import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
-import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptor;
 import org.eclipse.lsp4j.debug.*;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
@@ -174,7 +173,7 @@ public class DAPBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<DAP
 
     @Nullable
     public XBreakpoint<DAPBreakpointProperties> findBreakpoint(@NotNull StackFrame stackFrame) {
-        Path filePath = Paths.get(stackFrame.getSource().getPath().trim());
+        Path filePath = Paths.get(stackFrame.getSource().getPath().trim()).normalize();
         if (filePath == null) {
             return null;
         }


### PR DESCRIPTION
fix: normalize path of breakpoint

See #971

In comments https://github.com/redhat-developer/lsp4ij/issues/971#issuecomment-2813495337 path `/Users/amizanjaleel/src/.../code.py` uses `../` and breakpoint cannot be found. This PR normalize the path toretrieve correctly the IJ breakpoint.

```
[Trace - 12:25:53] Received response 'setBreakpoints - (6)' in 4ms.
Result: {
  "breakpoints": [
    {
      "id": 3,
      "verified": false,
      "message": "Breakpoint in file that does not exist.",
      "source": {
        "name": "code.py",
        "path": "/Users/amizanjaleel/src/.../code.py"
      },
      "line": 44
    },
```