### PR TITLE
docs: Add telemetry configuration and documentation for the Docker Language Server

### DIFF
--- a/docs/user-defined-ls/docker-language-server.md
+++ b/docs/user-defined-ls/docker-language-server.md
@@ -24,6 +24,8 @@ To get language support for files from the Docker ecosystem (Dockerfiles, Compos
 
 4. **Optional**: You may also customize the Configuration section according to your preferences.
 
+    - The Docker Language Server collects telemetry by default. You can configure this behaviour by modifying the Initialization Options. See [here](https://github.com/docker/docker-language-server/blob/main/TELEMETRY.md) for detailed information about what telemetry is collected.
+
 5. **Click OK** to apply the changes. You should now have language support for Dockerfiles, Compose files, and Bake files enabled in your IDE:
 
 ![Docker Language Server output in the LSP console](../images/user-defined-ls/docker-language-server/console-output.png)

--- a/src/main/resources/templates/dockerfile-language-server/initializationOptions.json
+++ b/src/main/resources/templates/dockerfile-language-server/initializationOptions.json
@@ -1,1 +1,3 @@
-{}
+{
+    "telemetry": "all"
+}

--- a/src/main/resources/templates/dockerfile-language-server/initializationOptions.schema.json
+++ b/src/main/resources/templates/dockerfile-language-server/initializationOptions.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "LSP4IJ/docker-language-server/initializationOptions.schema.json",
+  "title": "LSP4IJ Docker Language Server server initialization options JSON schema",
+  "description": "JSON schema for the Docker Language Server's server initialization options.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "telemetry": {
+      "type": "string",
+      "enum": [
+        "all",
+        "error",
+        "off"
+      ],
+      "enumDescriptions": [
+        "All telemetry will be sent",
+        "Language server errors",
+        "No telemetry will be sent"
+      ],
+      "default": "all",
+      "description": "Configures what kind of telemetry, if any, should be sent to Docker"
+    }
+  }
+}


### PR DESCRIPTION
Document that the telemetry in the Docker Language Server is opt-out by default but can be configured as the user wishes during the initial setup of the language server.

Did I setup the `initializationOptions.schema.json` schema file correctly...? 🤔