### PR TITLE
fix: Display LSP diagnostics for opened documents which are not associated to a language server

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/ClosedDocument.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/ClosedDocument.java
@@ -42,7 +42,6 @@ public class ClosedDocument extends LSPDocumentBase {
                 .stream()
                 .anyMatch(diagnostic -> diagnostic.getSeverity() != null && diagnostic.getSeverity() == DiagnosticSeverity.Error);
         return changed;
-
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -107,10 +107,10 @@ class LSPFileListener implements FileEditorManagerListener, VirtualFileListener 
         VirtualFile file = event.getFile();
         URI uri = languageServerWrapper.toUri(file);
         if (uri != null) {
-            OpenedDocument documentListener = languageServerWrapper.openedDocuments.get(uri);
-            if (documentListener != null) {
+            OpenedDocument openedDocument = languageServerWrapper.getOpenedDocument(uri);
+            if (openedDocument != null && openedDocument.getSynchronizer() != null) {
                 // 1. Send a textDocument/didSave for the saved file
-                documentListener.getSynchronizer().documentSaved();
+                openedDocument.getSynchronizer().documentSaved();
             }
             if (isMatchFilePatterns(uri, WatchKind.Change)) {
                 // 2. Send a workspace/didChangeWatchedFiles

--- a/src/main/java/com/redhat/devtools/lsp4ij/OpenedDocument.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/OpenedDocument.java
@@ -18,6 +18,7 @@ import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.features.diagnostics.LSPDiagnosticsForServer;
 import org.eclipse.lsp4j.Diagnostic;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,13 +35,13 @@ public class OpenedDocument extends LSPDocumentBase {
 
     private final LSPDiagnosticsForServer diagnosticsForServer;
 
-    private final DocumentContentSynchronizer synchronizer;
+    private final @Nullable DocumentContentSynchronizer synchronizer;
     private long updatedDiagnosticsTime; // time when diagnostics has been updated
     private long displayingDiagnosticsTime; // time when diagnostics has been displayed with the LSPDiagnosticAnnotator.
 
     public OpenedDocument(@NotNull LanguageServerItem languageServer,
                           @NotNull VirtualFile file,
-                          @NotNull DocumentContentSynchronizer synchronizer) {
+                          @Nullable DocumentContentSynchronizer synchronizer) {
         this.file = file;
         this.synchronizer = synchronizer;
         this.diagnosticsForServer = new LSPDiagnosticsForServer(languageServer,file);
@@ -56,7 +57,7 @@ public class OpenedDocument extends LSPDocumentBase {
         return file;
     }
 
-    public DocumentContentSynchronizer getSynchronizer() {
+    public @Nullable DocumentContentSynchronizer getSynchronizer() {
         return synchronizer;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/LanguageClientImpl.java
@@ -216,8 +216,10 @@ public class LanguageClientImpl implements LanguageClient, Disposable {
     private void refreshDiagnosticsForAllOpenedFiles() {
         // Received request 'workspace/diagnostic/refresh
         for (var openedDocument : wrapper.getOpenedDocuments()) {
-            openedDocument.getSynchronizer()
-                    .refreshPullDiagnostic(DocumentContentSynchronizer.RefreshPullDiagnosticOrigin.ON_WORKSPACE_REFRESH);
+            if (openedDocument.getSynchronizer() != null) {
+                openedDocument.getSynchronizer()
+                        .refreshPullDiagnostic(DocumentContentSynchronizer.RefreshPullDiagnosticOrigin.ON_WORKSPACE_REFRESH);
+            }
         }
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/DiagnosticCapabilityRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/capabilities/DiagnosticCapabilityRegistry.java
@@ -84,8 +84,10 @@ public class DiagnosticCapabilityRegistry extends TextDocumentServerCapabilityRe
         // - didOpen have not processed pull diagnostic
         // - and if language server support it for now if textDocument/diagnostic has been dynamically registered.
         for (var openedDocument : getClientFeatures().getServerWrapper().getOpenedDocuments()) {
-            openedDocument.getSynchronizer()
-                    .refreshPullDiagnostic(DocumentContentSynchronizer.RefreshPullDiagnosticOrigin.ON_REGISTER_CAPABILITY);
+            if (openedDocument.getSynchronizer() != null) {
+                openedDocument.getSynchronizer()
+                        .refreshPullDiagnostic(DocumentContentSynchronizer.RefreshPullDiagnosticOrigin.ON_REGISTER_CAPABILITY);
+            }
         }
         return options;
     }


### PR DESCRIPTION
fix: Display LSP diagnostics for opened documents which are not associated to a language server

Fixes #1232

<img width="1237" height="587" alt="image" src="https://github.com/user-attachments/assets/5162a122-87ba-4081-9354-c6ec55b34567" />

