### PR TITLE
feat: Preview support for LSP workspace symbols

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/WorkspaceSymbolData.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/WorkspaceSymbolData.java
@@ -10,13 +10,19 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.features.workspaceSymbol;
 
+import com.intellij.lang.Language;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.navigation.NavigationItem;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.util.NlsSafe;
+import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.impl.light.LightElement;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.ui.IconMapper;
@@ -27,44 +33,25 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.io.File;
 import java.util.Optional;
 
 /**
  * LSP navigation item implementation.
  */
-public class WorkspaceSymbolData implements NavigationItem {
+public class WorkspaceSymbolData extends LightElement implements NavigationItem, ItemPresentation {
 
+    private final String name;
     private final SymbolKind symbolKind;
     private final String fileUri;
+    private final FileUriSupport fileUriSupport;
     private final Position position;
     private final Project project;
-    private final VirtualFile file;
-    private final LSPItemPresentation presentation;
-    private final FileUriSupport fileUriSupport;
 
-    private record LSPItemPresentation(String name, SymbolKind symbolKind, String locationString) implements ItemPresentation {
+    private @Nullable VirtualFile file;
+    private @Nullable PsiFile psiFile;
+    private @Nullable String locationString;
+    private @Nullable TextRange textRange;
 
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public @NlsSafe @Nullable String getPresentableText() {
-            return name();
-        }
-
-        @Override
-        public @Nullable Icon getIcon(boolean unused) {
-            return IconMapper.getIcon(symbolKind);
-        }
-
-        @Override
-        public @NlsSafe @Nullable String getLocationString() {
-            return locationString;
-        }
-
-    }
 
     public WorkspaceSymbolData(String name,
                                SymbolKind symbolKind,
@@ -80,33 +67,47 @@ public class WorkspaceSymbolData implements NavigationItem {
                                Position position,
                                FileUriSupport fileUriSupport,
                                Project project) {
+        super(PsiManager.getInstance(project), Language.ANY);
+        this.name = name;
         this.symbolKind = symbolKind;
         this.fileUri = fileUri;
         this.position = position;
-        this.project = project;
-        this.file = FileUriSupport.findFileByUri(fileUri, fileUriSupport);
         this.fileUriSupport = fileUriSupport;
-        String locationString = file != null ? getLocationString(project, file) : fileUri;
-        this.presentation = new LSPItemPresentation(name, symbolKind, locationString);
-    }
-
-    @Nullable
-    public VirtualFile getFile() {
-        return file;
-    }
-
-    public @Nullable SymbolKind getSymbolKind() {
-        return symbolKind;
+        this.project = project;
     }
 
     @Override
-    public @Nullable @NlsSafe String getName() {
-        return presentation.name();
+    public @Nullable String getName() {
+        return name;
+    }
+
+    @Override
+    public @NotNull Language getLanguage() {
+        var psiFile = getPsiFile();
+        if (psiFile != null) {
+            return psiFile.getLanguage();
+        }
+        return super.getLanguage();
     }
 
     @Override
     public @Nullable ItemPresentation getPresentation() {
-        return presentation;
+        return this;
+    }
+
+    @Override
+    public @NlsSafe @Nullable String getPresentableText() {
+        return getName();
+    }
+
+    @Override
+    public @NlsSafe @Nullable String getLocationString() {
+        if (locationString != null) {
+            return locationString;
+        }
+        var file = getFile();
+        locationString = file != null ? getLocationString(project, file) : fileUri;
+        return locationString;
     }
 
     @Override
@@ -124,16 +125,94 @@ public class WorkspaceSymbolData implements NavigationItem {
         return true;
     }
 
+    @Override
+    public @Nullable TextRange getTextRange() {
+        if (textRange == null) {
+            var file = getFile();
+            if (file == null || !file.isValid()) {
+                return null;
+            }
+
+            var document = LSPIJUtils.getDocument(file);
+            if (document == null) {
+                return null;
+            }
+
+            int offset = LSPIJUtils.toOffset(position, document);
+            textRange = new TextRange(offset, offset);
+        }
+        return textRange;
+    }
+
+    @Override
+    public String getText() {
+        PsiFile file = getContainingFile();
+        return file != null ? file.getText() : "";
+    }
+
+    @Override
+    public @Nullable Icon getIcon(boolean unused) {
+        return IconMapper.getIcon(symbolKind);
+    }
+
+    public @Nullable SymbolKind getSymbolKind() {
+        return symbolKind;
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    @Override
+    public PsiFile getContainingFile() {
+        return getPsiFile();
+    }
+
+    @Override
+    public PsiManager getManager() {
+        return PsiManager.getInstance(project);
+    }
+
+    @Override
+    public @NotNull PsiElement getNavigationElement() {
+        return this;
+    }
+
+    public @Nullable VirtualFile getFile() {
+        if (file == null) {
+            file = FileUriSupport.findFileByUri(fileUri, fileUriSupport);
+        }
+        return file;
+    }
+
+    private @Nullable PsiFile getPsiFile() {
+        if (psiFile == null) {
+            var file = getFile();
+            if (file != null) {
+                psiFile = LSPIJUtils.getPsiFile(file, project);
+            }
+        }
+        return psiFile;
+    }
+
     /**
-     * This code is a copy/paste from https://github.com/JetBrains/intellij-community/blob/22243811e3e8342918b5c064cbb94c7886d8e3ed/plugins/htmltools/src/com/intellij/htmltools/html/HtmlGotoSymbolProvider.java#L46
-     * @param project
-     * @param file
-     * @return
+     * This code is a copy/paste from <a href="https://github.com/JetBrains/intellij-community/blob/22243811e3e8342918b5c064cbb94c7886d8e3ed/plugins/htmltools/src/com/intellij/htmltools/html/HtmlGotoSymbolProvider.java#L46">HtmlGotoSymbolProvider.java.</a>
+     *
+     * @param project the project
+     * @param file    the file
+     * @return the location string
      */
     private static @Nullable String getLocationString(@NotNull Project project, @NotNull VirtualFile file) {
         return Optional.ofNullable(ProjectUtil.guessProjectDir(project))
-                .map(projectDir -> VfsUtilCore.getRelativePath(file, projectDir, File.separatorChar))
+                .map(projectDir -> VfsUtilCore.getRelativePath(file, projectDir, java.io.File.separatorChar))
                 .map(path -> "(" + path + ")")
                 .orElse(null);
     }
+
 }


### PR DESCRIPTION
feat: Preview support for LSP workspace symbols

Here a sample with Symbol preview with rust.

![image](https://github.com/user-attachments/assets/4026cb1b-9196-4a6b-ad52-d8b8bb2f4178)

//cc @manwithafox

