### PR TITLE
feat: DAP installer API

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorerLifecycleListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/explorer/LanguageServerExplorerLifecycleListener.java
@@ -43,9 +43,9 @@ public class LanguageServerExplorerLifecycleListener implements LanguageServerLi
     }
 
     @Override
-    public void handleStatusChanged(LanguageServerWrapper languageServer) {
+    public void handleStatusChanged(@NotNull LanguageServerWrapper languageServer) {
         ServerStatus serverStatus = languageServer.getServerStatus();
-        boolean selectProcess = serverStatus == ServerStatus.starting;
+        boolean selectProcess = (serverStatus == ServerStatus.starting || serverStatus ==  ServerStatus.installing);
         updateServerStatus(languageServer, serverStatus, selectProcess);
     }
 
@@ -105,7 +105,8 @@ public class LanguageServerExplorerLifecycleListener implements LanguageServerLi
     }
 
     private @Nullable LanguageServerProcessTreeNode updateServerStatus(@NotNull LanguageServerWrapper languageServer,
-                                                                       @Nullable ServerStatus serverStatus, boolean selectProcess) {
+                                                                       @Nullable ServerStatus serverStatus,
+                                                                       boolean selectProcess) {
         LanguageServerTreeNode serverNode = explorer.findNodeForServer(languageServer.getServerDefinition());
         if (serverNode == null) {
             // Should never occur.

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugRunner.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugRunner.java
@@ -14,9 +14,15 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.configurations.RunnerSettings;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.runners.AsyncProgramRunner;
 import com.intellij.execution.runners.ExecutionEnvironment;
-import com.intellij.execution.runners.GenericProgramRunner;
+import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.execution.ui.RunContentManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugProcessStarter;
@@ -24,47 +30,129 @@ import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPCommandLineState;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPRunConfiguration;
-import org.jetbrains.annotations.NonNls;
+import com.redhat.devtools.lsp4ij.installation.CommandLineUpdater;
+import com.redhat.devtools.lsp4ij.installation.ConsoleProvider;
+import com.redhat.devtools.lsp4ij.installation.ServerInstallationStatus;
+import com.redhat.devtools.lsp4ij.installation.ServerInstaller;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.concurrency.AsyncPromise;
+import org.jetbrains.concurrency.Promise;
+import org.jetbrains.concurrency.Promises;
 
 /**
- * Debug Adapter Protocol (DAP) program runner.
+ * Debug runner that integrates with Debug Adapter Protocol (DAP).
+ * Handles server installation if necessary and launches the debug process.
  */
-public class DAPDebugRunner extends GenericProgramRunner {
+public class DAPDebugRunner extends AsyncProgramRunner<RunnerSettings> {
 
-    private static final @NotNull
-    @NonNls String RUNNER_ID = "DAPDebugRunner";
+    // ID used to associate with the default IntelliJ debug executor
+    public static final String DEBUG_EXECUTOR_ID = DefaultDebugExecutor.EXECUTOR_ID;
 
-    public static final String DEBUG_EXECUTOR_ID = "Debug";
+    // Unique ID for this runner
+    private static final String RUNNER_ID = "DAPDebugRunner";
 
     @Override
-    public @NotNull @NonNls String getRunnerId() {
+    public @NotNull String getRunnerId() {
         return RUNNER_ID;
     }
 
+    /**
+     * Determines whether this runner can handle the given run configuration.
+     */
     @Override
     public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
-        return profile instanceof DAPRunConfiguration dapProfile && dapProfile.canRun(executorId);
+        return profile instanceof DAPRunConfiguration dap && dap.canRun(executorId);
     }
 
+    /**
+     * Executes the run configuration. If the debugger needs to be installed, it shows
+     * a temporary console and performs installation first, then launches the debug session.
+     */
     @Override
-    protected @Nullable RunContentDescriptor doExecute(@NotNull RunProfileState state,
-                                                       @NotNull ExecutionEnvironment environment) throws ExecutionException {
-        FileDocumentManager.getInstance().saveAllDocuments();
-        return createContentDescriptor(state, environment);
+    protected @NotNull Promise<@Nullable RunContentDescriptor> execute(@NotNull ExecutionEnvironment env,
+                                                                       @NotNull RunProfileState state) {
+        FileDocumentManager.getInstance().saveAllDocuments(); // Ensure all documents are saved
+
+        final DAPCommandLineState dapState = (DAPCommandLineState) state;
+        var serverDefinition = dapState.getServerDescriptor().getServerDefinition();
+        final ServerInstaller installer = serverDefinition != null ? serverDefinition.getServerInstaller() : null;
+
+        // If already installed or no installer required, run directly
+        if (installer == null || installer.getStatus() == ServerInstallationStatus.INSTALLED) {
+            try {
+                return Promises.resolvedPromise(doExecute(env, dapState));
+            } catch (Exception e) {
+                return Promises.rejectedPromise(e);
+            }
+        }
+
+        // Otherwise, install the debugger first
+        AsyncPromise<RunContentDescriptor> promise = new AsyncPromise<>();
+
+        // Create a temporary console to show installation progress
+        var consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(env.getProject());
+        var console = consoleBuilder.getConsole();
+        console.print("⏳ Downloading debugger...\n", ConsoleViewContentType.NORMAL_OUTPUT);
+
+        RunContentDescriptor tempDescriptor = new RunContentDescriptor(
+                console, null, console.getComponent(), "DAP Debugger (initializing)"
+        );
+        RunContentManager.getInstance(env.getProject())
+                .showRunContent(env.getExecutor(), tempDescriptor);
+
+        var consoleProvider = new ConsoleProvider(console, env.getProject());
+        installer.registerConsoleProvider(consoleProvider);
+
+        // Trigger installation
+        installer
+                .checkInstallation()
+                .handle((ignored, err) -> {
+                    if (err != null) {
+                        ApplicationManager.getApplication().invokeLater(() -> {
+                            console.print("❌ Debugger installation failed: " + err.getMessage(),
+                                    ConsoleViewContentType.ERROR_OUTPUT);
+                            promise.setError(new ExecutionException("Debugger installation failed", err));
+                        });
+                        return null;
+                    }
+
+                    // Launch the debug session after installation
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        try {
+                            if (serverDefinition instanceof CommandLineUpdater commandLineUpdater) {
+                                dapState.setCommandLine(commandLineUpdater.getCommandLine());
+                            }
+
+                            RunContentDescriptor finalDescriptor = doExecute(env, dapState);
+
+                            // Remove temporary initialization console
+                            RunContentManager.getInstance(env.getProject())
+                                    .removeRunContent(env.getExecutor(), tempDescriptor);
+
+                            promise.setResult(finalDescriptor);
+                        } catch (Throwable e) {
+                            promise.setError(e);
+                        }
+                    });
+                    return null;
+                });
+
+        return promise;
     }
 
-    private RunContentDescriptor createContentDescriptor(@NotNull RunProfileState state,
-                                                         @NotNull ExecutionEnvironment environment) throws ExecutionException {
-        return XDebuggerManager.getInstance(environment.getProject())
-                .startSession(environment, new XDebugProcessStarter() {
+    /**
+     * Launches the actual debug session using the IntelliJ XDebugger infrastructure.
+     */
+    private @NotNull RunContentDescriptor doExecute(@NotNull ExecutionEnvironment env, DAPCommandLineState dapState)
+            throws ExecutionException {
+        return XDebuggerManager.getInstance(env.getProject())
+                .startSession(env, new XDebugProcessStarter() {
                     @Override
-                    public @NotNull XDebugProcess start(final @NotNull XDebugSession session) throws ExecutionException {
-                        final DAPCommandLineState dapState = (DAPCommandLineState) state;
-                        final ExecutionResult executionResult = state.execute(environment.getExecutor(), DAPDebugRunner.this);
-                        boolean debugMode = DEBUG_EXECUTOR_ID.equals(environment.getExecutor().getId());
-                        return new DAPDebugProcess(dapState, session, executionResult, debugMode);
+                    public @NotNull XDebugProcess start(@NotNull XDebugSession session) throws ExecutionException {
+                        ExecutionResult result = dapState.execute(env.getExecutor(), DAPDebugRunner.this);
+                        boolean debugMode = DEBUG_EXECUTOR_ID.equals(env.getExecutor().getId());
+                        return new DAPDebugProcess(dapState, session, result, debugMode);
                     }
                 }).getRunContentDescriptor();
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/DebugAdapterManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/DebugAdapterManager.java
@@ -189,7 +189,8 @@ public class DebugAdapterManager implements DebuggableFile {
             @NotNull List<ServerMappingSettings> fileTypeMappings,
             @Nullable List<LaunchConfiguration> launchConfigurations,
             @Nullable String attachAddress,
-            @Nullable String attachPort) {
+            @Nullable String attachPort,
+            @Nullable String installerConfiguration) {
     }
 
     /**
@@ -216,6 +217,7 @@ public class DebugAdapterManager implements DebuggableFile {
         serverDefinition.setFileTypeMappings(request.fileTypeMappings());
 
         serverDefinition.setLaunchConfigurations(request.launchConfigurations());
+        serverDefinition.setInstallerConfiguration(request.installerConfiguration());
 
         List<ServerMappingSettings> mappings = Stream.concat(request.languageMappings().stream(), request.fileTypeMappings().stream()).toList();
         UserDefinedDebugAdapterServerSettings.ItemSettings settings = UserDefinedDebugAdapterServerSettings.getInstance().getSettings(serverId);
@@ -229,6 +231,7 @@ public class DebugAdapterManager implements DebuggableFile {
         boolean launchConfigurationChanged = !Objects.equals(settings.getLaunchConfigurations(), request.launchConfigurations());
         boolean attachAddressChanged = !Objects.equals(settings.getAttachAddress(), request.attachAddress());
         boolean attachPortChanged = !Objects.equals(settings.getAttachAddress(), request.attachPort());
+        boolean installerConfigurationChanged = !Objects.equals(settings.getInstallerConfiguration(), request.installerConfiguration());
 
         // Not checking whether client config changed because that shouldn't result in a LanguageServerChangedEvent
 
@@ -241,11 +244,12 @@ public class DebugAdapterManager implements DebuggableFile {
         settings.setDebugServerReadyPattern(request.debugServerReadyPattern);
         settings.setMappings(mappings);
         settings.setLaunchConfigurations(request.launchConfigurations());
+        settings.setInstallerConfiguration(request.installerConfiguration());
 
         if (nameChanged || userEnvironmentVariablesChanged || includeSystemEnvironmentVariablesChanged ||
                 commandChanged || connectTimeoutChanged || debugServerReadyPatternChanged ||
                 mappingsChanged || launchConfigurationChanged ||
-        attachAddressChanged || attachPortChanged) {
+        attachAddressChanged || attachPortChanged || installerConfigurationChanged) {
             // Notifications
             DebugAdapterServerListener.ChangedEvent event = new DebugAdapterServerListener.ChangedEvent(
                     serverDefinition,
@@ -258,7 +262,8 @@ public class DebugAdapterManager implements DebuggableFile {
                     mappingsChanged,
                     launchConfigurationChanged,
                     attachAddressChanged,
-                    attachPortChanged);
+                    attachPortChanged,
+                    installerConfigurationChanged);
             if (notify) {
                 handleChangeEvent(event);
             }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPCommandLineState.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPCommandLineState.java
@@ -23,6 +23,7 @@ import com.redhat.devtools.lsp4ij.dap.configurations.options.FileOptionConfigura
 import com.redhat.devtools.lsp4ij.dap.console.DAPTextConsoleBuilderImpl;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptor;
 import com.redhat.devtools.lsp4ij.dap.descriptors.ServerReadyConfig;
+import com.redhat.devtools.lsp4ij.installation.CommandLineUpdater;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,7 +33,7 @@ import java.util.Map;
 /**
  * Debug Adapter Protocol (DAP) command line state.
  */
-public class DAPCommandLineState extends CommandLineState {
+public class DAPCommandLineState extends CommandLineState implements CommandLineUpdater {
 
     private final @NotNull RunConfigurationOptions options;
     private final @NotNull DebugAdapterDescriptor serverDescriptor;
@@ -99,4 +100,26 @@ public class DAPCommandLineState extends CommandLineState {
         }
         return null;
     }
+
+    @Override
+    public @Nullable String getCommandLine() {
+        if (options instanceof CommandLineUpdater commandLineUpdater) {
+            return commandLineUpdater.getCommandLine();
+        }
+        return null;
+    }
+
+    @Override
+    public void setCommandLine(String commandLine) {
+        if (options instanceof CommandLineUpdater commandLineUpdater) {
+            commandLineUpdater.setCommandLine(commandLine);
+        }
+    }
+    public @Nullable String getInstallerConfiguration() {
+        if (options instanceof DAPRunConfigurationOptions dapOptions) {
+            return dapOptions.getInstallerConfiguration();
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPRunConfigurationOptions.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPRunConfigurationOptions.java
@@ -23,6 +23,7 @@ import com.redhat.devtools.lsp4ij.dap.configurations.extractors.NetworkAddressEx
 import com.redhat.devtools.lsp4ij.dap.configurations.options.FileOptionConfigurable;
 import com.redhat.devtools.lsp4ij.dap.configurations.options.WorkingDirectoryConfigurable;
 import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
+import com.redhat.devtools.lsp4ij.installation.CommandLineUpdater;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import com.redhat.devtools.lsp4ij.templates.ServerMappingSettings;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
@@ -35,7 +36,7 @@ import java.util.List;
 /**
  * Debug Adapter Protocol (DAP) run configuration options.
  */
-public class DAPRunConfigurationOptions extends RunConfigurationOptions implements FileOptionConfigurable, WorkingDirectoryConfigurable, DebuggableFile {
+public class DAPRunConfigurationOptions extends RunConfigurationOptions implements FileOptionConfigurable, WorkingDirectoryConfigurable, DebuggableFile, CommandLineUpdater {
 
     @Nullable
     private NetworkAddressExtractor networkAddressExtractor;
@@ -208,6 +209,16 @@ public class DAPRunConfigurationOptions extends RunConfigurationOptions implemen
 
     public void setServerUrl(String serverUrl) {
         this.serverUrl.setValue(this, serverUrl);
+    }
+
+    @Override
+    public String getCommandLine() {
+        return getCommand();
+    }
+
+    @Override
+    public void setCommandLine(String commandLine) {
+        setCommand(commandLine);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/DebugAdapterServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/DebugAdapterServerDefinition.java
@@ -17,11 +17,13 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.dap.configurations.DebuggableFile;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.installation.ServerInstaller;
 import com.redhat.devtools.lsp4ij.server.definition.ServerFileNamePatternMapping;
 import com.redhat.devtools.lsp4ij.server.definition.ServerFileTypeMapping;
 import com.redhat.devtools.lsp4ij.server.definition.ServerLanguageMapping;
 import com.redhat.devtools.lsp4ij.server.definition.ServerMapping;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.List;
@@ -51,6 +53,9 @@ public abstract class DebugAdapterServerDefinition implements DebuggableFile {
     private final @NotNull String id;
     private @NotNull String name;
     private @NotNull DebugAdapterDescriptorFactory factory;
+
+    private boolean serverInstallerCreated;
+    private @Nullable ServerInstaller serverInstaller;
 
     /**
      * Creates a new debug adapter server definition with a given ID and name.
@@ -181,4 +186,20 @@ public abstract class DebugAdapterServerDefinition implements DebuggableFile {
      * @return a list of {@link ServerMapping} instances
      */
     protected abstract List<ServerMapping> getServerMappings();
+
+    public @Nullable ServerInstaller getServerInstaller() {
+        if (serverInstallerCreated) {
+            return serverInstaller;
+        }
+        return getServerInstallerSync();
+    }
+
+    private synchronized @Nullable ServerInstaller getServerInstallerSync() {
+        if (serverInstallerCreated) {
+            return serverInstaller;
+        }
+        serverInstaller = getFactory().createServerInstaller();
+        serverInstallerCreated = true;
+        return serverInstaller;
+    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/userdefined/UserDefinedDebugAdapterDescriptorFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/userdefined/UserDefinedDebugAdapterDescriptorFactory.java
@@ -16,8 +16,10 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.dap.DebugServerWaitStrategy;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPRunConfiguration;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory;
+import com.redhat.devtools.lsp4ij.installation.ServerInstaller;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.stream.Stream;
 
@@ -52,7 +54,6 @@ public class UserDefinedDebugAdapterDescriptorFactory extends DebugAdapterDescri
                 DebugServerWaitStrategy debugServerWaitStrategy = DebugServerWaitStrategy.TIMEOUT;
                 int connectTimeout = serverDefinition.getConnectTimeout();
                 if (connectTimeout > 0) {
-                    debugServerWaitStrategy = DebugServerWaitStrategy.TIMEOUT;
                     dapConfiguration.setConnectTimeout(connectTimeout);
                 } else {
                     String trackTrace = serverDefinition.getDebugServerReadyPattern();
@@ -71,7 +72,12 @@ public class UserDefinedDebugAdapterDescriptorFactory extends DebugAdapterDescri
     }
 
     @Override
-    public UserDefinedDebugAdapterServerDefinition getServerDefinition() {
+    public @NotNull UserDefinedDebugAdapterServerDefinition getServerDefinition() {
         return (UserDefinedDebugAdapterServerDefinition) super.getServerDefinition();
+    }
+
+    @Override
+    public @Nullable ServerInstaller createServerInstaller() {
+        return new UserDefinedDebugAdapterServerInstaller(getServerDefinition());
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/userdefined/UserDefinedDebugAdapterServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/userdefined/UserDefinedDebugAdapterServerDefinition.java
@@ -15,6 +15,10 @@ import com.redhat.devtools.lsp4ij.dap.LaunchConfiguration;
 import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory;
 import com.redhat.devtools.lsp4ij.installation.CommandLineUpdater;
+import com.redhat.devtools.lsp4ij.installation.ServerInstaller;
+import com.redhat.devtools.lsp4ij.installation.definition.ServerInstallerDescriptor;
+import com.redhat.devtools.lsp4ij.installation.definition.ServerInstallerManager;
+import com.redhat.devtools.lsp4ij.server.definition.launching.UserDefinedLanguageServerInstaller;
 import com.redhat.devtools.lsp4ij.templates.ServerMappingSettings;
 import com.redhat.devtools.lsp4ij.server.definition.ServerMapping;
 import org.jetbrains.annotations.NotNull;
@@ -71,6 +75,7 @@ public class UserDefinedDebugAdapterServerDefinition extends DebugAdapterServerD
     // Installer
     private @Nullable String installerConfiguration;
     private @Nullable String url;
+    private @Nullable ServerInstallerDescriptor serverInstallerDescriptor;
 
     /**
      * Creates a user-defined debug adapter server definition.
@@ -300,6 +305,7 @@ public class UserDefinedDebugAdapterServerDefinition extends DebugAdapterServerD
 
     public void setInstallerConfiguration(@Nullable String installerConfiguration) {
         this.installerConfiguration = installerConfiguration;
+        this.serverInstallerDescriptor = null;
     }
 
     public @Nullable String getUrl() {
@@ -309,4 +315,17 @@ public class UserDefinedDebugAdapterServerDefinition extends DebugAdapterServerD
     public void setUrl(@Nullable String url) {
         this.url = url;
     }
+
+    @Nullable
+    public ServerInstallerDescriptor getServerInstallerDescriptor() {
+        if ((serverInstallerDescriptor == null) && (installerConfiguration != null) && !installerConfiguration.isBlank()) {
+            try {
+                serverInstallerDescriptor = ServerInstallerManager.getInstance().loadInstaller(installerConfiguration);
+            } catch (Exception e) {
+                // Do nothing
+            }
+        }
+        return serverInstallerDescriptor;
+    }
+
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/userdefined/UserDefinedDebugAdapterServerInstaller.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/definitions/userdefined/UserDefinedDebugAdapterServerInstaller.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.definitions.userdefined;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
+import com.redhat.devtools.lsp4ij.dap.installation.DeclarativeDebugAdapterServerInstaller;
+import com.redhat.devtools.lsp4ij.dap.settings.ui.UICommandLineUpdater;
+import com.redhat.devtools.lsp4ij.installation.ServerInstallationStatus;
+import com.redhat.devtools.lsp4ij.installation.definition.InstallerContext;
+import com.redhat.devtools.lsp4ij.installation.definition.ServerInstallerDescriptor;
+import com.redhat.devtools.lsp4ij.launching.UserDefinedLanguageServerSettings;
+import com.redhat.devtools.lsp4ij.server.definition.launching.UserDefinedLanguageServerDefinition;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Debug Adapter server installer specifically for user-defined DAP servers.
+ * <p>
+ * This implementation extends {@link DeclarativeDebugAdapterServerInstaller}
+ * and provides additional logic for remembering whether installation
+ * has already been performed, in order to prevent re-installation
+ * on subsequent startups.
+ * </p>
+ *
+ * <p>
+ * It also configures the {@link InstallerContext} to include a {@link com.redhat.devtools.lsp4ij.dap.settings.ui.UICommandLineUpdater}
+ * based on the user-defined DAP server settings.
+ * </p>
+ */
+public class UserDefinedDebugAdapterServerInstaller extends DeclarativeDebugAdapterServerInstaller {
+
+    private boolean initialized;
+
+    /**
+     * Constructs a new installer for the specified user-defined DAP server definition.
+     *
+     * @param serverDefinition the user-defined server definition
+     */
+    public UserDefinedDebugAdapterServerInstaller(@Nullable DebugAdapterServerDefinition serverDefinition) {
+        super(serverDefinition);
+        this.initialized = false;
+    }
+
+    /**
+     * Executes the installation check and ensures settings are updated once.
+     *
+     * @param checkInstallationFuture future representing the status of the check
+     * @return the same future passed as input
+     */
+    @Override
+    protected @NotNull CompletableFuture<ServerInstallationStatus> execute(@NotNull CompletableFuture<ServerInstallationStatus> checkInstallationFuture) {
+        if (!initialized) {
+            initialize(checkInstallationFuture);
+        }
+        return checkInstallationFuture;
+    }
+
+    /**
+     * Registers a one-time completion handler that sets {@code installAlreadyDone = true}
+     * in the user's configuration once the installation check completes.
+     *
+     * @param checkInstallationFuture the future to attach the handler to
+     */
+    private synchronized void initialize(@NotNull CompletableFuture<ServerInstallationStatus> checkInstallationFuture) {
+        if (initialized) {
+            return;
+        }
+        checkInstallationFuture.handle((result, error) -> {
+            var settings = getSettings();
+            if (settings != null) {
+                settings.setInstallAlreadyDone(true);
+            }
+            return result;
+        });
+        initialized = true;
+    }
+
+    /**
+     * Returns the installer descriptor for the current user-defined DAP server.
+     *
+     * @return the installer descriptor, or {@code null} if not available
+     */
+    @Override
+    protected @Nullable ServerInstallerDescriptor getServerInstallerDescriptor() {
+        var serverDefinition = getUserDefinedLanguageServerDefinition();
+        return serverDefinition != null ? serverDefinition.getServerInstallerDescriptor() : null;
+    }
+
+    /**
+     * Creates an installer context and attaches a UI-based command-line updater.
+     *
+     * @param action    the installer action (CHECK or RUN)
+     * @param indicator the progress indicator
+     * @return the customized installer context
+     */
+    @Override
+    protected @NotNull InstallerContext createInstallerContext(InstallerContext.@NotNull InstallerAction action,
+                                                               @NotNull ProgressIndicator indicator) {
+        var context = super.createInstallerContext(action, indicator);
+        var serverDefinition = getUserDefinedLanguageServerDefinition();
+        if (serverDefinition != null) {
+            context.setCommandLineUpdater(new UICommandLineUpdater(serverDefinition));
+        }
+        return context;
+    }
+
+    /**
+     * Gets the user-defined DAP server definition, if applicable.
+     *
+     * @return the {@link UserDefinedLanguageServerDefinition}, or {@code null} if not applicable
+     */
+    private @Nullable UserDefinedDebugAdapterServerDefinition getUserDefinedLanguageServerDefinition() {
+        var serverDefinition = getServerDefinition();
+        if (serverDefinition instanceof UserDefinedDebugAdapterServerDefinition ls) {
+            return ls;
+        }
+        return null;
+    }
+
+    /**
+     * Checks if installation should be executed, even if the descriptor says not to.
+     * <p>
+     * If {@link UserDefinedLanguageServerSettings.UserDefinedLanguageServerItemSettings#isInstallAlreadyDone()} is false,
+     * installation will proceed regardless of the descriptor's settings.
+     * </p>
+     *
+     * @param serverInstallerDescriptor the installer descriptor
+     * @return {@code true} if installation should proceed
+     */
+    @Override
+    protected boolean canExecute(@NotNull ServerInstallerDescriptor serverInstallerDescriptor) {
+        if (super.canExecute(serverInstallerDescriptor)) {
+            return true;
+        }
+        /*UserDefinedLanguageServerSettings.UserDefinedLanguageServerItemSettings settings = getSettings();
+        if (settings != null) {
+            return !settings.isInstallAlreadyDone();
+        }
+        return false;*/
+        return true;
+    }
+
+    /**
+     * Retrieves the user's stored settings for the current user-defined DAP server.
+     *
+     * @return the item settings or {@code null} if not found
+     */
+    private UserDefinedLanguageServerSettings.@Nullable UserDefinedLanguageServerItemSettings getSettings() {
+        var serverDefinition = getUserDefinedLanguageServerDefinition();
+        if (serverDefinition == null) {
+            return null;
+        }
+        String languageServerId = serverDefinition.getId();
+        return UserDefinedLanguageServerSettings.getInstance().getLaunchConfigSettings(languageServerId);
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactory.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.dap.DebugMode;
 import com.redhat.devtools.lsp4ij.dap.LaunchConfiguration;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPRunConfiguration;
@@ -26,9 +27,11 @@ import com.redhat.devtools.lsp4ij.dap.configurations.DAPSettingsEditor;
 import com.redhat.devtools.lsp4ij.dap.configurations.DebuggableFile;
 import com.redhat.devtools.lsp4ij.dap.configurations.options.FileOptionConfigurable;
 import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
+import com.redhat.devtools.lsp4ij.installation.ServerInstaller;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -160,5 +163,23 @@ public abstract class DebugAdapterDescriptorFactory implements DebuggableFile {
         assert pluginPath != null;
         pluginPath = pluginPath.toAbsolutePath();
         return pluginPath.resolve(serverPath);
+    }
+
+    /**
+     * Creates a server installer intended to install a server shared by all projects (global scope).
+     *
+     * <p>
+     * The server may be installed in the user's home directory, making it accessible to all projects.
+     * </p>
+     *
+     * <p>
+     * To install a server for a specific project only (project scope), use {@link LSPClientFeatures#setServerInstaller(ServerInstaller)} instead.
+     * </p>
+     *
+     * @return a {@link ServerInstaller} for global use, or {@code null} if no global installer is provided.
+     */
+    @Nullable
+    public ServerInstaller createServerInstaller() {
+        return null;
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterServerListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterServerListener.java
@@ -61,6 +61,7 @@ public interface DebugAdapterServerListener {
         public final boolean launchConfigurationsContentChanged;
         private final boolean attachAddressChanged;
         private final boolean attachPortChanged;
+        private final boolean installerConfigurationChanged;
 
         public ChangedEvent(@NotNull DebugAdapterServerDefinition serverDefinition,
                             boolean nameChanged,
@@ -72,7 +73,8 @@ public interface DebugAdapterServerListener {
                             boolean mappingsChanged,
                             boolean launchConfigurationsContentChanged,
                             boolean attachAddressChanged,
-                            boolean attachPortChanged) {
+                            boolean attachPortChanged,
+                            boolean installerConfigurationChanged) {
             this.serverDefinition = serverDefinition;
             this.nameChanged = nameChanged;
             this.commandChanged = commandChanged;
@@ -84,6 +86,7 @@ public interface DebugAdapterServerListener {
             this.launchConfigurationsContentChanged = launchConfigurationsContentChanged;
             this.attachAddressChanged = attachAddressChanged;
             this.attachPortChanged = attachPortChanged;
+            this.installerConfigurationChanged = installerConfigurationChanged;
         }
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DefaultDebugAdapterDescriptor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DefaultDebugAdapterDescriptor.java
@@ -24,6 +24,7 @@ import com.redhat.devtools.lsp4ij.dap.client.LaunchUtils;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPRunConfigurationOptions;
 import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
 import com.redhat.devtools.lsp4ij.dap.definitions.userdefined.UserDefinedDebugAdapterServerDefinition;
+import com.redhat.devtools.lsp4ij.installation.CommandLineUpdater;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import org.jetbrains.annotations.ApiStatus;
@@ -80,7 +81,7 @@ public class DefaultDebugAdapterDescriptor extends DebugAdapterDescriptor {
             String command = dapOptions.getCommand();
             if (StringUtils.isBlank(command)) {
                 var server = dapOptions.getDebugAdapterServer();
-                if (server instanceof UserDefinedDebugAdapterServerDefinition userDefinedServer) {
+                if (server instanceof CommandLineUpdater userDefinedServer) {
                     command = userDefinedServer.getCommandLine();
                 }
             }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/installation/DebugAdapterServerInstallerBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/installation/DebugAdapterServerInstallerBase.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.installation;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.redhat.devtools.lsp4ij.*;
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatureAware;
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
+import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
+import com.redhat.devtools.lsp4ij.installation.ServerInstallationStatus;
+import com.redhat.devtools.lsp4ij.installation.ServerInstallerBase;
+import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Base class to install a DAP server.
+ */
+public abstract class DebugAdapterServerInstallerBase extends ServerInstallerBase  {
+
+    private final @Nullable DebugAdapterServerDefinition serverDefinition;
+
+    public DebugAdapterServerInstallerBase() {
+        this(null);
+    }
+
+    public DebugAdapterServerInstallerBase(@Nullable DebugAdapterServerDefinition serverDefinition) {
+        this.serverDefinition = serverDefinition;
+    }
+
+    protected @Nullable DebugAdapterServerDefinition getServerDefinition() {
+        return serverDefinition;
+    }
+
+    /**
+     * Gets the title of the installation task.
+     *
+     * @return the title for the installation task.
+     */
+    protected String getInstallationTaskTitle() {
+        return LanguageServerBundle.message("server.installer.lsp.task.installing", getServerName());
+    }
+
+    /**
+     * Displays progress while checking if the server is installed.
+     *
+     * @param indicator the progress indicator to update with progress.
+     */
+    protected void progressCheckingServerInstalled(@NotNull ProgressIndicator indicator) {
+        progress(LanguageServerBundle.message("server.installer.lsp.progress.check.installed", getServerName()), 0.1d, indicator);
+    }
+
+    /**
+     * Displays progress during the installation process.
+     *
+     * @param indicator the progress indicator to update with progress.
+     */
+    protected void progressInstallingServer(@NotNull ProgressIndicator indicator) {
+        progress(LanguageServerBundle.message("server.installer.lsp.progress.installing", getServerName()), 0.2d, indicator);
+    }
+
+    /**
+     * Returns the language server name.
+     *
+     * @return the language server name.
+     */
+    protected @NotNull String getServerName() {
+        var serverDefinition = getServerDefinition();
+        return serverDefinition != null ? serverDefinition.getDisplayName() : "";
+    }
+
+    @Override
+    protected @Nullable Project getProject() {
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/installation/DeclarativeDebugAdapterServerInstaller.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/installation/DeclarativeDebugAdapterServerInstaller.java
@@ -11,9 +11,12 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.lsp4ij.installation;
+package com.redhat.devtools.lsp4ij.dap.installation;
 
 import com.intellij.openapi.progress.ProgressIndicator;
+import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
+import com.redhat.devtools.lsp4ij.installation.LanguageServerInstallerBase;
+import com.redhat.devtools.lsp4ij.installation.ServerInstallationStatus;
 import com.redhat.devtools.lsp4ij.installation.definition.InstallerContext;
 import com.redhat.devtools.lsp4ij.installation.definition.ServerInstallerDescriptor;
 import com.redhat.devtools.lsp4ij.installation.definition.ServerInstallerManager;
@@ -24,9 +27,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Abstract base class for declarative language server installers in IntelliJ.
+ * Abstract base class for declarative DAP server installers in IntelliJ.
  * <p>
- * This class provides a framework for installing language servers based on
+ * This class provides a framework for installing DAP servers based on
  * a {@code serverInstallerDescriptor}, typically declared in a {@code installer.json}
  * file associated with a {@link LanguageServerDefinition}.
  * </p>
@@ -39,33 +42,33 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>
  * If no installer descriptor is available, or if the descriptor is not meant to be executed,
- * the language server is considered already installed.
+ * the DAP server is considered already installed.
  * </p>
  *
- * @see LanguageServerInstallerBase
+ * @see DebugAdapterServerInstallerBase
  * @see ServerInstallerDescriptor
  * @see ServerInstallerManager
  */
-public abstract class DeclarativeLanguageServerInstaller extends LanguageServerInstallerBase {
+public abstract class DeclarativeDebugAdapterServerInstaller extends DebugAdapterServerInstallerBase {
 
     /**
-     * Constructs a new declarative language server installer with no initial definition.
+     * Constructs a new declarative DAP server installer with no initial definition.
      */
-    public DeclarativeLanguageServerInstaller() {
+    public DeclarativeDebugAdapterServerInstaller() {
         this(null);
     }
 
     /**
-     * Constructs a new declarative language server installer for the given definition.
+     * Constructs a new declarative DAP server installer for the given definition.
      *
-     * @param serverDefinition the language server definition
+     * @param serverDefinition the DAP server definition
      */
-    public DeclarativeLanguageServerInstaller(@Nullable LanguageServerDefinition serverDefinition) {
+    public DeclarativeDebugAdapterServerInstaller(@Nullable DebugAdapterServerDefinition serverDefinition) {
         super(serverDefinition);
     }
 
     /**
-     * Checks whether the language server installation is needed or already completed.
+     * Checks whether the DAP server installation is needed or already completed.
      * <p>
      * If a {@link ServerInstallerDescriptor} is provided and marked as executable,
      * defers to {@link #execute(CompletableFuture)} to proceed with installation checks.
@@ -77,7 +80,7 @@ public abstract class DeclarativeLanguageServerInstaller extends LanguageServerI
     public @NotNull CompletableFuture<ServerInstallationStatus> checkInstallation() {
         ServerInstallerDescriptor serverInstallerDescriptor = getServerInstallerDescriptor();
         if (serverInstallerDescriptor == null) {
-            // The user defined language server doesn't define an installer.json
+            // The user defined DAP server doesn't define an installer.json
             // we consider that installation is done
             return INSTALLED_FUTURE;
         }
@@ -101,7 +104,7 @@ public abstract class DeclarativeLanguageServerInstaller extends LanguageServerI
     }
 
     /**
-     * Executes a declarative check for whether the language server is already installed.
+     * Executes a declarative check for whether the DAP server is already installed.
      * <p>
      * This uses the {@link ServerInstallerManager} in CHECK mode and disables user notifications.
      * </p>
@@ -122,7 +125,7 @@ public abstract class DeclarativeLanguageServerInstaller extends LanguageServerI
     }
 
     /**
-     * Determines whether the installer should be executed on language server startup.
+     * Determines whether the installer should be executed on DAP server startup.
      *
      * @param serverInstallerDescriptor the installer descriptor to inspect
      * @return {@code true} if executable; {@code false} otherwise

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterServerPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterServerPanel.java
@@ -357,8 +357,8 @@ public class DebugAdapterServerPanel implements Disposable {
     }
 
     private void addInstallerTab(@NotNull JBTabbedPane tabbedPane) {
-        FormBuilder installerTab = addTab(tabbedPane, LanguageServerBundle.message("language.server.tab.installer"), false);
-        this.installerPanel = new InstallerPanel(installerTab, commandLine, true, true, project);
+        FormBuilder installerTab = addTab(tabbedPane, DAPBundle.message("dap.settings.editor.installer.tab"), false);
+        this.installerPanel = new InstallerPanel(installerTab, false, project);
     }
 
     public void setCommandLineUpdater(@Nullable CommandLineUpdater commandLineUpdater) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterServerView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/DebugAdapterServerView.java
@@ -94,7 +94,8 @@ public class DebugAdapterServerView implements Disposable {
                     && isEquals(this.getDebugServerReadyPattern(), settings.getDebugServerReadyPattern())
                     && isEquals(this.getAttachAddress(), settings.getAttachAddress())
                     && isEquals(this.getAttachPort(), settings.getAttachPort())
-                    && Objects.equals(this.getMappings(), settings.getMappings()));
+                    && Objects.equals(this.getMappings(), settings.getMappings())
+                    && isEquals(this.getInstallerConfiguration(), settings.getInstallerConfiguration()));
         }
         return false;
     }
@@ -143,6 +144,8 @@ public class DebugAdapterServerView implements Disposable {
                         .filter(mapping -> mapping.getFileNamePatterns() != null)
                         .collect(Collectors.toList());
                 this.setFileNamePatternMappings(fileNamePatternMappings);
+
+                this.setInstallerConfiguration(settings.getInstallerConfiguration());
             }
         } else {
             // TODO : extension point
@@ -213,7 +216,8 @@ public class DebugAdapterServerView implements Disposable {
                                     getFileTypeMappings(),
                                     getLaunchConfigurations(),
                                     getAttachAddress(),
-                                    getAttachPort()),
+                                    getAttachPort(),
+                                    getInstallerConfiguration()),
                             false);
             if (settingsChangedEvent != null) {
                 // Settings has changed, fire the event
@@ -343,11 +347,6 @@ public class DebugAdapterServerView implements Disposable {
         mappingPanel.setFileNamePatternMappings(mappings);
     }
 
-    @Override
-    public void dispose() {
-        debugAdapterServerPanel.dispose();
-    }
-
     public List<ServerMappingSettings> getLanguageMappings() {
         return mappingPanel.getLanguageMappings();
     }
@@ -365,8 +364,18 @@ public class DebugAdapterServerView implements Disposable {
                 .toList();
     }
 
-    public void refreshLaunchConfigurations(List<LaunchConfiguration> launchConfigurations) {
-        debugAdapterServerPanel.refreshLaunchConfigurations(launchConfigurations);
+
+    public String getInstallerConfiguration() {
+        return debugAdapterServerPanel.getInstallerConfiguration();
+    }
+
+    public void setInstallerConfiguration(String installerConfiguration) {
+        debugAdapterServerPanel.setInstallerConfiguration(installerConfiguration);
+    }
+
+    @Override
+    public void dispose() {
+        debugAdapterServerPanel.dispose();
     }
 
     public @Nullable List<LaunchConfiguration> getLaunchConfigurations() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/NewDebugAdapterServerDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/NewDebugAdapterServerDialog.java
@@ -11,25 +11,16 @@
 package com.redhat.devtools.lsp4ij.dap.settings.ui;
 
 import com.google.common.collect.Streams;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.ui.MessageDialogBuilder;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.HyperlinkLabel;
 import com.intellij.util.ui.FormBuilder;
-import com.redhat.devtools.lsp4ij.ServerMessageHandler;
 import com.redhat.devtools.lsp4ij.dap.DAPBundle;
 import com.redhat.devtools.lsp4ij.dap.DebugAdapterManager;
 import com.redhat.devtools.lsp4ij.dap.definitions.userdefined.UserDefinedDebugAdapterServerDefinition;
 import com.redhat.devtools.lsp4ij.dap.descriptors.templates.DAPTemplate;
-import com.redhat.devtools.lsp4ij.installation.CommandLineUpdater;
-import com.redhat.devtools.lsp4ij.installation.definition.InstallerContext;
-import com.redhat.devtools.lsp4ij.installation.definition.ServerInstallerManager;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -208,31 +199,6 @@ public class NewDebugAdapterServerDialog extends DialogWrapper {
         createdServer.setAttachPort(attachPort);
         createdServer.setInstallerConfiguration(installerConfiguration);
         DebugAdapterManager.getInstance().addDebugAdapterServer(createdServer);
-
-        if (installerConfiguration != null && StringUtils.isNotBlank(installerConfiguration) && !installerConfiguration.equals("{}")) {
-            if (MessageDialogBuilder.yesNo(DAPBundle.message("new.debug.adapter.dialog.install.title"),
-                            DAPBundle.message("new.debug.adapter.dialog.install.content"))
-                    .ask(project)) {
-                try {
-                    var context = createInstallerContext();
-                    ServerInstallerManager
-                            .getInstance()
-                            .install(installerConfiguration, context);
-                } catch (Exception s) {
-                    Notification notification = new Notification(ServerMessageHandler.LSP_WINDOW_SHOW_MESSAGE_GROUP_ID,
-                            "Install error",
-                            s.getMessage(),
-                            NotificationType.ERROR);
-                    Notifications.Bus.notify(notification, project);
-                }
-            }
-        }
-    }
-
-    private @NotNull InstallerContext createInstallerContext() {
-        var context = new InstallerContext(project, InstallerContext.InstallerAction.CHECK_AND_RUN);
-        context.setCommandLineUpdater(new UICommandLineUpdater(createdServer));
-        return context;
     }
 
     private void addValidator(JTextComponent textComponent) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/UICommandLineUpdater.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/UICommandLineUpdater.java
@@ -57,6 +57,7 @@ public class UICommandLineUpdater implements CommandLineUpdater {
                 false,
                 false,
                 false,
+                false,
                 false);
         DebugAdapterManager.getInstance().handleChangeEvent(event);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/installation/ConsoleProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/installation/ConsoleProvider.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.installation;
+
+import com.intellij.execution.impl.ConsoleViewImpl;
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Provides an abstraction around IntelliJ's ConsoleView,
+ * allowing custom printing and live-updating progress messages.
+ */
+public class ConsoleProvider {
+
+    // The console instance used to display output
+    private final @NotNull ConsoleView console;
+
+    // The associated IntelliJ project
+    private final @NotNull Project project;
+
+    /**
+     * Constructs a ConsoleProvider with the given console and project.
+     */
+    public ConsoleProvider(@NotNull ConsoleView console,
+                           @NotNull Project project) {
+        this.console = console;
+        this.project = project;
+    }
+
+    /**
+     * Returns the associated ConsoleView instance.
+     */
+    public @NotNull ConsoleView getConsole() {
+        return console;
+    }
+
+    /**
+     * Returns the associated Project.
+     */
+    public @NotNull Project getProject() {
+        return project;
+    }
+
+    /**
+     * Clears all content in the console.
+     */
+    public void clear() {
+        console.clear();
+    }
+
+    /**
+     * Prints a message to the console, followed by a newline.
+     *
+     * @param message     the text to print
+     * @param contentType the content type (normal, error, etc.)
+     */
+    public void print(@Nullable String message,
+                      @NotNull ConsoleViewContentType contentType) {
+        console.print(message + "\n", contentType);
+    }
+
+    /**
+     * Replaces the last printed line in the console with the specified message.
+     * Useful for showing progress updates without flooding the console.
+     *
+     * If the console does not support direct document access, falls back to standard print.
+     *
+     * @param message the message to replace the last line with
+     */
+    public void printProgress(@Nullable String message) {
+        if (message == null) {
+            return;
+        }
+
+        // Check if we can access the underlying editor (ConsoleViewImpl)
+        if (console instanceof ConsoleViewImpl consoleView) {
+            Editor editor = consoleView.getEditor();
+            if (editor != null) {
+                Document document = editor.getDocument();
+                // Perform document update in a write-safe context
+                WriteCommandAction.runWriteCommandAction(project, () -> {
+                    try {
+                        int lineCount = document.getLineCount();
+                        if (lineCount > 0) {
+                            int startOffset = document.getLineStartOffset(lineCount - 1);
+                            int endOffset = document.getLineEndOffset(lineCount - 1);
+                            document.replaceString(startOffset, endOffset, message);
+                        } else {
+                            document.insertString(0, message);
+                        }
+                    } catch (Exception e) {
+                        // On failure, just print the message normally
+                        print(message, ConsoleViewContentType.NORMAL_OUTPUT);
+                    }
+                });
+            }
+        } else {
+            // If not a ConsoleViewImpl, fallback to normal print
+            print(message, ConsoleViewContentType.NORMAL_OUTPUT);
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/installation/PrintableProgressIndicator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/installation/PrintableProgressIndicator.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.installation;
+
+import com.intellij.ide.util.DelegatingProgressIndicator;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.util.NlsContexts;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A progress indicator that can also output progress messages
+ * (e.g., to a console) instead of just updating the UI.
+ *
+ * This class extracts and prints meaningful progress messages
+ * when they are embedded in HTML-formatted text (e.g., during downloads).
+ */
+public abstract class PrintableProgressIndicator extends DelegatingProgressIndicator {
+
+    /**
+     * Constructs a PrintableProgressIndicator that delegates to an existing ProgressIndicator.
+     *
+     * @param indicator the base progress indicator to delegate to
+     */
+    public PrintableProgressIndicator(@NotNull ProgressIndicator indicator) {
+        super(indicator);
+    }
+
+    /**
+     * Overrides the default setText2 behavior to extract and print progress messages.
+     *
+     * If the text is HTML-formatted with <html><code>...</code></html>,
+     * we assume it's a progress update and print it without creating a new line.
+     */
+    @Override
+    public void setText2(@Nls @NlsContexts.ProgressDetails String text) {
+        super.setText2(text);
+
+        if (text.startsWith("<html><code>")) {
+            // During certain operations (e.g., downloading),
+            // IntelliJ sends progress messages wrapped in HTML tags.
+            // To avoid flooding the console, we strip the tags and update the current line.
+            String progressMessage = text.substring("<html><code>".length(), text.length() - "</code></html>".length());
+            printProgress(progressMessage);
+        }
+    }
+
+    /**
+     * Called when a progress message needs to be printed (or updated).
+     * Subclasses should implement this to handle message output (e.g., update a console).
+     *
+     * @param progressMessage the clean progress message without HTML
+     */
+    protected abstract void printProgress(@NotNull String progressMessage);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/installation/ServerInstaller.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/installation/ServerInstaller.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.installation;
 
+import com.intellij.execution.ui.ConsoleView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
@@ -26,6 +27,15 @@ public interface ServerInstaller {
      */
     @NotNull
     CompletableFuture<ServerInstallationStatus> checkInstallation();
+
+
+    /**
+     * Returns the current server installer status.
+     *
+     * @return the current server installer status.
+     */
+    @NotNull
+    ServerInstallationStatus getStatus();
 
     /**
      * Code to be executed before installation (optional).
@@ -51,4 +61,8 @@ public interface ServerInstaller {
      * Resets the installation state, allowing the process to be restarted if necessary.
      */
     void reset();
+
+    void registerConsoleProvider(@NotNull ConsoleProvider consoleProvider);
+
+    void unregisterConsoleProvider(@NotNull ConsoleProvider consoleProvider);
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/installation/definition/ServerInstallerManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/installation/definition/ServerInstallerManager.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.util.NlsContexts;
 import com.redhat.devtools.lsp4ij.ServerMessageHandler;
+import com.redhat.devtools.lsp4ij.installation.PrintableProgressIndicator;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
@@ -113,15 +114,11 @@ public class ServerInstallerManager extends InstallerTaskRegistry {
         ProgressManager.getInstance().run(new Task.Backgroundable(context.getProject(), title.toString(), true) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
-                context.setProgressIndicator(new DelegatingProgressIndicator(indicator) {
+                context.setProgressIndicator(new PrintableProgressIndicator(indicator) {
 
                     @Override
-                    public void setText2(@Nls @NlsContexts.ProgressDetails String text) {
-                        super.setText2(text);
-                        if (text.startsWith("<html><code>")) {
-                            String s = text.substring("<html><code>".length(), text.length() - "</code></html>".length());
-                            context.printProgress(s);
-                        }
+                    protected void printProgress(@NotNull String progressMessage) {
+                        context.printProgress(progressMessage);
                     }
                 });
                 install(serverInstallerDescriptor, context);

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/NewLanguageServerDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/NewLanguageServerDialog.java
@@ -87,7 +87,7 @@ public class NewLanguageServerDialog extends DialogWrapper {
         // Template combo
         createTemplatePanel(builder);
         // Create server name,  command line, mappings, configuration UI
-        this.languageServerPanel = new LanguageServerPanel(builder, null, LanguageServerPanel.EditionMode.NEW_USER_DEFINED, true, false, project);
+        this.languageServerPanel = new LanguageServerPanel(builder, null, LanguageServerPanel.EditionMode.NEW_USER_DEFINED, false, project);
         languageServerPanel.setCommandLineUpdater(new CommandLineUpdater() {
             @Override
             public String getCommandLine() {

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerConfigurable.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerConfigurable.java
@@ -66,7 +66,7 @@ public class LanguageServerConfigurable extends NamedConfigurable<LanguageServer
     @Override
     public JComponent createOptionsPanel() {
         if (myView == null) {
-            myView = new LanguageServerView(languageServerDefinition, this, true, false, project);
+            myView = new LanguageServerView(languageServerDefinition, this, false, project);
         }
         return myView.getComponent();
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/LanguageServerView.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 public class LanguageServerView implements Disposable {
 
     private final LanguageServerNameProvider languageServerNameProvider;
-    private final boolean flushOnEachPrint;
     private final boolean canExecuteInstaller;
     private final JPanel myMainPanel;
     private final LanguageServerDefinition languageServerDefinition;
@@ -67,10 +66,8 @@ public class LanguageServerView implements Disposable {
 
     public LanguageServerView(@NotNull LanguageServerDefinition languageServerDefinition,
                               @Nullable LanguageServerNameProvider languageServerNameProvider,
-                              boolean flushOnEachPrint,
                               boolean canExecuteInstaller,
                               @NotNull Project project) {
-        this.flushOnEachPrint = flushOnEachPrint;
         this.canExecuteInstaller = canExecuteInstaller;
         this.languageServerDefinition = languageServerDefinition;
         this.languageServerNameProvider = languageServerNameProvider;
@@ -335,7 +332,7 @@ public class LanguageServerView implements Disposable {
         this.languageServerPanel = new LanguageServerPanel(builder,
                 description,
                 launchingServerDefinition ? LanguageServerPanel.EditionMode.EDIT_USER_DEFINED :
-                        LanguageServerPanel.EditionMode.EDIT_EXTENSION, flushOnEachPrint, canExecuteInstaller, project);
+                        LanguageServerPanel.EditionMode.EDIT_EXTENSION, canExecuteInstaller, project);
         if (languageServerDefinition instanceof UserDefinedLanguageServerDefinition def) {
             languageServerPanel.setCommandLineUpdater(new UICommandLineUpdater(def, project));
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
@@ -72,7 +72,6 @@ public class LanguageServerPanel implements Disposable {
     private final ComboBox<ServerTrace> serverTraceComboBox = new ComboBox<>(new DefaultComboBoxModel<>(ServerTrace.values()));
     private final PortField debugPortField = new PortField();
     private final JBCheckBox debugSuspendCheckBox = new JBCheckBox(LanguageServerBundle.message("language.server.debug.suspend"));
-    private final boolean flushOnEachPrint;
     private final boolean canExecuteInstaller;
     private HyperlinkLabel editJsonSchemaAction;
     private JBTextField serverName;
@@ -92,10 +91,8 @@ public class LanguageServerPanel implements Disposable {
     public LanguageServerPanel(@NotNull FormBuilder builder,
                                @Nullable JComponent description,
                                @NotNull EditionMode mode,
-                               boolean flushOnEachPrint,
                                boolean canExecuteInstaller,
                                @NotNull Project project) {
-        this.flushOnEachPrint = flushOnEachPrint;
         this.canExecuteInstaller = canExecuteInstaller;
         this.project = project;
         createUI(builder, description, mode);
@@ -238,7 +235,7 @@ public class LanguageServerPanel implements Disposable {
 
     private void addInstallerTab(@NotNull JBTabbedPane tabbedPane) {
         FormBuilder installerTab = addTab(tabbedPane, LanguageServerBundle.message("language.server.tab.installer"), false);
-        this.installerPanel = new InstallerPanel(installerTab, getCommandLine(), flushOnEachPrint, canExecuteInstaller, project);
+        this.installerPanel = new InstallerPanel(installerTab, canExecuteInstaller, project);
     }
 
     public void setCommandLineUpdater(@Nullable CommandLineUpdater commandLineUpdater) {

--- a/src/main/resources/messages/DAPBundle.properties
+++ b/src/main/resources/messages/DAPBundle.properties
@@ -26,10 +26,6 @@ new.debug.adapter.dialog.template=Template:
 new.debug.adapter.dialog.choose.template=Choose template...
 new.debug.adapter.dialog.choose.template.title=Choose Debug Server template
 new.debug.adapter.dialog.validation.serverName.must.be.set=Server name must be set
-new.debug.adapter.dialog.validation.commandLine.must.be.set=Command must be set
-new.debug.adapter.dialog.install.title=Debug Adapter Server installation
-new.debug.adapter.dialog.install.content=The debug adapter server defines an installer.\n Do you want to proceed with the server installation?
-
 
 # DAP settings editor
 # - Server settings
@@ -62,3 +58,5 @@ dap.settings.editor.configuration.parameters.launch.tab=Launch
 dap.settings.editor.configuration.parameters.attach.tab=Attach
 dap.settings.editor.configuration.attach.address.field=Address:
 dap.settings.editor.configuration.attach.port.field=Port:
+# - Installer tab
+dap.settings.editor.installer.tab=Installer

--- a/src/main/resources/templates/dap/codelldb/installer.json
+++ b/src/main/resources/templates/dap/codelldb/installer.json
@@ -2,6 +2,11 @@
   "id": "codelldb",
   "name": "CodeLLDB",
   "check": {
+    "exec": {
+      "name": "Trying current command",
+      "command": "${server.command}",
+      "timeout": 2000
+    }
   },
   "run": {
     "download": {

--- a/src/main/resources/templates/dap/go-delve/installer.json
+++ b/src/main/resources/templates/dap/go-delve/installer.json
@@ -2,6 +2,11 @@
   "id": "go-delve",
   "name": "Install and verify go-delve DAP Server",
   "check": {
+    "exec": {
+      "name": "Trying current command",
+      "command": "${server.command}",
+      "timeout": 2000
+    }
   },
   "run": {
     "exec": {

--- a/src/main/resources/templates/dap/python-debugpy/installer.json
+++ b/src/main/resources/templates/dap/python-debugpy/installer.json
@@ -2,6 +2,11 @@
   "id": "debugpy",
   "name": "Install and verify debugpy DAP Server",
   "check": {
+    "exec": {
+      "name": "Trying current command",
+      "command": "${server.command}",
+      "timeout": 2000
+    }
   },
   "run": {
     "exec": {

--- a/src/main/resources/templates/dap/vscode-js-debug/installer.json
+++ b/src/main/resources/templates/dap/vscode-js-debug/installer.json
@@ -2,6 +2,11 @@
   "id": "vscode-js-debug-installer",
   "name": "vscode-js-debug",
   "check": {
+    "exec": {
+      "name": "Trying current command",
+      "command": "${server.command}",
+      "timeout": 2000
+    }
   },
   "run": {
     "download": {


### PR DESCRIPTION
feat: DAP installer API

This PR provides the capability to register a server installer for DAP server.

This installer is now used when DAP debugger is started. It means that you just need to create a DAP server (ex : Vscode JS Debug) and you don't need to adjust start command. Click on Run and if DAP server is not installed it should show a temporary console which shows the progress of installation:

![image](https://github.com/user-attachments/assets/9b6e4555-1be6-423a-b719-c1879a293e0e)

Once installation is finished, it switch to the standard UI of debugging:

![image](https://github.com/user-attachments/assets/ab3fa174-65e3-4582-990c-a79df833da7d)

This PR improves also the language server installation, now you should see some installation traces in the LSP console:

![image](https://github.com/user-attachments/assets/1203f2cb-2d7b-45a4-a63a-4e3d7bde7335)

