### PR TITLE
feat: set vscode html ls as dev

### DIFF
--- a/src/main/resources/templates/lsp/vscode-html-language-server/template.json
+++ b/src/main/resources/templates/lsp/vscode-html-language-server/template.json
@@ -1,6 +1,7 @@
 {
   "id": "vscode-html-language-server",
   "name": "HTML Language Server",
+  "dev": true,
   "url": null,
   "programArgs": {
     "windows": "node \"$USER_HOME$/AppData/Local/Programs/Microsoft VS Code/resources/app/extensions/html-language-features/server/dist/node/htmlServerMain.js\" --stdio",


### PR DESCRIPTION
feat: set vscode html ls as dev

HTML Language Server will be visible only if the LSP4IJ is started in dev mode otherwise user will not see the language server.

As JetBrains provide a nice HTML support we don't need to show this language server to the user.

//cc @SCWells72 