### PR TITLE
fix: integrated/external runInTerminal fails with empty cwd on Windows OS

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/runInTerminal/external/ExternalTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/runInTerminal/external/ExternalTerminalService.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.lsp4ij.dap.runInTerminal.external;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.dap.runInTerminal.RunInTerminalService;
 import com.redhat.devtools.lsp4ij.internal.ResponseErrorExceptionWrapper;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
 import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.jetbrains.annotations.NotNull;
@@ -84,7 +85,7 @@ public abstract class ExternalTerminalService implements RunInTerminalService {
 
         // Configure the process builder with working directory and environment variables.
         ProcessBuilder pb = new ProcessBuilder(commandBuilder.apply(args));
-        if (args.getCwd() != null) {
+        if (StringUtils.isNotBlank(args.getCwd())) {
             pb.directory(new File(args.getCwd()));
         }
         if (args.getEnv() != null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/runInTerminal/integrated/RunInIntegratedTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/runInTerminal/integrated/RunInIntegratedTerminalService.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.Alarm;
 import com.redhat.devtools.lsp4ij.dap.runInTerminal.RunInTerminalService;
+import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
 import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.jetbrains.annotations.NotNull;
@@ -87,7 +88,7 @@ public class RunInIntegratedTerminalService implements RunInTerminalService {
                 TerminalToolWindowManager tm = TerminalToolWindowManager.getInstance(project);
 
                 String title = args.getTitle();
-                String workingDirectory = args.getCwd();
+                String workingDirectory = StringUtils.isBlank(args.getCwd()) ? null : args.getCwd();
                 ShellTerminalWidget shellWidget = tm.createLocalShellWidget(workingDirectory, title);
 
                 String command = prepareCommandWithEnv(args);


### PR DESCRIPTION
fix: integrated/external runInTerminal fails with empty cwd on Windows OS