### PR TITLE
fix: Don't force file support creation with document symbol

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
@@ -86,6 +86,13 @@ public class LSPDocumentSymbolStructureViewModel extends StructureViewModelBase 
                 return Collections.emptyList();
             }
 
+            if (!LSPFileSupport.hasSupport(psiFile)) {
+                // Don't force file support creation
+                // Ex: when file is closed, document symbol must return an empty list.
+                return Collections.emptyList();
+            }
+
+
             LSPFileSupport fileSupport = LSPFileSupport.getSupport(psiFile);
             LSPDocumentSymbolSupport documentSymbolSupport = fileSupport.getDocumentSymbolSupport();
             var params = new DocumentSymbolParams(LSPIJUtils.toTextDocumentIdentifier(psiFile.getVirtualFile()));


### PR DESCRIPTION
fix: Don't force file support creation with document symbol