### PR TITLE
docs: add Smart Data Lake Builder to users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Here are some projects that use LSP4IJ:
  * [SAP CDS Language Support for IntelliJ](https://github.com/cap-js/cds-intellij)
  * [RyeCharm](https://github.com/InSyncWithFoo/ryecharm)
  * [Huly Code](https://github.com/hcengineering/huly-code)
+ * [SDLB LSP](https://github.com/smart-data-lake/sdl-lsp)
 
 ## Requirements
 


### PR DESCRIPTION
Adding LSP4IJ user to the list for Smart Data Lake Builder (SDLB) project. 

I would like to wait for Monday 28th April, 11:30AM UTC time to confirm it is ok with my team.