### PR TITLE
fix: NPE thrown when server returns a TextDocumentSyncOptions.save to null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -886,7 +886,11 @@ public class LanguageServerWrapper implements Disposable {
                 newSyncOptions.setSave(true);
                 return newSyncOptions;
             } else if (syncOptions.isRight()) {
-                return syncOptions.getRight();
+                TextDocumentSyncOptions newSyncOptions =  syncOptions.getRight();
+                if (newSyncOptions.getSave() == null) {
+                    newSyncOptions.setSave(true);
+                }
+                return newSyncOptions;
             }
         }
         return DEFAULT_SYNC_OPTIONS;


### PR DESCRIPTION
fix: NPE thrown when server returns a TextDocumentSyncOptions.save to null

Fixes #1076