### PR TITLE
fix: Include compose.yaml and compose.yml to the Docker Language Server

### DIFF
--- a/src/main/resources/templates/dockerfile-language-server/template.json
+++ b/src/main/resources/templates/dockerfile-language-server/template.json
@@ -15,6 +15,8 @@
       "fileType": {
         "name": "Docker Compose",
         "patterns": [
+          "compose.yaml",
+          "compose.yml",
           "docker-compose.yml",
           "docker-compose.yaml"
         ]


### PR DESCRIPTION
The default path for Compose is `compose.yaml` and `compose.yml` so we should add those to the Docker Language Server as well.