### PR TITLE
fix: use "unix"  instead of "linux"

### DIFF
--- a/docs/UserDefinedLanguageServerTemplate.md
+++ b/docs/UserDefinedLanguageServerTemplate.md
@@ -298,7 +298,7 @@ you can use the `github` JSON object to download the proper asset:
       "prerelease": false,
       "asset": {
         "windows": "clojure-lsp-native-windows-amd64.zip",
-        "linux": {
+        "unix": {
           "amd64": "clojure-lsp-native-linux-amd64.zip",
           "arm64": "clojure-lsp-native-linux-aarch64.zip"
         },
@@ -335,7 +335,7 @@ If there is an asset per OS and with architecture, you can write:
 {
   "asset": {
     "windows": "clojure-lsp-native-windows-amd64.zip",
-    "linux": {
+    "unix": {
       "amd64": "clojure-lsp-native-linux-amd64.zip",
       "arm64": "clojure-lsp-native-linux-aarch64.zip"
     },
@@ -364,7 +364,7 @@ You can customize the output directory and executable name:
     "file": {
       "name": {
         "windows": "rust-analyzer.exe",
-        "linux": "rust-analyzer-aarch64-unknown-linux-gnu",
+        "unix": "rust-analyzer-aarch64-unknown-linux-gnu",
         "mac": "rust-analyzer-aarch64-apple-darwin"
       },
       "executable": true

--- a/src/main/resources/templates/lsp/clangd/installer.json
+++ b/src/main/resources/templates/lsp/clangd/installer.json
@@ -12,13 +12,13 @@
         "prerelease": true,
         "asset": {
           "windows": "clangd-windows*.zip",
-          "linux": "clangd-linux*.zip",
+          "unix": "clangd-linux*.zip",
           "mac": "clangd-mac*.zip"
         }
       },
       "url": {
         "windows": "https://github.com/clangd/clangd/releases/download/snapshot_20250518/clangd-windows-snapshot_20250518.zip",
-        "linux": "https://github.com/clangd/clangd/releases/download/snapshot_20250518/clangd-linux-snapshot_20250518.zip",
+        "unix": "https://github.com/clangd/clangd/releases/download/snapshot_20250518/clangd-linux-snapshot_20250518.zip",
         "mac": " https://github.com/clangd/clangd/releases/download/snapshot_20250518/clangd-mac-snapshot_20250518.zip"
       },
       "output": {
@@ -26,7 +26,7 @@
         "file": {
           "name": {
             "windows": "bin/clangd.exe",
-            "linux": "bin/clangd",
+            "unix": "bin/clangd",
             "mac": "bin/clangd"
           },
           "executable": true

--- a/src/main/resources/templates/lsp/clojure-lsp/installer.json
+++ b/src/main/resources/templates/lsp/clojure-lsp/installer.json
@@ -12,7 +12,7 @@
         "prerelease": false,
         "asset": {
           "windows": "clojure-lsp-native-windows-amd64.zip",
-          "linux": {
+          "unix": {
             "amd64": "clojure-lsp-native-linux-amd64.zip",
             "arm64": "clojure-lsp-native-linux-aarch64.zip"
           },
@@ -27,7 +27,7 @@
         "file": {
           "name": {
             "windows": "clojure-lsp.exe",
-            "linux": "clojure-lsp",
+            "unix": "clojure-lsp",
             "mac": "clojure-lsp"
           },
           "executable": true

--- a/src/main/resources/templates/lsp/erlang-ls/installer.json
+++ b/src/main/resources/templates/lsp/erlang-ls/installer.json
@@ -18,7 +18,7 @@
         "repository": "erlang_ls",        
         "asset": {
           "windows": "erlang_ls-win*.tar.gz",
-          "linux": "erlang-linux*.zip",
+          "unix": "erlang-linux*.zip",
           "mac": "erlang-macos*.zip"
         }
       },

--- a/src/main/resources/templates/lsp/rust-analyzer/installer.json
+++ b/src/main/resources/templates/lsp/rust-analyzer/installer.json
@@ -16,7 +16,7 @@
             "x86": "rust-analyzer-i686-pc-windows-msvc.zip",
             "arm64": "rust-analyzer-aarch64-pc-windows-msvc.zip"
           },
-          "linux": {
+          "unix": {
             "x86_64": "rust-analyzer-x86_64-unknown-linux-gnu.gz",
             "arm64": "rust-analyzer-aarch64-unknown-linux-gnu.gz"
           },
@@ -32,7 +32,7 @@
           "x86": "https://github.com/rust-lang/rust-analyzer/releases/download/2025-05-12/rust-analyzer-i686-pc-windows-msvc.zip",
           "arm64": "https://github.com/rust-lang/rust-analyzer/releases/download/2025-05-12/rust-analyzer-aarch64-pc-windows-msvc.zip"
         },
-        "linux": {
+        "unix": {
           "x86_64": "https://github.com/rust-lang/rust-analyzer/releases/download/2025-05-12/rust-analyzer-x86_64-unknown-linux-gnu.gz",
           "arm64": "https://github.com/rust-lang/rust-analyzer/releases/download/2025-05-12/rust-analyzer-aarch64-unknown-linux-gnu.gz"
         },
@@ -46,7 +46,7 @@
         "file": {
           "name": {
             "windows": "rust-analyzer.exe",
-            "linux": "rust-analyzer-aarch64-unknown-linux-gnu",
+            "unix": "rust-analyzer-aarch64-unknown-linux-gnu",
             "mac": "rust-analyzer-aarch64-apple-darwin"
           },
           "executable": true


### PR DESCRIPTION
fix: use "unix"  instead of "linux"