### PR TITLE
feat: add Vala JetBrains Plugin to `Who is using LSP4IJ?` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Here are some projects that use LSP4IJ:
  * [Huly Code](https://github.com/hcengineering/huly-code)
  * [SDLB LSP](https://github.com/smart-data-lake/sdl-lsp)
  * [Bloc Linter Support for IntelliJ](https://github.com/felangel/bloc)
+ * [Vala JetBrains Plugin](https://github.com/Tbusk/vala-jetbrains-plugin)
 
 ## Requirements
 


### PR DESCRIPTION
- Add link to Vala JetBrains Plugin in the `Who is using LSP4IJ` section of the `README.md`.

Suggested by @angelozerr  in https://github.com/Tbusk/vala-jetbrains-plugin/issues/30