### PR TITLE
fix: Changed "StyleLint" to the correct case "Stylelint"

### DIFF
--- a/docs/UserDefinedLanguageServer.md
+++ b/docs/UserDefinedLanguageServer.md
@@ -164,7 +164,7 @@ pre-filled with server name, command, mappings and potential configuration.
 * [Rust Language Server](./user-defined-ls/rust-analyzer.md) 
 * [Scala Language Server (Metals)](./user-defined-ls/metals.md)
 * [SourceKit-LSP](./user-defined-ls/sourcekit-lsp.md)
-* [StyleLint-LSP](./user-defined-ls/stylelint-lsp.md)
+* [Stylelint-LSP](./user-defined-ls/stylelint-lsp.md)
 * [Svelte Language Server](./user-defined-ls/svelte-language-server.md) 
 * [Terraform Language Server](./user-defined-ls/terraform-ls.md)
 * [TypeScript Language Server](./user-defined-ls/typescript-language-server.md)

--- a/docs/user-defined-ls/stylelint-lsp.md
+++ b/docs/user-defined-ls/stylelint-lsp.md
@@ -1,25 +1,25 @@
-# StyleLint Language Server
+# Stylelint Language Server
 
-To enable [StyleLint](https://stylelint.io/) language support in your IDE, you can integrate the [StyleLint-LSP](https://github.com/bmatcuk/stylelint-lsp) by following these steps:
+To enable [Stylelint](https://stylelint.io/) language support in your IDE, you can integrate the [Stylelint-LSP](https://github.com/bmatcuk/stylelint-lsp) by following these steps:
 
 ## Step 1: Install the Language Server
 
 1. Open a `.css` file in your project.
-2. Click on **Install StyleLint Language Server**:
+2. Click on **Install Stylelint Language Server**:
 
    ![Open file](../images/user-defined-ls/stylelint-lsp/open_file.png)
 
-3. This will open the [New Language Server Dialog](../UserDefinedLanguageServer.md#new-language-server-dialog) with `StyleLint Language Server` pre-selected:
+3. This will open the [New Language Server Dialog](../UserDefinedLanguageServer.md#new-language-server-dialog) with `Stylelint Language Server` pre-selected:
 
    ![New Language Server Dialog](../images/user-defined-ls/stylelint-lsp/new_language_server_dialog.png)
 
-4. Click **OK**. This will create the `StyleLint Language Server` definition and start the installation:
+4. Click **OK**. This will create the `Stylelint Language Server` definition and start the installation:
 
    ![Installing Language Server](../images/user-defined-ls/stylelint-lsp/language_server_installing.png)
 
-5. Once the installation completes, the server should start automatically and provide StyleLint language diagnostics directly within the IDE.
+5. Once the installation completes, the server should start automatically and provide Stylelint language diagnostics directly within the IDE.
 
-## Step 2: Configure StyleLint
+## Step 2: Configure Stylelint
 
 * If necessary, execute `npm install stylelint` in your project root.
 * Create a [configuration file](https://stylelint.io/user-guide/configure).

--- a/src/main/resources/templates/lsp/stylelint-lsp/installer.json
+++ b/src/main/resources/templates/lsp/stylelint-lsp/installer.json
@@ -1,6 +1,6 @@
 {
   "id": "stylelint-lsp",
-  "name": "StyleLint Language Server",
+  "name": "Stylelint Language Server",
   "executeOnStartServer": false,
   "properties": {
     "workingDir" : "$USER_HOME$/.lsp4ij/lsp/stylelint-lsp/node_modules"
@@ -14,7 +14,7 @@
   },
   "run": {
     "exec": {
-      "name": "Install StyleLint Language Server",
+      "name": "Install Stylelint Language Server",
       "workingDir": "${workingDir}",
       "ignoreStderr": true,
       "command": {
@@ -23,7 +23,7 @@
       },
       "onSuccess": {
         "configureServer": {
-          "name": "Configure StyleLint Language Server command",
+          "name": "Configure Stylelint Language Server command",
           "command": {
             "windows": "${workingDir}/.bin/stylelint-lsp.cmd --stdio",
             "default": "${workingDir}/.bin/stylelint-lsp --stdio"

--- a/src/main/resources/templates/lsp/stylelint-lsp/settings.schema.json
+++ b/src/main/resources/templates/lsp/stylelint-lsp/settings.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "LSP4IJ/stylelint-lsp/settings.schema.json",
-  "title": "LSP4IJ StyleLint language server settings JSON schema",
-  "description": "JSON schema for StyleLint language server settings.",
+  "title": "LSP4IJ Stylelint language server settings JSON schema",
+  "description": "JSON schema for Stylelint language server settings.",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/main/resources/templates/lsp/stylelint-lsp/template.json
+++ b/src/main/resources/templates/lsp/stylelint-lsp/template.json
@@ -1,6 +1,6 @@
 {
   "id": "stylelint-lsp",
-  "name": "StyleLint Language Server",
+  "name": "Stylelint Language Server",
   "programArgs": {
     "windows": "cmd /C stylelint-lsp.cmd --stdio",
     "default": "sh -c stylelint-lsp --stdio"


### PR DESCRIPTION
The correct tool name is "Stylelint" without a capital "L". This corrects the name in all places where it was wrong.