### PR TITLE
fix: Language server auto-install doesn't trigger for *.js and *.css files (perhaps others) if not associated with the bundled simple file types in Community Edition IDEs

### DIFF
--- a/src/main/resources/templates/lsp/typescript-language-server/template.json
+++ b/src/main/resources/templates/lsp/typescript-language-server/template.json
@@ -8,7 +8,10 @@
   "fileTypeMappings": [
     {
       "fileType": {
-        "name": "JavaScript"
+        "name": "JavaScript",
+        "patterns": [
+          "*.js"
+        ]
       },
       "languageId": "javascript"
     },

--- a/src/main/resources/templates/lsp/vscode-css-language-server/template.json
+++ b/src/main/resources/templates/lsp/vscode-css-language-server/template.json
@@ -11,7 +11,10 @@
   "fileTypeMappings": [
     {
       "fileType": {
-        "name": "CSS"
+        "name": "CSS",
+        "patterns": [
+          "*.css"
+        ]
       },
       "languageId": "css"
     },


### PR DESCRIPTION
fix: Language server auto-install doesn't trigger for *.js and *.css files (perhaps others) if not associated with the bundled simple file types in Community Edition IDEs

Fixes #1139