### PR TITLE
feat: Support runInTerminal (external only for Windows OS) request for DAP

### DIFF
--- a/docs/dap/DAPSupport.md
+++ b/docs/dap/DAPSupport.md
@@ -76,5 +76,5 @@ Current state of [Requests](https://microsoft.github.io/debug-adapter-protocol//
 
 Current state of [Reverse Requests](https://microsoft.github.io/debug-adapter-protocol//specification.html#Reverse_Requests) support:
 
-* ❌ [RunInTerminal](https://microsoft.github.io/debug-adapter-protocol//specification.html#Reverse_Requests_RunInTerminal).
+* ✅ [RunInTerminal](https://microsoft.github.io/debug-adapter-protocol//specification.html#Reverse_Requests_RunInTerminal).
 * ✅ [StartDebugging](https://microsoft.github.io/debug-adapter-protocol//specification.html#Reverse_Requests_StartDebugging).

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/RunInTerminalManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/RunInTerminalManager.java
@@ -16,6 +16,10 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.Alarm;
+import com.redhat.devtools.lsp4ij.dap.client.runInterminal.external.LinuxExternalTerminalService;
+import com.redhat.devtools.lsp4ij.dap.client.runInterminal.external.MacExternalTerminalService;
+import com.redhat.devtools.lsp4ij.dap.client.runInterminal.external.WindowsExternalTerminalService;
+import com.redhat.devtools.lsp4ij.dap.client.runInterminal.integrated.RunInIntegratedTerminalService;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArgumentsKind;
 import org.eclipse.lsp4j.debug.RunInTerminalResponse;
@@ -24,7 +28,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -35,9 +41,23 @@ import java.util.stream.Collectors;
 public class RunInTerminalManager {
 
     private final @NotNull Project project;
+    private final @NotNull RunInTerminalService runInIntegratedTerminalService;
+    private final @NotNull RunInTerminalService runInExternalTerminalService;
 
     public RunInTerminalManager(@NotNull Project project) {
         this.project = project;
+        this.runInIntegratedTerminalService = new RunInIntegratedTerminalService();
+        this.runInExternalTerminalService = createExternalTerminalService();
+    }
+
+    private @NotNull RunInTerminalService createExternalTerminalService() {
+        if (SystemInfo.isWindows) {
+            return new WindowsExternalTerminalService();
+        }
+        if (SystemInfo.isMac) {
+            return new MacExternalTerminalService();
+        }
+        return new LinuxExternalTerminalService();
     }
 
     public static RunInTerminalManager getInstance(@NotNull Project project) {
@@ -50,164 +70,13 @@ public class RunInTerminalManager {
      * @param args DAP {@link RunInTerminalRequestArguments}
      * @return a {@link CompletableFuture} resolving to the {@link RunInTerminalResponse}
      */
-    public CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args) {
-        if (shouldUseIntegratedTerminal(args.getKind())) {
-            return runInIntegratedTerminal(args);
-        }
-        return runInExternalTerminal(args);
-    }
-
-    /**
-     * Runs a command in IntelliJ's integrated terminal.
-     */
-    private CompletableFuture<RunInTerminalResponse> runInIntegratedTerminal(RunInTerminalRequestArguments args) {
-        CompletableFuture<RunInTerminalResponse> future = new CompletableFuture<>();
-
-        ApplicationManager.getApplication().invokeLater(() -> {
-            try {
-                TerminalToolWindowManager tm = TerminalToolWindowManager.getInstance(project);
-
-                String title = args.getTitle();
-                String workingDirectory = args.getCwd();
-                ShellTerminalWidget shellWidget = tm.createLocalShellWidget(workingDirectory, title);
-
-                String command = prepareCommandWithEnv(args);
-
-                shellWidget.executeCommand(command);
-
-                Alarm alarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, project);
-                Runnable checkProcess = new Runnable() {
-                    @Override
-                    public void run() {
-                        var tty = shellWidget.getProcessTtyConnector();
-                        if (tty != null) {
-                            RunInTerminalResponse resp = new RunInTerminalResponse();
-                            resp.setProcessId((int) tty.getProcess().pid());
-                            future.complete(resp);
-                        } else if (!future.isDone()) {
-                            alarm.addRequest(this, 100); // recheck in 100ms
-                        }
-                    }
-                };
-                alarm.addRequest(checkProcess, 100);
-
-            } catch (Exception e) {
-                future.completeExceptionally(e);
+    public CompletableFuture<RunInTerminalResponse> runInTerminal(@NotNull RunInTerminalRequestArguments args) {
+        if (args.getKind() == RunInTerminalRequestArgumentsKind.INTEGRATED) {
+            if (runInIntegratedTerminalService.isApplicable()) {
+                return runInIntegratedTerminalService.runInTerminal(args, project);
             }
-        });
-
-        return future;
-    }
-
-    /**
-     * Prepares a full command line with environment variable injection,
-     * adapting to the current OS and shell syntax.
-     * <p>
-     * - PowerShell: ${env:VAR}='value'; command
-     * - cmd.exe: set VAR=value && set VAR2=value && command
-     * - Unix shells: VAR='value' VAR2='value' command
-     */
-    private String prepareCommandWithEnv(RunInTerminalRequestArguments args) {
-        String command = formatCommandArguments(args.getArgs());
-
-        if (args.getEnv() == null || args.getEnv().isEmpty()) {
-            return command;
         }
-
-        boolean isWindows = SystemInfo.isWindows;
-        boolean isPowerShell = isWindows && isPowerShellEnvironment();
-        StringBuilder envCmd = new StringBuilder();
-
-        if (isPowerShell) {
-            args.getEnv().forEach((k, v) -> {
-                envCmd.append("${env:").append(k).append("}='")
-                        .append(v.replace("'", "''")).append("'; ");
-            });
-            envCmd.append(command);
-        } else if (isWindows) {
-            args.getEnv().forEach((k, v) -> {
-                envCmd.append("set ").append(k).append("=").append(v).append(" && ");
-            });
-            envCmd.append(command);
-        } else {
-            args.getEnv().forEach((k, v) -> {
-                envCmd.append(k).append("='")
-                        .append(v.replace("'", "'\"'\"'")).append("' ");
-            });
-            envCmd.append(command);
-        }
-
-        return envCmd.toString();
+        return runInExternalTerminalService.runInTerminal(args, project);
     }
 
-    /**
-     * Formats a command line by quoting and escaping arguments for the current OS/shell.
-     * <p>
-     * - PowerShell: adds call operator '&' and quotes paths with spaces
-     * - cmd.exe: escapes spaces with '^'
-     * - Unix: wraps arguments with spaces in single quotes
-     */
-    private String formatCommandArguments(String[] args) {
-        boolean isWindows = SystemInfo.isWindows;
-        boolean isPowerShell = isWindows && isPowerShellEnvironment();
-
-        if (args.length == 0) {
-            return "";
-        }
-
-        if (isPowerShell) {
-            String first = args[0];
-            if (first.contains(" ")) {
-                first = "& \"" + first + "\"";
-            } else {
-                first = "& " + first;
-            }
-
-            String rest = Arrays.stream(args, 1, args.length)
-                    .map(arg -> arg.contains(" ") ? "\"" + arg + "\"" : arg)
-                    .collect(Collectors.joining(" "));
-
-            return first + (rest.isEmpty() ? "" : " " + rest);
-        } else if (isWindows) {
-            return Arrays.stream(args)
-                    .map(arg -> arg.contains(" ") ? arg.replace(" ", "^ ") : arg)
-                    .collect(Collectors.joining(" "));
-        } else {
-            return Arrays.stream(args)
-                    .map(arg -> arg.contains(" ") ? "'" + arg.replace("'", "'\"'\"'") + "'" : arg)
-                    .collect(Collectors.joining(" "));
-        }
-    }
-
-    /**
-     * Detects whether the current environment is running PowerShell on Windows.
-     */
-    private boolean isPowerShellEnvironment() {
-        String psModule = System.getenv("PSModulePath");
-        return psModule != null && psModule.contains("PowerShell");
-    }
-
-    /**
-     * Placeholder for running in an external terminal.
-     */
-    private CompletableFuture<RunInTerminalResponse> runInExternalTerminal(RunInTerminalRequestArguments args) {
-        CompletableFuture<RunInTerminalResponse> future = new CompletableFuture<>();
-        future.completeExceptionally(new UnsupportedOperationException("runInExternalTerminal not supported"));
-        return future;
-    }
-
-    /**
-     * Checks if the request should use the integrated terminal.
-     */
-    private boolean shouldUseIntegratedTerminal(@Nullable RunInTerminalRequestArgumentsKind kind) {
-        return kind == RunInTerminalRequestArgumentsKind.INTEGRATED && isTerminalPluginInstalled();
-    }
-
-    /**
-     * Verifies if the IntelliJ terminal plugin is installed.
-     */
-    private static boolean isTerminalPluginInstalled() {
-        PluginId pluginId = PluginId.getId("org.jetbrains.plugins.terminal");
-        return PluginManagerCore.getPlugin(pluginId) != null;
-    }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/RunInTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/RunInTerminalService.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.runInterminal;
+
+import com.intellij.openapi.project.Project;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalResponse;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service API for handling Debug Adapter Protocol {@code runInTerminal} requests.
+ * <p>
+ * Implementations of this service are responsible for spawning a new terminal instance
+ * (either external or integrated) and executing the command specified in the
+ * {@link RunInTerminalRequestArguments}. Implementations are typically platform-specific
+ * (e.g., Windows, Linux, macOS).
+ * </p>
+ *
+ * <p>This service is used to support the DAP {@code runInTerminal} feature, allowing
+ * debug adapters to request that a program be launched in a user-visible terminal.</p>
+ *
+ * <h2>Implementation notes:</h2>
+ * <ul>
+ *   <li>Implementations should check {@link #isApplicable()} to determine whether the service
+ *       can run on the current OS/environment.</li>
+ *   <li>The {@link #runInTerminal(RunInTerminalRequestArguments, Project)} method should
+ *       execute the command asynchronously and return a {@link CompletableFuture} that
+ *       completes with the {@link RunInTerminalResponse} when the terminal is launched.</li>
+ * </ul>
+ */
+public interface RunInTerminalService {
+
+    /**
+     * Determines whether this implementation is applicable in the current environment.
+     * <p>
+     * This is typically used to filter OS-specific services (e.g., Windows, Linux, macOS)
+     * so that only the correct one is used at runtime.
+     * </p>
+     *
+     * @return {@code true} if this service can handle {@code runInTerminal} requests
+     *         on the current platform, {@code false} otherwise.
+     */
+    boolean isApplicable();
+
+    /**
+     * Launches a new terminal and executes the command specified in the given
+     * {@link RunInTerminalRequestArguments}.
+     *
+     * <p>
+     * The implementation should spawn a terminal process (external or integrated),
+     * set the working directory and environment variables as specified,
+     * and start the target program. This method must return immediately
+     * with a {@link CompletableFuture} that completes when the terminal is successfully
+     * launched or completes exceptionally if an error occurs.
+     * </p>
+     *
+     * @param args    the {@link RunInTerminalRequestArguments} containing the command,
+     *                working directory, environment variables, and terminal type
+     * @param project the IntelliJ {@link Project} in which this terminal is being launched
+     * @return a {@link CompletableFuture} resolving to a {@link RunInTerminalResponse}
+     *         containing the process ID or {@code null} if not supported.
+     */
+    CompletableFuture<RunInTerminalResponse> runInTerminal(@NotNull RunInTerminalRequestArguments args,
+                                                           @NotNull Project project);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/ExternalTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/ExternalTerminalService.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.runInterminal.external;
+
+import com.intellij.openapi.project.Project;
+import com.redhat.devtools.lsp4ij.dap.client.runInterminal.RunInTerminalService;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalResponse;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Base class for external terminal services that handle Debug Adapter Protocol
+ * {@code runInTerminal} requests.
+ * <p>
+ * This abstract class implements the {@link RunInTerminalService} API and provides
+ * a standard mechanism to wrap the process ID into a {@link RunInTerminalResponse}.
+ * Subclasses are responsible for providing the OS-specific logic to actually
+ * spawn the terminal and execute the command via {@link #doRunInTerminal(RunInTerminalRequestArguments, Project)}.
+ * </p>
+ *
+ * <p>
+ * Implementations typically include:
+ * <ul>
+ *     <li>{@code WindowsExternalTerminalService}</li>
+ *     <li>{@code LinuxExternalTerminalService}</li>
+ *     <li>{@code MacExternalTerminalService}</li>
+ * </ul>
+ * </p>
+ */
+public abstract class ExternalTerminalService implements RunInTerminalService {
+
+    /**
+     * Executes a DAP {@code runInTerminal} request by delegating to the
+     * platform-specific {@link #doRunInTerminal(RunInTerminalRequestArguments, Project)}
+     * implementation and wrapping the resulting process ID into a
+     * {@link RunInTerminalResponse}.
+     *
+     * @param args    the {@link RunInTerminalRequestArguments} containing the command,
+     *                working directory, environment variables, and terminal kind
+     * @param project the IntelliJ {@link Project} in which this terminal is being launched
+     * @return a {@link CompletableFuture} that resolves to a {@link RunInTerminalResponse}
+     *         containing the process ID of the spawned terminal process.
+     */
+    @Override
+    public CompletableFuture<RunInTerminalResponse> runInTerminal(@NotNull RunInTerminalRequestArguments args,
+                                                                  @NotNull Project project) {
+        return doRunInTerminal(args, project)
+                .thenApply(pid -> {
+                    RunInTerminalResponse response = new RunInTerminalResponse();
+                    response.setProcessId(pid);
+                    return response;
+                });
+    }
+
+    /**
+     * Spawns an external terminal process and executes the command specified in
+     * the given {@link RunInTerminalRequestArguments}.
+     * <p>
+     * Subclasses must implement this method to handle the platform-specific logic
+     * (Windows, Linux, macOS).
+     * </p>
+     *
+     * @param args    the {@link RunInTerminalRequestArguments} with the command and environment settings
+     * @param project the IntelliJ {@link Project} context
+     * @return a {@link CompletableFuture} resolving to the process ID of the spawned terminal
+     */
+    protected abstract CompletableFuture<Integer> doRunInTerminal(@NotNull RunInTerminalRequestArguments args,
+                                                                  @NotNull Project project);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/LinuxExternalTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/LinuxExternalTerminalService.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.runInterminal.external;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class code is the vscode TypeScript translate from
+ * <a href="https://github.com/microsoft/vscode/blob/62093721f21b6b178ea92d9f6c9da74c6afdeaf5/src/vs/platform/externalTerminal/node/externalTerminalService.ts#L234">LinuxExternalTerminalService</a>
+ */
+public class LinuxExternalTerminalService extends ExternalTerminalService {
+
+    // List of common Linux terminals in the same order VS Code tries them
+    private static final String[] LINUX_TERMINALS = new String[]{
+            "gnome-terminal",
+            "konsole",
+            "xfce4-terminal",
+            "xterm",
+            "lxterminal",
+            "mate-terminal",
+            "terminator",
+            "tilix",
+            "deepin-terminal",
+            "kitty",
+            "alacritty",
+            "x-terminal-emulator"
+    };
+
+    @Override
+    public boolean isApplicable() {
+        return SystemInfo.isLinux;
+    }
+
+    @Override
+    protected CompletableFuture<Integer> doRunInTerminal(@NotNull RunInTerminalRequestArguments args,
+                                                         @NotNull Project project) {
+
+        // TODO : reimplement this class!!!
+
+        String terminal = findAvailableTerminal();
+        if (terminal == null) {
+            CompletableFuture<Integer> failed = new CompletableFuture<>();
+            failed.completeExceptionally(new RuntimeException("No supported Linux terminal found in PATH"));
+            return failed;
+        }
+
+        // Build the shell command like VS Code:
+        // bash -c "cd /cwd && <command args> ; exec bash"
+        String joinedArgs = String.join(" ", escapeArgs(args.getArgs()));
+        String fullCommand = "cd " + escapeArg(args.getCwd()) + " && " + joinedArgs + " ; exec bash";
+
+        List<String> cmd = new ArrayList<>();
+        cmd.add(terminal);
+        cmd.add("-e");
+        cmd.add("bash");
+        cmd.add("-c");
+        cmd.add(fullCommand);
+
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.directory(new File(args.getCwd()));
+
+        // Filter out null values in the environment variables
+        Map<String, String> env = args.getEnv() != null ? args.getEnv() : new HashMap<>();
+        env.entrySet().removeIf(e -> e.getValue() == null);
+        pb.environment().putAll(env);
+
+        return runProcessAsyncWithExitCode(pb);
+    }
+
+    /**
+     * Run the process asynchronously and complete the future with the exit code.
+     */
+    private CompletableFuture<Integer> runProcessAsyncWithExitCode(ProcessBuilder pb) {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        try {
+            Process p = pb.start();
+            p.onExit().thenAccept(pr -> future.complete(pr.exitValue()));
+        } catch (IOException e) {
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
+
+    /**
+     * Finds the first available terminal from the list in the PATH.
+     */
+    private String findAvailableTerminal() {
+        for (String term : LINUX_TERMINALS) {
+            if (isExecutableInPath(term)) {
+                return term;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if the given executable is available in the PATH using 'which'.
+     */
+    private boolean isExecutableInPath(String exec) {
+        try {
+            Process p = new ProcessBuilder("which", exec).start();
+            return p.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Escape arguments for safe usage inside bash -c.
+     */
+    private List<String> escapeArgs(String[] args) {
+        List<String> escaped = new ArrayList<>();
+        for (String arg : args) {
+            escaped.add(escapeArg(arg));
+        }
+        return escaped;
+    }
+
+    /**
+     * Escape a single argument by wrapping it in single quotes and handling embedded quotes.
+     */
+    private String escapeArg(String arg) {
+        return "'" + arg.replace("'", "'\"'\"'") + "'";
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/MacExternalTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/MacExternalTerminalService.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.runInterminal.external;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class code is the vscode TypeScript translate from
+ * <a href="https://github.com/microsoft/vscode/blob/62093721f21b6b178ea92d9f6c9da74c6afdeaf5/src/vs/platform/externalTerminal/node/externalTerminalService.ts#L144">MacExternalTerminalService</a>
+ */
+public class MacExternalTerminalService extends ExternalTerminalService {
+
+    @Override
+    public boolean isApplicable() {
+        return SystemInfo.isMac;
+    }
+
+    @Override
+    protected CompletableFuture<Integer> doRunInTerminal(@NotNull RunInTerminalRequestArguments args,
+                                                         @NotNull Project project) {
+
+        // TODO : reimplement this class!!!
+
+        // Build AppleScript command like VS Code does
+        String joinedArgs = String.join(" ", escapeArgs(args.getArgs()));
+        String fullCommand = "cd " + escapeArg(args.getCwd()) + " && " + joinedArgs;
+
+        // AppleScript to tell Terminal to open a new window and run the command
+        String appleScript = "tell application \"Terminal\"\n" +
+                "do script \"" + fullCommand + "\"\n" +
+                "activate\n" +
+                "end tell";
+
+        List<String> cmd = Arrays.asList("osascript", "-e", appleScript);
+
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.directory(new File(args.getCwd()));
+
+        Map<String, String> env = args.getEnv() != null ? args.getEnv() : new HashMap<>();
+        env.entrySet().removeIf(e -> e.getValue() == null);
+        pb.environment().putAll(env);
+
+        return runProcessAsyncWithExitCode(pb);
+    }
+
+    /**
+     * Run the process asynchronously and complete the future with the exit code.
+     */
+    private CompletableFuture<Integer> runProcessAsyncWithExitCode(ProcessBuilder pb) {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        try {
+            Process p = pb.start();
+            p.onExit().thenAccept(pr -> future.complete(pr.exitValue()));
+        } catch (IOException e) {
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
+
+    /**
+     * Escape arguments for safe usage inside AppleScript/Terminal.
+     */
+    private List<String> escapeArgs(String[] args) {
+        List<String> escaped = new ArrayList<>();
+        for (String arg : args) {
+            escaped.add(escapeArg(arg));
+        }
+        return escaped;
+    }
+
+    /**
+     * Escape a single argument for safe bash usage.
+     */
+    private String escapeArg(String arg) {
+        return "'" + arg.replace("'", "'\"'\"'") + "'";
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/WindowsExternalTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/external/WindowsExternalTerminalService.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.runInterminal.external;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Windows-specific implementation of {@link ExternalTerminalService} used to spawn external
+ * terminals when handling the Debug Adapter Protocol (DAP) {@code runInTerminal} request.
+ * <p>
+ * This class is based on the VS Code implementation
+ * <a href="https://github.com/microsoft/vscode/blob/62093721f21b6b178ea92d9f6c9da74c6afdeaf5/src/vs/platform/externalTerminal/node/externalTerminalService.ts#L32">
+ * WindowsExternalTerminalService</a>, translated from TypeScript to Java.
+ * <p>
+ * The service detects whether the Windows Terminal (`wt.exe`) or the classic `cmd.exe` should be used,
+ * constructs the appropriate command-line arguments, injects environment variables, and runs the
+ * process asynchronously, returning its exit code once completed.
+ */
+public class WindowsExternalTerminalService extends ExternalTerminalService {
+
+    /** Default Windows command-line interpreter. */
+    private static final String CMD = "cmd.exe";
+
+    /** Cached default terminal path to avoid recomputing. */
+    private static String DEFAULT_TERMINAL_WINDOWS;
+
+    /**
+     * Indicates if this service is applicable on the current platform.
+     *
+     * @return {@code true} if running on Windows, {@code false} otherwise.
+     */
+    @Override
+    public boolean isApplicable() {
+        return SystemInfo.isWindows;
+    }
+
+    /**
+     * Executes the {@code runInTerminal} request in an external Windows terminal.
+     *
+     * @param args    the DAP {@link RunInTerminalRequestArguments} containing command, environment and working directory.
+     * @param project the current IntelliJ project context.
+     * @return a {@link CompletableFuture} that completes with the exit code of the spawned process.
+     */
+    @Override
+    protected CompletableFuture<Integer> doRunInTerminal(@NotNull RunInTerminalRequestArguments args,
+                                                         @NotNull Project project) {
+        // Resolve the terminal executable. Fallback to default Windows terminal if not configured.
+        String exec = /* settings.getWindowsExec() != null ?
+                settings.getWindowsExec() : */ getDefaultTerminalWindows();
+
+        // Prepare the title and the command to be executed.
+        String fullTitle = "\"" + args.getTitle() + "\"";
+        String command = "\"" + String.join("\" \"", args.getArgs()) + "\" & pause";
+
+        // Prepare environment variables, removing null entries.
+        Map<String, String> env = args.getEnv() != null ? args.getEnv() : new HashMap<>();
+        env.entrySet().removeIf(e -> e.getValue() == null);
+
+        List<String> cmdArgs = new ArrayList<>();
+        String spawnExec;
+
+        // Detect if the configured executable is Windows Terminal (wt.exe) or a classic cmd.exe session.
+        if (new File(exec).getName().equalsIgnoreCase("wt.exe")) {
+            spawnExec = exec;
+            // Use Windows Terminal with cmd.exe as shell.
+            cmdArgs.addAll(Arrays.asList("-d", ".", CMD, "/c", command));
+        } else {
+            spawnExec = CMD;
+            // Use classic cmd.exe and spawn the configured terminal as a subprocess.
+            cmdArgs.addAll(Arrays.asList("/c", "start", fullTitle, "/wait", exec, "/c", "\"" + command + "\""));
+        }
+
+        // Configure the process builder with working directory and environment variables.
+        ProcessBuilder pb = new ProcessBuilder(spawnExec);
+        pb.command().addAll(cmdArgs);
+        pb.directory(new File(args.getCwd()));
+        pb.environment().putAll(env);
+
+        return runProcessAsyncWithExitCode(pb);
+    }
+
+    /**
+     * Starts the process asynchronously and completes with its exit code when finished.
+     *
+     * @param pb the configured {@link ProcessBuilder} to launch.
+     * @return a {@link CompletableFuture} of the process exit code.
+     */
+    private CompletableFuture<Integer> runProcessAsyncWithExitCode(ProcessBuilder pb) {
+        CompletableFuture<Integer> future = new CompletableFuture<>();
+        try {
+            Process p = pb.start();
+            p.onExit()
+                    .thenAccept(pr -> future.complete(pr.exitValue()));
+        } catch (IOException e) {
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
+
+    /**
+     * Determines the default Windows terminal executable path depending on the architecture (Sysnative/System32).
+     * <p>
+     * This method caches the computed path to avoid recomputing it for every invocation.
+     *
+     * @return the absolute path of the default terminal executable (cmd.exe).
+     */
+    public static String getDefaultTerminalWindows() {
+        if (DEFAULT_TERMINAL_WINDOWS == null) {
+            boolean isWoW64 = System.getenv().containsKey("PROCESSOR_ARCHITEW6432");
+            String winDir = System.getenv().getOrDefault("windir", "C:\\Windows");
+            DEFAULT_TERMINAL_WINDOWS = winDir + "\\" + (isWoW64 ? "Sysnative" : "System32") + "\\cmd.exe";
+        }
+        return DEFAULT_TERMINAL_WINDOWS;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/integrated/RunInIntegratedTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/runInterminal/integrated/RunInIntegratedTerminalService.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.runInterminal.integrated;
+
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.util.Alarm;
+import com.redhat.devtools.lsp4ij.dap.client.runInterminal.RunInTerminalService;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalResponse;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.terminal.ShellTerminalWidget;
+import org.jetbrains.plugins.terminal.TerminalToolWindowManager;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Integrated terminal implementation of {@link RunInTerminalService} for Debug Adapter Protocol (DAP).
+ * <p>
+ * This service opens a new IntelliJ integrated terminal tab and executes the command specified
+ * by a {@link RunInTerminalRequestArguments} request. It supports injecting environment variables
+ * and formatting commands based on the underlying OS and shell.
+ * </p>
+ *
+ * <p><b>Features:</b></p>
+ * <ul>
+ *   <li>Creates a local shell widget in the integrated terminal window.</li>
+ *   <li>Supports PowerShell, cmd.exe, and Unix-style shells.</li>
+ *   <li>Injects environment variables with syntax adapted to the active shell.</li>
+ *   <li>Returns the process ID of the spawned shell through {@link RunInTerminalResponse}.</li>
+ * </ul>
+ *
+ * <p>
+ * This service requires the IntelliJ Terminal plugin to be installed. If the plugin is missing,
+ * {@link #isApplicable()} returns {@code false}.
+ * </p>
+ */
+public class RunInIntegratedTerminalService implements RunInTerminalService {
+
+    /**
+     * Checks if the IntelliJ terminal plugin is installed and available.
+     *
+     * @return {@code true} if the terminal plugin is installed, {@code false} otherwise
+     */
+    @Override
+    public boolean isApplicable() {
+        return isTerminalPluginInstalled();
+    }
+
+    /**
+     * Executes the given DAP {@code runInTerminal} request in an integrated terminal tab.
+     *
+     * <p>The method:</p>
+     * <ol>
+     *   <li>Creates a new {@link ShellTerminalWidget} for the project.</li>
+     *   <li>Prepares the command line with proper argument quoting and environment variable injection.</li>
+     *   <li>Executes the command inside the terminal.</li>
+     *   <li>Polls the terminal widget until a process ID is available, then completes the future.</li>
+     * </ol>
+     *
+     * @param args    the {@link RunInTerminalRequestArguments} containing command, working directory,
+     *                environment variables, and title
+     * @param project the IntelliJ {@link Project} in which to open the integrated terminal
+     * @return a {@link CompletableFuture} resolving to a {@link RunInTerminalResponse}
+     *         containing the process ID of the spawned terminal process
+     */
+    @Override
+    public CompletableFuture<RunInTerminalResponse> runInTerminal(@NotNull RunInTerminalRequestArguments args,
+                                                                  @NotNull Project project) {
+        CompletableFuture<RunInTerminalResponse> future = new CompletableFuture<>();
+
+        ApplicationManager.getApplication().invokeLater(() -> {
+            try {
+                TerminalToolWindowManager tm = TerminalToolWindowManager.getInstance(project);
+
+                String title = args.getTitle();
+                String workingDirectory = args.getCwd();
+                ShellTerminalWidget shellWidget = tm.createLocalShellWidget(workingDirectory, title);
+
+                String command = prepareCommandWithEnv(args);
+                shellWidget.executeCommand(command);
+
+                // Poll until the process PID becomes available
+                Alarm alarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, project);
+                Runnable checkProcess = new Runnable() {
+                    @Override
+                    public void run() {
+                        var tty = shellWidget.getProcessTtyConnector();
+                        if (tty != null) {
+                            RunInTerminalResponse resp = new RunInTerminalResponse();
+                            resp.setProcessId((int) tty.getProcess().pid());
+                            future.complete(resp);
+                        } else if (!future.isDone()) {
+                            alarm.addRequest(this, 100);
+                        }
+                    }
+                };
+                alarm.addRequest(checkProcess, 100);
+
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+
+        return future;
+    }
+
+    /**
+     * Builds a full command line with environment variable injection adapted
+     * to the current OS and shell syntax.
+     * <p>
+     * - PowerShell: {@code ${env:VAR}='value'; command}<br>
+     * - cmd.exe: {@code set VAR=value && set VAR2=value && command}<br>
+     * - Unix shells: {@code VAR='value' VAR2='value' command}
+     * </p>
+     *
+     * @param args the {@link RunInTerminalRequestArguments} containing the command and environment
+     * @return the formatted command string
+     */
+    private String prepareCommandWithEnv(@NotNull RunInTerminalRequestArguments args) {
+        String command = formatCommandArguments(args.getArgs());
+
+        if (args.getEnv() == null || args.getEnv().isEmpty()) {
+            return command;
+        }
+
+        boolean isWindows = SystemInfo.isWindows;
+        boolean isPowerShell = isWindows && isPowerShellEnvironment();
+        StringBuilder envCmd = new StringBuilder();
+
+        if (isPowerShell) {
+            args.getEnv().forEach((k, v) -> {
+                envCmd.append("${env:").append(k).append("}='")
+                        .append(v.replace("'", "''")).append("'; ");
+            });
+            envCmd.append(command);
+        } else if (isWindows) {
+            args.getEnv().forEach((k, v) -> {
+                envCmd.append("set ").append(k).append("=").append(v).append(" && ");
+            });
+            envCmd.append(command);
+        } else {
+            args.getEnv().forEach((k, v) -> {
+                envCmd.append(k).append("='")
+                        .append(v.replace("'", "'\"'\"'")).append("' ");
+            });
+            envCmd.append(command);
+        }
+
+        return envCmd.toString();
+    }
+
+    /**
+     * Formats command-line arguments for the active OS and shell.
+     * <p>
+     * - PowerShell: adds call operator {@code &} and quotes paths with spaces<br>
+     * - cmd.exe: escapes spaces with {@code ^ }<br>
+     * - Unix: wraps arguments with spaces in single quotes
+     * </p>
+     *
+     * @param args the array of command arguments
+     * @return a properly quoted and escaped command string
+     */
+    private String formatCommandArguments(String[] args) {
+        boolean isWindows = SystemInfo.isWindows;
+        boolean isPowerShell = isWindows && isPowerShellEnvironment();
+
+        if (args.length == 0) {
+            return "";
+        }
+
+        if (isPowerShell) {
+            String first = args[0];
+            if (first.contains(" ")) {
+                first = "& \"" + first + "\"";
+            } else {
+                first = "& " + first;
+            }
+
+            String rest = Arrays.stream(args, 1, args.length)
+                    .map(arg -> arg.contains(" ") ? "\"" + arg + "\"" : arg)
+                    .collect(Collectors.joining(" "));
+
+            return first + (rest.isEmpty() ? "" : " " + rest);
+        } else if (isWindows) {
+            return Arrays.stream(args)
+                    .map(arg -> arg.contains(" ") ? arg.replace(" ", "^ ") : arg)
+                    .collect(Collectors.joining(" "));
+        } else {
+            return Arrays.stream(args)
+                    .map(arg -> arg.contains(" ") ? "'" + arg.replace("'", "'\"'\"'") + "'" : arg)
+                    .collect(Collectors.joining(" "));
+        }
+    }
+
+    /**
+     * Detects whether the current environment is running under PowerShell on Windows.
+     *
+     * @return {@code true} if the environment suggests PowerShell, {@code false} otherwise
+     */
+    private boolean isPowerShellEnvironment() {
+        String psModule = System.getenv("PSModulePath");
+        return psModule != null && psModule.contains("PowerShell");
+    }
+
+    /**
+     * Checks if the IntelliJ terminal plugin is installed and available.
+     *
+     * @return {@code true} if the terminal plugin is present, {@code false} otherwise
+     */
+    private static boolean isTerminalPluginInstalled() {
+        PluginId pluginId = PluginId.getId("org.jetbrains.plugins.terminal");
+        return PluginManagerCore.getPlugin(pluginId) != null;
+    }
+}


### PR DESCRIPTION
feat: Support runInTerminal (external only for Windows OS) request for DAP

This PR translate vscode code https://github.com/microsoft/vscode/blob/main/src/vs/platform/externalTerminal/node/externalTerminalService.ts which supports external terminal.

I have tested with windows but not with linux and mac.

@sbouchet @adietish is there any chance that you could test this PR (and debug it to fix issues on Linux/Mac), if yes I could explain how to test it.

Thanks