### PR TITLE
docs(readme): Add bloc linter plugin on 'Who is using LSP4IJ'

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Here are some projects that use LSP4IJ:
  * [RyeCharm](https://github.com/InSyncWithFoo/ryecharm)
  * [Huly Code](https://github.com/hcengineering/huly-code)
  * [SDLB LSP](https://github.com/smart-data-lake/sdl-lsp)
+ * [Bloc Linter Support for IntelliJ](https://github.com/felangel/bloc)
 
 ## Requirements
 


### PR DESCRIPTION
I'm here to resolve our issue : https://github.com/felangel/bloc/issues/4478 🫣
Thanks a lot for your work on LSP4IJ.