### PR TITLE
fix: move telemetry class in the plugin-telemtry.xml

### DIFF
--- a/src/main/resources/META-INF/plugin-telemetry.xml
+++ b/src/main/resources/META-INF/plugin-telemetry.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <applicationService
+                serviceImplementation="com.redhat.devtools.lsp4ij.internal.telemetry.TelemetryManager"/>
+    </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -267,8 +267,6 @@
         <applicationService
                 serviceImplementation="com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingDumbAndScanningStrategy"/>
         <applicationService
-                serviceImplementation="com.redhat.devtools.lsp4ij.internal.telemetry.TelemetryManager"/>
-        <applicationService
                 serviceImplementation="com.redhat.devtools.lsp4ij.LanguageServersRegistry"/>
         <applicationService
                 id="com.redhat.devtools.lsp4ij.launching.UserDefinedLanguageServerSettings"


### PR DESCRIPTION
fix: move telemetry class in the plugin-telemtry.xml