### PR TITLE
fix: `textDocument/didOpen` not called when language server doesn't support codelens, highlight, etc

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -11,53 +11,81 @@
 package com.redhat.devtools.lsp4ij;
 
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.lifecycle.LanguageServerLifecycleManager;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Track file opened / closed to start language servers / disconnect file from language servers.
+ * Manages the connection between open editor files and Language Servers:
+ * <ul>
+ *   <li>Starts Language Servers when a supported file becomes active in the editor.</li>
+ *   <li>Releases resources when a file is closed.</li>
+ *   <li>Properly stops Language Servers when the project is closed.</li>
+ * </ul>
  */
 public class ConnectDocumentToLanguageServerSetupParticipant implements ProjectManagerListener, FileEditorManagerListener {
 
     @Override
     public void projectOpened(@NotNull Project project) {
+        // Subscribe to file open/close/selection events for this project.
         project.getMessageBus().connect().subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, this);
     }
 
     @Override
     public void projectClosing(@NotNull Project project) {
+        // Stop active Language Servers and clean up resources before the project is closed.
         LanguageServerLifecycleManager.getInstance(project).dispose();
         LanguageServiceAccessor.getInstance(project).projectClosing(project);
     }
 
     @Override
     public void fileOpened(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
-        Project project = source.getProject();
-        // As document matcher requires read action, and language server starts can take some times, we connect the file in a future
-        // to avoid starting language server in the EDT Thread which could freeze IJ.
-        // Wait for indexing is finished and read action is enabled
-        // --> force the start of all languages servers mapped with the given file when indexing is finished and read action is allowed
-        /*ProjectIndexingManager
+        // Do not send textDocument/didOpen here:
+        // this method is also called when a file is opened in the background (tab not visible).
+        // To optimize performance, Language Servers are only started when the editor tab becomes active.
+    }
+
+    @Override
+    public void selectionChanged(@NotNull FileEditorManagerEvent event) {
+        VirtualFile file = event.getNewFile();
+        if (file == null) {
+            return;
+        }
+        var project = event.getManager().getProject();
+        PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+        if (psiFile == null || LSPFileSupport.hasSupport(psiFile)) {
+            // No PsiFile available, or the file is already connected to a Language Server.
+            return;
+        }
+        if (!LanguageServersRegistry.getInstance().isFileSupported(file, project)) {
+            return;
+        }
+        // Since file-to-server matching requires a read action,
+        // and Language Server startup may be expensive,
+        // schedule the connection asynchronously after indexing is finished.
+        ProjectIndexingManager
                 .waitForIndexingAll()
                 .thenApplyAsync(unused -> {
                     connectToLanguageServer(file, project);
                     return null;
-                });*/
+                });
     }
 
     @Override
     public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
-        // file is closed
+        // When a file is closed:
         PsiFile psiFile = LSPIJUtils.getPsiFile(file, source.getProject());
         if (psiFile != null) {
             if (LSPFileSupport.hasSupport(psiFile)) {
-                // The closed file is mapped with language servers, dispose it
-                // to cancel all LSP codeLens, inlayHint, color, etc futures
+                // If the file is associated with a Language Server,
+                // release its resources (code lenses, inlay hints, color providers, etc.).
                 LSPFileSupport.getSupport(psiFile).dispose();
             }
         }
@@ -66,12 +94,9 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements ProjectM
     private static void connectToLanguageServer(@NotNull VirtualFile file, @NotNull Project project) {
         PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
         if (psiFile != null) {
-            // Force the start of all languages servers mapped with the given file
-            // Server capabilities filter is set to null to avoid waiting
-            // for the start of the server when server capabilities are checked
+            // Force the startup of all Language Servers mapped to this file.
             LanguageServiceAccessor.getInstance(project)
                     .getLanguageServers(psiFile, null, null);
         }
     }
-
 }


### PR DESCRIPTION
fix: `textDocument/didOpen` not called when language server doesn't support codelens, highlight, etc

Fixes #1224