### PR TITLE
fix: using integer max value as line end indicator

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -658,6 +658,10 @@ public class LSPIJUtils {
         int lineOffset = document.getLineStartOffset(line);
         int nextLineOffset = document.getLineEndOffset(line);
         // If the character value is greater than the line length it defaults back to the line length
+        // Handle the common LSP pattern where Integer.MAX_VALUE indicates "end of line" as a special case.
+        if (character == Integer.MAX_VALUE) {
+            return nextLineOffset;
+        }
         return Math.max(Math.min(lineOffset + character, nextLineOffset), lineOffset);
     }
 

--- a/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_toOffsetTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/LSPIJUtils_toOffsetTest.java
@@ -74,6 +74,11 @@ public class LSPIJUtils_toOffsetTest extends BasePlatformTestCase {
         assertOffset("foo\nbar", 999999, 999999, 7, null);
     }
 
+    public void testIntegerMaxValueAsLineEnding() {
+        assertOffset("foo\nbar", 0, Integer.MAX_VALUE, 3, null);
+        assertOffset("foo\nbar", 1, Integer.MAX_VALUE, 7, null);
+    }
+    
     public void test_vscode_EmptyContent() {
         // See https://github.com/microsoft/vscode-languageserver-node/blob/8e625564b531da607859b8cb982abb7cdb2fbe2e/textDocument/src/test/textdocument.test.ts#L18
         String str = "";


### PR DESCRIPTION
Some LSP servers use Integer.MAX_VALUE as a special character position value to indicate "end of line" in position coordinates. LSPIJUtils.toOffset was not correctly handling this, which lead to for example received diagnostics notifications to be silently ignored.