### PR TITLE
feat: make configurable DAP exceptions

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/breakpoints/DAPExceptionBreakpointsPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/breakpoints/DAPExceptionBreakpointsPanel.java
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.breakpoints;
+
+import com.intellij.CommonBundle;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.Disposable;
+import com.intellij.ui.*;
+import com.intellij.ui.table.TableView;
+import com.intellij.util.ui.ColumnInfo;
+import com.intellij.util.ui.ListTableModel;
+import com.intellij.util.ui.components.BorderLayoutPanel;
+import com.redhat.devtools.lsp4ij.dap.settings.UserDefinedDebugAdapterServerSettings;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
+import org.eclipse.lsp4j.debug.ExceptionBreakpointsFilter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import javax.swing.table.TableCellRenderer;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * "Exception Breakpoints" panel which shows the DAP exceptions breakpoints filter in a table
+ * which can be enabled/disabled with checkbox.
+ */
+public class DAPExceptionBreakpointsPanel extends BorderLayoutPanel implements Disposable {
+
+    static final EnabledColumnInfo ENABLED_COLUMN = new EnabledColumnInfo();
+    static final NameColumnInfo NAME_COLUMN = new NameColumnInfo();
+
+    private final @NotNull DAPBreakpointHandler breakpointHandler;
+    private final @NotNull ListTableModel<ExceptionBreakpointsFilter> myModel;
+    private final @NotNull TableView<ExceptionBreakpointsFilter> myTable;
+
+    public DAPExceptionBreakpointsPanel(@NotNull DAPBreakpointHandler breakpointHandler) {
+        this.breakpointHandler = breakpointHandler;
+
+        // Create Table view
+        this.myModel = new ListTableModel(new ColumnInfo[]{ENABLED_COLUMN, NAME_COLUMN});
+        this.myModel.setSortable(true);
+        this.myTable = new TableView(this.myModel);
+        this.addToCenter(ScrollPaneFactory.createScrollPane(this.myTable));
+        TableUtil.setupCheckboxColumn(this.myTable.getColumnModel().getColumn(0));
+
+        // Load table view with DAP exceptions breakpoints filter
+        // stored in settings
+        var settings = getFilterSettings();
+        var filtersSettings = settings.getExceptionBreakpointsFilters();
+        if (filtersSettings != null) {
+            refreshModel(filtersSettings);
+        }
+        myModel.addTableModelListener(e -> {
+            if (e.getColumn() == 0) {
+                // An "exception breakpoint filter" item has been selected/unselected
+                breakpointHandler.sendExceptionBreakpointFilters();
+            }
+        });
+    }
+
+    private static class EnabledColumnInfo extends ColumnInfo<ExceptionBreakpointsFilter, Boolean> {
+        EnabledColumnInfo() {
+            super("");
+        }
+
+        public Class<?> getColumnClass() {
+            return Boolean.class;
+        }
+
+        public @Nullable Boolean valueOf(ExceptionBreakpointsFilter item) {
+            return item.getDefault_() != null && item.getDefault_();
+        }
+
+        public boolean isCellEditable(ExceptionBreakpointsFilter item) {
+            return true;
+        }
+
+        public void setValue(ExceptionBreakpointsFilter item, Boolean value) {
+            item.setDefault_(value);
+        }
+    }
+
+    private static class NameColumnInfo extends ColumnInfo<ExceptionBreakpointsFilter, ExceptionBreakpointsFilter> {
+
+        NameColumnInfo() {
+            super(CommonBundle.message("title.name", new Object[0]));
+        }
+
+        public @Nullable ExceptionBreakpointsFilter valueOf(ExceptionBreakpointsFilter aspects) {
+            return aspects;
+        }
+
+        public Class<?> getColumnClass() {
+            return ExceptionBreakpointsFilter.class;
+        }
+
+        public @Nullable TableCellRenderer getRenderer(ExceptionBreakpointsFilter producer) {
+            return new ColoredTableCellRenderer() {
+                protected void customizeCellRenderer(@NotNull JTable table, @Nullable Object value, boolean selected, boolean hasFocus, int row, int column) {
+                    if (value instanceof ExceptionBreakpointsFilter filter) {
+                        String label = StringUtils.isNotBlank(filter.getLabel()) ? filter.getLabel() : filter.getFilter();
+                        this.append(label);
+                        String tooltip = filter.getDescription();
+                        if (StringUtils.isNotBlank(tooltip)) {
+                            super.setToolTipText(tooltip);
+                        }
+                        super.setIcon(AllIcons.Debugger.Db_exception_breakpoint);
+                        this.setTransparentIconBackground(true);
+                    }
+                }
+            };
+        }
+    }
+
+    /**
+     * Redresh the table view with the given DAP breakpoint exception filters.
+     *
+     * @param filters the DAP breakpoint exception filters.
+     * @return the DAP breakpoint exception filters which are enabled.
+     */
+    public Collection<ExceptionBreakpointsFilter> refresh(@NotNull ExceptionBreakpointsFilter[] filters) {
+        // Store filter as key and ExceptionBreakpointsFilter instance as value
+        Map<String, ExceptionBreakpointsFilter> map = filters == null ? Collections.emptyMap() :
+                Arrays.stream(filters)
+                        .filter(f -> f.getFilter() != null)
+                        .collect(Collectors.toMap(
+                                ExceptionBreakpointsFilter::getFilter,
+                                filter -> filter
+                        ));
+
+        var settings = getFilterSettings();
+        // Update filters item.default with the settings.default
+        var filtersSettings = settings.getExceptionBreakpointsFilters();
+        if (filtersSettings != null) {
+            for (var filterSettings : filtersSettings) {
+                String filter = filterSettings.getFilter();
+                var newFilter = map.get(filter);
+                if (newFilter != null) {
+                    newFilter.setDefault_(filterSettings.getDefault_());
+                }
+            }
+        }
+        // Update settings
+        settings.setExceptionBreakpointsFilters(map.values());
+        // Refresh the list of exception breakpoints
+        refreshModel(map.values());
+        // Returns list of exception breakpoints which are enabled
+        return getApplicableFilters();
+    }
+
+    private void refreshModel(@NotNull Collection<ExceptionBreakpointsFilter> filters) {
+        this.myModel.setItems(new ArrayList<>(filters));
+    }
+
+    private UserDefinedDebugAdapterServerSettings.@NotNull FilterItemSettings getFilterSettings() {
+        var serverId = breakpointHandler.getDebugAdapterDescriptor().getId();
+        var settings = UserDefinedDebugAdapterServerSettings.getInstance().getFilterSettings(serverId);
+        if (settings == null) {
+            settings = new UserDefinedDebugAdapterServerSettings.FilterItemSettings();
+            UserDefinedDebugAdapterServerSettings.getInstance().setFilterSettings(serverId, settings);
+        }
+        return settings;
+    }
+
+    public JComponent getDefaultFocusedComponent() {
+        return this.myTable;
+    }
+
+    public List<ExceptionBreakpointsFilter> getApplicableFilters() {
+        return myModel.getItems()
+                .stream()
+                .filter(DAPExceptionBreakpointsPanel::isEnabled)
+                .toList();
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+
+    private static boolean isEnabled(@NotNull ExceptionBreakpointsFilter filter) {
+        return filter.getDefault_() != null && filter.getDefault_();
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/DAPClient.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/DAPClient.java
@@ -216,17 +216,9 @@ public class DAPClient implements IDebugProtocolClient, Disposable {
 
                         var filters = getCapabilities().getExceptionBreakpointFilters();
                         if (filters != null) {
-                            SetExceptionBreakpointsArguments args = new SetExceptionBreakpointsArguments();
-                            args.setFilters(Arrays
-                                    .stream(filters)
-                                    .map(ExceptionBreakpointsFilter::getFilter)
-                                    .toArray(String[]::new));
-
-                            return getDebugProtocolServer()
-                                    .setExceptionBreakpoints(args)
-                                    .thenAccept(r -> {
-
-                                    });
+                            return debugProcess
+                                    .getBreakpointHandler()
+                                    .sendExceptionBreakpointFilters(filters, getDebugProtocolServer());
                         }
                         return CompletableFuture.completedFuture(null);
                     });
@@ -238,7 +230,8 @@ public class DAPClient implements IDebugProtocolClient, Disposable {
                     monitor.setFraction(80d / 100d);
                     monitor.setText2("Sending configuration done");
                     if (Boolean.TRUE.equals(getCapabilities().getSupportsConfigurationDoneRequest())) {
-                        return getDebugProtocolServer().configurationDone(new ConfigurationDoneArguments());
+                        return getDebugProtocolServer()
+                                .configurationDone(new ConfigurationDoneArguments());
                     }
                     return CompletableFuture.completedFuture(null);
                 });

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPRunConfiguration.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPRunConfiguration.java
@@ -236,7 +236,7 @@ public class DAPRunConfiguration extends RunConfigurationBase<DAPRunConfiguratio
         var debugAdapterServer = getDebugAdapterServer();
         DebugAdapterDescriptor serverDescriptor = debugAdapterServer != null ?
                 debugAdapterServer.getFactory().createDebugAdapterDescriptor(getOptions(), environment) :
-                new DefaultDebugAdapterDescriptor(getOptions(), environment, null);
+                new DefaultDebugAdapterDescriptor(getOptions(), environment, getName());
         return new DAPCommandLineState(serverDescriptor, getOptions(), environment);
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptor.java
@@ -61,6 +61,10 @@ public abstract class DebugAdapterDescriptor implements DebuggableFile {
         this.serverDefinition = serverDefinition;
     }
 
+    public String getId() {
+        return serverDefinition != null ? serverDefinition.getId() : null;
+    }
+
     // Start the Debug Adapter server.
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DefaultDebugAdapterDescriptor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DefaultDebugAdapterDescriptor.java
@@ -42,10 +42,25 @@ import static com.redhat.devtools.lsp4ij.server.definition.launching.CommandUtil
 @ApiStatus.Experimental
 public class DefaultDebugAdapterDescriptor extends DebugAdapterDescriptor {
 
+    private final @NotNull String id;
+
     public DefaultDebugAdapterDescriptor(@NotNull RunConfigurationOptions options,
                                          @NotNull ExecutionEnvironment environment,
-                                         @Nullable DebugAdapterServerDefinition serverDefinition) {
+                                         @NotNull DebugAdapterServerDefinition serverDefinition) {
         super(options, environment, serverDefinition);
+        this.id = serverDefinition.getId();
+    }
+
+    public DefaultDebugAdapterDescriptor(@NotNull DAPRunConfigurationOptions options,
+                                         @NotNull ExecutionEnvironment environment,
+                                         @NotNull String runConfigurationName) {
+        super(options, environment, null);
+        this.id = runConfigurationName;
+    }
+
+    @Override
+    public @NotNull String getId() {
+        return id;
     }
 
     // Start the Debug Adapter server.


### PR DESCRIPTION
This PR provides the capability to customize the enabled/disabled of exception breakpoint filters supported by the DAP server.

Once you will start the DAP server you can open the exception breakpoint menu:

![image](https://github.com/user-attachments/assets/3d2c66d8-5adf-4ee1-8194-ad329c74ddf4)

This list of exception breakpoints is filled when the DAP server is initialized. The first time, the enabled/disabled of those breakpoints are managed by the DAP server (default value).

User can check/uncheck the exception to customize it. Those check/uncheck are persistent.