### PR TITLE
fix: empty section must return the full server config

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -263,7 +263,7 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     protected Object findSettings(@Nullable String section) {
         var config = createSettings();
         if (config instanceof JsonObject json) {
-            if (section == null) {
+            if (section == null || section.isEmpty()) {
                 return config;
             }
             return findSettings(section, json);


### PR DESCRIPTION
fix: empty section must return the full server config

Language server from vscode-eslint get the configuration with empty section which must return the full config.