### PR TITLE
feat: replace template combo with advanced search popup

### DIFF
--- a/docs/UserDefinedLanguageServerTemplate.md
+++ b/docs/UserDefinedLanguageServerTemplate.md
@@ -33,11 +33,15 @@ and want to share it with others, you can contribute it to the official template
    Provide documentation for your language server in the [`/docs/user-defined-ls`](https://github.com/redhat-developer/lsp4ij/tree/main/docs/user-defined-ls) folder.
   - Use existing docs as reference, for instance: [`/docs/user-defined-ls/typescript-language-server`](https://github.com/redhat-developer/lsp4ij/tree/main/docs/user-defined-ls/typescript-language-server.md).
 
+4. **Reference it**  
+   Add your language server in the [`Default template`](https://github.com/redhat-developer/lsp4ij/blob/main/docs/UserDefinedLanguageServer.md#default-template).
+
 ### ✅ Contribution Checklist
 
 - [ ] `template.json` contains a unique `id` and correct `programArgs`
 - [ ] Template is placed under `/templates/lsp/<your-language-server-name>`
 - [ ] Documentation is placed under `/docs/user-defined-ls/<your-language-server-name>.md`
+- [ ] Template is listed in the [Default template](https://github.com/redhat-developer/lsp4ij/blob/main/docs/UserDefinedLanguageServer.md#default-template)
 - [ ] Pull Request includes only relevant files and follows the structure of existing examples
  
 ## Template descriptor

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/ChooseDebugServerTemplatePopupUI.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/ChooseDebugServerTemplatePopupUI.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.settings.ui;
+
+import com.redhat.devtools.lsp4ij.dap.DAPBundle;
+import com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplate;
+import com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplateManager;
+import com.redhat.devtools.lsp4ij.ui.ChooseItemPopupUI;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * A UI component that displays a searchable popup for selecting a {@link DAPTemplate}
+ * (Debug Adapter Protocol template) when creating a new debug adapter configuration.
+ * <p>
+ * This class is a specialization of {@link ChooseItemPopupUI} configured with
+ * {@link DAPTemplate} instances, using their ID and name for display and filtering.
+ * </p>
+ *
+ */
+public class ChooseDebugServerTemplatePopupUI extends ChooseItemPopupUI<DAPTemplate> {
+
+    /**
+     * Creates a new popup UI for choosing a DAP template.
+     *
+     * @param onItemSelected the callback invoked when a template is selected
+     */
+    public ChooseDebugServerTemplatePopupUI(@NotNull Consumer<DAPTemplate> onItemSelected) {
+        super(DAPBundle.message("new.debug.adapter.dialog.choose.template.title"),
+                DAPTemplateManager.getInstance().getTemplates(),
+                DAPTemplate::getId,
+                DAPTemplate::getName,
+                onItemSelected);
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/ChooseLanguageServerTemplatePopupUI.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/ChooseLanguageServerTemplatePopupUI.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.launching.ui;
+
+import com.redhat.devtools.lsp4ij.LanguageServerBundle;
+import com.redhat.devtools.lsp4ij.launching.templates.LanguageServerTemplate;
+import com.redhat.devtools.lsp4ij.launching.templates.LanguageServerTemplateManager;
+import com.redhat.devtools.lsp4ij.ui.ChooseItemPopupUI;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * UI component that displays a popup to let the user select a {@link LanguageServerTemplate}.
+ * <p>
+ * This class is a specialization of {@link ChooseItemPopupUI} that preconfigures
+ * the list of items to show using {@link LanguageServerTemplateManager#getTemplates()},
+ * and defines how each {@link LanguageServerTemplate} is displayed and identified.
+ * </p>
+ *
+ * <p>
+ * When the user selects an item (via double-click or pressing Enter), the provided
+ * {@code onItemSelected} {@link Consumer} is invoked with the selected template.
+ * </p>
+ *
+ * <p>
+ * This popup is typically used when configuring or creating a new language server
+ * from predefined templates.
+ * </p>
+ *
+ */
+public class ChooseLanguageServerTemplatePopupUI extends ChooseItemPopupUI<LanguageServerTemplate> {
+
+    /**
+     * Creates a new popup UI for choosing a Language Server template.
+     *
+     * @param onItemSelected the callback invoked when a template is selected
+     */
+    public ChooseLanguageServerTemplatePopupUI(@NotNull Consumer<LanguageServerTemplate> onItemSelected) {
+        super(LanguageServerBundle.message("new.language.server.dialog.choose.template.title"),
+                LanguageServerTemplateManager.getInstance().getTemplates(),
+                LanguageServerTemplate::getId,
+                LanguageServerTemplate::getName,
+                onItemSelected);
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/ui/ChooseItemPopupUI.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ui/ChooseItemPopupUI.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.ui;
+
+import com.intellij.openapi.ui.popup.IPopupChooserBuilder;
+import com.intellij.openapi.ui.popup.JBPopup;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.ui.ColoredListCellRenderer;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.ui.speedSearch.SpeedSearchUtil;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A reusable popup UI component that displays a searchable list of items of type {@code T}.
+ * <p>
+ * This component allows customization of how items are identified, displayed, and selected.
+ * It provides automatic search/filtering via IntelliJ’s {@link IPopupChooserBuilder}
+ * and highlights matching text.
+ * </p>
+ *
+ * @param <T> the type of items displayed in the list
+ *
+ */
+public class ChooseItemPopupUI<T> {
+
+    private final @NotNull String title;
+    private final @NotNull List<T> items;
+    private final @NotNull Function<T, String> idProvider;
+    private final @NotNull Function<T, String> nameProvider;
+    private final @NotNull Consumer<T> onItemSelected;
+    private JBPopup popup;
+
+    public ChooseItemPopupUI(@NotNull String title,
+                             @NotNull List<T> items,
+                             @NotNull Function<T, String> idProvider,
+                             @NotNull Function<T, String> nameProvider,
+                             @NotNull Consumer<T> onItemSelected) {
+        this.title = title;
+        this.items = items;
+        this.idProvider = idProvider;
+        this.nameProvider = nameProvider;
+        this.onItemSelected = onItemSelected;
+    }
+
+    public void show(@NotNull Component parent) {
+        IPopupChooserBuilder<T> builder = JBPopupFactory.getInstance()
+                .createPopupChooserBuilder(items)
+                .setRenderer(new ColoredListCellRenderer<>() {
+                    @Override
+                    protected void customizeCellRenderer(@NotNull JList<? extends T> list, T value, int index, boolean selected, boolean hasFocus) {
+                        append(nameProvider.apply(value), SimpleTextAttributes.REGULAR_ATTRIBUTES);
+                        append(" - ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
+                        append(idProvider.apply(value), SimpleTextAttributes.GRAY_ATTRIBUTES);
+                        // Highlight matching part
+                        SpeedSearchUtil.applySpeedSearchHighlighting(list, this, true, selected);
+                    }
+                })
+                .setTitle(title)
+                .setMovable(true)
+                .setResizable(true)
+                .setRequestFocus(true)
+                .setNamerForFiltering(nameProvider::apply)
+                .setItemsChosenCallback(selectedElements -> {
+                    if (!selectedElements.isEmpty()) {
+                        onItemSelected.accept(selectedElements.iterator().next());
+                        if (popup != null) popup.closeOk(null);
+                    }
+                });
+
+        popup = builder.createPopup();
+
+        // Get the button's location on screen
+        Point location = parent.getLocationOnScreen();
+        // Calculate position just to the right of the button
+        int x = location.x + parent.getWidth();
+        int y = location.y;
+        // Show the popup at the calculated screen coordinates
+        popup.showInScreenCoordinates(parent, new Point(x, y));
+    }
+}

--- a/src/main/resources/messages/DAPBundle.properties
+++ b/src/main/resources/messages/DAPBundle.properties
@@ -23,6 +23,8 @@ debug.adapter.action.remove=Remove selected Debug Adapter Server(s)
 ## New Debug Adapter descriptor factory dialog
 new.debug.adapter.dialog.title=New Debug Adapter Server
 new.debug.adapter.dialog.template=Template:
+new.debug.adapter.dialog.choose.template=Choose template...
+new.debug.adapter.dialog.choose.template.title=Choose Debug Server template
 new.debug.adapter.dialog.validation.serverName.must.be.set=Server name must be set
 new.debug.adapter.dialog.validation.commandLine.must.be.set=Command must be set
 new.debug.adapter.dialog.install.title=Debug Adapter Server installation

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -71,6 +71,9 @@ language.server.action.remove=Remove selected Language server(s)
 ## New Language Server dialog
 new.language.server.dialog.title=New Language Server
 new.language.server.dialog.template=Template:
+new.language.server.dialog.choose.template=Choose template...
+new.language.server.dialog.choose.template.title=Choose Language Server template
+new.language.server.dialog.import.template=Import template...
 new.language.server.dialog.export.template.title=Load Template
 new.language.server.dialog.export.template.description=Load template from a directory
 new.language.server.dialog.import.template.error.title=Template import failed

--- a/src/main/resources/templates/lsp/vscode-css-language-server/template.json
+++ b/src/main/resources/templates/lsp/vscode-css-language-server/template.json
@@ -2,7 +2,7 @@
   "id": "vscode-css-language-server",
   "name": "CSS Language Server",
   "programArgs": {
-    "windows": "node \"C:/Users/${user.name}/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js\" --stdio",
+    "windows": "node \"$USER_HOME$/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js\" --stdio",
     "mac": "sh -c \"node '/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js' --stdio\"",
     "unix": "sh -c \"node '/usr/share/code/resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js' --stdio\"",
     "default": "sh -c \"node 'resources/app/extensions/css-language-features/server/dist/node/cssServerMain.js' --stdio\""

--- a/src/main/resources/templates/lsp/vscode-html-language-server/template.json
+++ b/src/main/resources/templates/lsp/vscode-html-language-server/template.json
@@ -2,7 +2,7 @@
   "id": "vscode-html-language-server",
   "name": "HTML Language Server",
   "programArgs": {
-    "windows": "node \"C:/Users/${user.name}/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js\" --stdio",
+    "windows": "node \"$USER_HOME$/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js\" --stdio",
     "mac": "sh -c \"node '/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js' --stdio\"",
     "unix": "sh -c \"node '/usr/share/code/resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js' --stdio\"",
     "default": "sh -c \"node 'resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js' --stdio\""


### PR DESCRIPTION
feat: replace template combo with advanced search popup

As we are more and more user defined language server, it starts to be hard to retrieve the language server template in the combo. This PR replace the combo with a search dialog popup.

 * before:
 
![SelectTemplateWithCombo](https://github.com/user-attachments/assets/171489a3-326f-43d4-838d-ea2a9c265205)

after:

![SelectTemplateWithPopup2](https://github.com/user-attachments/assets/06919ed2-3a09-4714-9b3a-03ea1f3cfdaa)

This search dialog popup is also used by DAP server.

