### PR TITLE
feat: added separation of application output consoles and DAP debugger consoles

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
@@ -33,11 +33,11 @@ import com.intellij.xdebugger.frame.XStackFrame;
 import com.intellij.xdebugger.frame.XSuspendContext;
 import com.intellij.xdebugger.ui.XDebugTabLayouter;
 import com.redhat.devtools.lsp4ij.dap.breakpoints.DAPBreakpointHandler;
-import com.redhat.devtools.lsp4ij.dap.breakpoints.DAPExceptionBreakpointsPanel;
 import com.redhat.devtools.lsp4ij.dap.client.DAPClient;
 import com.redhat.devtools.lsp4ij.dap.client.DAPStackFrame;
 import com.redhat.devtools.lsp4ij.dap.client.DAPSuspendContext;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPCommandLineState;
+import com.redhat.devtools.lsp4ij.dap.console.DAPDuplexConsoleView;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptor;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
@@ -340,7 +340,9 @@ public class DAPDebugProcess extends XDebugProcess {
             var consoleView = getSession().getConsoleView();
             if (consoleView == null) {
                 return;
-
+            }
+            if (consoleView instanceof DAPDuplexConsoleView) {
+                consoleView = ((DAPDuplexConsoleView) consoleView).getPrimaryConsoleView();
             }
             consoleView.print(text, type);
         });

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/console/DAPDuplexConsoleView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/console/DAPDuplexConsoleView.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.console;
+
+import com.intellij.execution.console.DuplexConsoleView;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.redhat.devtools.lsp4ij.dap.DAPBundle;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Extends {@link DuplexConsoleView} to support dual debug console (application console and debugger console).
+ */
+public class DAPDuplexConsoleView extends DuplexConsoleView<DAPConsoleView, DAPConsoleView> {
+
+    public DAPDuplexConsoleView(@NotNull Project project,
+                                @NotNull GlobalSearchScope searchScope,
+                                boolean viewer,
+                                boolean usePredefinedMessageFilter) {
+
+        super(new DAPConsoleView(project, searchScope, viewer, usePredefinedMessageFilter), new DAPConsoleView(project, searchScope, viewer, usePredefinedMessageFilter));
+
+        enableConsole(true);
+        setDisableSwitchConsoleActionOnProcessEnd(false);
+
+        getSwitchConsoleActionPresentation().setIcon(AllIcons.RunConfigurations.RemoteDebug);
+        getSwitchConsoleActionPresentation().setText(DAPBundle.message("dap.console.log.show.dap"));
+    }
+
+    public void print(@NotNull String s, @NotNull ConsoleViewContentType contentType) {
+        getSecondaryConsoleView().print(s, contentType);
+    }
+
+    public void attachToProcess(@NotNull ProcessHandler processHandler) {
+        getSecondaryConsoleView().attachToProcess(processHandler);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/console/DAPTextConsoleBuilderImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/console/DAPTextConsoleBuilderImpl.java
@@ -27,6 +27,6 @@ public class DAPTextConsoleBuilderImpl extends TextConsoleBuilderImpl {
 
     @Override
     protected @NotNull ConsoleView createConsole() {
-        return new DAPConsoleView(getProject(), getScope(), isViewer(), isUsePredefinedMessageFilter());
+        return new DAPDuplexConsoleView(getProject(), getScope(), isViewer(), isUsePredefinedMessageFilter());
     }
 }

--- a/src/main/resources/messages/DAPBundle.properties
+++ b/src/main/resources/messages/DAPBundle.properties
@@ -62,3 +62,6 @@ dap.settings.editor.configuration.parameters.launch.tab=Launch
 dap.settings.editor.configuration.parameters.attach.tab=Attach
 dap.settings.editor.configuration.attach.address.field=Address:
 dap.settings.editor.configuration.attach.port.field=Port:
+
+# DAP console
+dap.console.log.show.dap=Show DAP Server Log


### PR DESCRIPTION
It can be quite difficult to find the application output in the DAP debugger output. Added separation to two switchable consoles.

Checked on LLDB-DAP.