### PR TITLE
feat: use vscode-langservers-extracted for CSS language server

### DIFF
--- a/src/main/resources/templates/lsp/vscode-css-language-server/installer.json
+++ b/src/main/resources/templates/lsp/vscode-css-language-server/installer.json
@@ -1,0 +1,33 @@
+{
+  "id": "vscode-css-language-server",
+  "name": "CSS Language Server",
+  "executeOnStartServer": false,
+  "properties": {
+    "workingDir" : "$USER_HOME$/.lsp4ij/lsp/vscode-css-language-server/node_modules"
+  },
+  "check": {
+    "exec": {
+      "name": "Trying current command",
+      "command": "${server.command}",
+      "timeout": 2000
+    }
+  },
+  "run": {
+    "exec": {
+      "name": "Install CSS Language Server",
+      "workingDir": "${workingDir}",
+      "ignoreStderr": true,
+      "command": {
+        "windows": "npm.cmd install vscode-langservers-extracted --force",
+        "default": "npm install vscode-langservers-extracted --force"
+      },
+      "onSuccess": {
+        "configureServer": {
+          "name": "Configure CSS Language Server command",
+          "command": "node ${workingDir}/vscode-langservers-extracted/lib/css-language-server/node/cssServerMain.js --stdio",
+          "update": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
feat: use vscode-langservers-extracted for CSS language server