### PR TITLE
fix: Correct the name of the Docker Language Server

### DIFF
--- a/src/main/resources/templates/lsp/dockerfile-language-server/installer.json
+++ b/src/main/resources/templates/lsp/dockerfile-language-server/installer.json
@@ -1,6 +1,6 @@
 {
-  "id": "dockerfile-language-server",
-  "name": "Dockerfile Language Server",
+  "id": "docker-language-server",
+  "name": "Docker Language Server",
   "executeOnStartServer": false,
   "check": {
     "exec": {
@@ -11,7 +11,7 @@
   },
   "run": {
     "download": {
-      "name": "Download dockerfile-language-server",
+      "name": "Download docker-language-server",
       "github": {
         "owner": "docker",
         "repository": "docker-language-server",
@@ -32,7 +32,7 @@
         }
       },
       "output": {
-        "dir": "$USER_HOME$/.lsp4ij/lsp/dockerfile-language-server",
+        "dir": "$USER_HOME$/.lsp4ij/lsp/docker-language-server",
         "file": {
           "name": {
             "windows": "docker-language-server.exe",
@@ -43,7 +43,7 @@
       },
       "onSuccess": {
         "configureServer": {
-          "name": "Configure Dockerfile Language Server command",
+          "name": "Configure Docker Language Server command",
           "command": "${output.dir}/${output.file.name} start --stdio",
           "update": true
         }


### PR DESCRIPTION
1. There is another language server named the [Dockerfile Language Server](https://github.com/rcjsuen/dockerfile-language-server). This is _not_ that.
2. This language server provides features for Compose files and Bake files as well so this language server is _not_ only for Dockerfiles.