### PR TITLE
fix: adds immediate document saving after applying text edits to trig…

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -1212,6 +1212,8 @@ public class LSPIJUtils {
         if (newCaretOffset > -1 && oldCaretOffset != newCaretOffset) {
             editor.getCaretModel().moveToOffset(newCaretOffset);
         }
+
+        FileDocumentManager.getInstance().saveDocument(document);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -1213,6 +1213,9 @@ public class LSPIJUtils {
             editor.getCaretModel().moveToOffset(newCaretOffset);
         }
 
+        // Explicit document save is required to trigger LSPFileListener#contentsChanged immediately for files
+        // that are not open in the editor, which will send didChangeWatchedFiles notification to the language server.
+        // By default, for such files, IDEA's auto-save logic is used which causes a delay until auto-save happens.
         FileDocumentManager.getInstance().saveDocument(document);
     }
 


### PR DESCRIPTION
Ensures immediate VFS events when LSPIJUtils.applyEdits is used on unopened files

Added document saving after applying text edits to trigger VFS events right away.

Tested on Clojure LSP plugin:

Before fix:

https://github.com/user-attachments/assets/41194789-72a9-45fd-a24e-c61484033d7d

After fix:

https://github.com/user-attachments/assets/ccbba016-c69c-4e22-acfa-fbd97ce0581f







Fixes #1225
