### PR TITLE
fix: java.lang.IllegalStateException: @NotNull method com/redhat/devtools/lsp4ij/dap/evaluation/DAPDebuggerEvaluator.getExpressionInfoAtOffsetAsync must not return null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPDebuggerEvaluator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPDebuggerEvaluator.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.concurrency.Promise;
+import org.jetbrains.concurrency.Promises;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletionException;
@@ -144,7 +145,7 @@ public class DAPDebuggerEvaluator extends XDebuggerEvaluator {
         var client = stackFrame.getClient();
         if (!client.isSupportsEvaluateForHovers()) {
             // DAP server doesn't support evaluate for hovers
-            return null;
+            return Promises.resolvedPromise(null);
         }
         return ReadAction.nonBlocking(() -> {
 


### PR DESCRIPTION
```
Unhandled exception in [ComponentManager(ApplicationImpl@1575243501), com.intellij.codeWithMe.ClientIdContextElementPrecursor@5a2d3d1f, CoroutineName(com.intellij.platform.kernel.backend.BackendKernelService), Dispatchers.Default]

java.lang.IllegalStateException: @NotNull method com/redhat/devtools/lsp4ij/dap/evaluation/DAPDebuggerEvaluator.getExpressionInfoAtOffsetAsync must not return null
	at com.redhat.devtools.lsp4ij.dap.evaluation.DAPDebuggerEvaluator.$$$reportNull$$$0(DAPDebuggerEvaluator.java)
	at com.redhat.devtools.lsp4ij.dap.evaluation.DAPDebuggerEvaluator.getExpressionInfoAtOffsetAsync(DAPDebuggerEvaluator.java:147)
	at com.intellij.platform.debugger.impl.backend.BackendXDebuggerValueLookupHintsRemoteApi.getExpressionInfo$lambda$1(BackendXDebuggerValueLookupHintsRemoteApi.kt:77)
	at com.intellij.openapi.application.rw.InternalReadAction.insideReadAction(InternalReadAction.kt:114)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadCancellable$lambda$4(InternalReadAction.kt:104)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$3$lambda$2$lambda$1(cancellableReadAction.kt:32)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:351)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:971)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$3$lambda$2(cancellableReadAction.kt:30)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:66)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:157)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal(cancellableReadAction.kt:28)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadCancellable(InternalReadAction.kt:103)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadAction(InternalReadAction.kt:87)
	at com.intellij.openapi.application.rw.InternalReadAction.readLoop(InternalReadAction.kt:74)
	at com.intellij.openapi.application.rw.InternalReadAction.access$readLoop(InternalReadAction.kt:16)
	at com.intellij.openapi.application.rw.InternalReadAction$runReadAction$6.invokeSuspend(InternalReadAction.kt:53)
	at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
	at com.intellij.platform.debugger.impl.backend.BackendXDebuggerValueLookupHintsRemoteApi.getExpressionInfo(BackendXDebuggerValueLookupHintsRemoteApi.kt:76)
	at com.intellij.platform.debugger.impl.backend.BackendXDebuggerValueLookupHintsRemoteApi$getExpressionInfo$2.invokeSuspend(BackendXDebuggerValueLookupHintsRemoteApi.kt:44)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.XQuickEvaluateHandler$createValueHintAsync$expressionInfoDeferred$1$1.invokeSuspend(XQuickEvaluateHandler.kt:57)
	at com.intellij.platform.kernel.ApiKt$withKernel$2.invokeSuspend(api.kt:21)
	at com.intellij.platform.kernel.ApiKt.withKernel(api.kt:19)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.XQuickEvaluateHandler$createValueHintAsync$expressionInfoDeferred$1.invokeSuspend(XQuickEvaluateHandler.kt:55)
	at fleet.kernel.rete.ReteKt$withRete$2$1$2.invokeSuspend(Rete.kt:108)
	at fleet.util.async.WithLaunchedKt$use$2.invokeSuspend(WithLaunched.kt:8)
	at fleet.util.async.WithLaunchedKt.use(WithLaunched.kt:8)
	at fleet.kernel.TransactorKt$subscribe$2$1.invokeSuspend(Transactor.kt:145)
	at fleet.kernel.TransactorKt$subscribe$2.invokeSuspend(Transactor.kt:144)
	at fleet.kernel.rete.ReteKt$withRete$2.invokeSuspend(Rete.kt:63)
	at fleet.tracing.TracingKt.spannedScope(Tracing.kt:62)
	at com.intellij.platform.kernel.util.KernelUtilsKt$withKernel$2.invokeSuspend(kernelUtils.kt:31)
	at fleet.kernel.TransactorKt$withTransactor$2$3$1.invokeSuspend(Transactor.kt:483)
	at fleet.kernel.TransactorKt$withTransactor$2$3.invokeSuspend(Transactor.kt:482)
	at fleet.util.async.WithLaunchedKt$use$2.invokeSuspend(WithLaunched.kt:8)
	at fleet.util.async.WithLaunchedKt.use(WithLaunched.kt:8)
	at fleet.kernel.TransactorKt$withTransactor$2.invokeSuspend(Transactor.kt:480)
	at fleet.tracing.TracingKt.spannedScope(Tracing.kt:62)
	at com.intellij.platform.kernel.backend.BackendKernelService$1.invokeSuspend(BackendKernelService.kt:52)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [ComponentManager(ApplicationImpl@1575243501), com.intellij.codeWithMe.ClientIdContextElementPrecursor@5a2d3d1f, CoroutineName(com.intellij.platform.kernel.backend.BackendKernelService), CoroutineId(173), "com.intellij.platform.kernel.backend.BackendKernelService#173":StandaloneCoroutine{Cancelled}@40d05517, Dispatchers.Default]
Caused by: java.lang.IllegalStateException: @NotNull method com/redhat/devtools/lsp4ij/dap/evaluation/DAPDebuggerEvaluator.getExpressionInfoAtOffsetAsync must not return null
	at com.redhat.devtools.lsp4ij.dap.evaluation.DAPDebuggerEvaluator.$$$reportNull$$$0(DAPDebuggerEvaluator.java)
	at com.redhat.devtools.lsp4ij.dap.evaluation.DAPDebuggerEvaluator.getExpressionInfoAtOffsetAsync(DAPDebuggerEvaluator.java:147)
	at com.intellij.platform.debugger.impl.backend.BackendXDebuggerValueLookupHintsRemoteApi.getExpressionInfo$lambda$1(BackendXDebuggerValueLookupHintsRemoteApi.kt:77)
	at com.intellij.openapi.application.rw.InternalReadAction.insideReadAction(InternalReadAction.kt:114)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadCancellable$lambda$4(InternalReadAction.kt:104)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$3$lambda$2$lambda$1(cancellableReadAction.kt:32)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:351)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:971)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$3$lambda$2(cancellableReadAction.kt:30)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:66)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:157)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal(cancellableReadAction.kt:28)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadCancellable(InternalReadAction.kt:103)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadAction(InternalReadAction.kt:87)
	at com.intellij.openapi.application.rw.InternalReadAction.readLoop(InternalReadAction.kt:74)
	at com.intellij.openapi.application.rw.InternalReadAction.access$readLoop(InternalReadAction.kt:16)
	at com.intellij.openapi.application.rw.InternalReadAction$runReadAction$6.invokeSuspend(InternalReadAction.kt:53)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async(Builders.common.kt:87)
	at kotlinx.coroutines.BuildersKt.async(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.async$default(Builders.common.kt:78)
	at kotlinx.coroutines.BuildersKt.async$default(Unknown Source)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.XQuickEvaluateHandler.createValueHintAsync(XQuickEvaluateHandler.kt:54)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.common.ValueLookupManager.doShowHint(ValueLookupManager.java:192)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.common.ValueLookupManager.lambda$showHint$1(ValueLookupManager.java:172)
	at com.intellij.psi.impl.PsiDocumentManagerBase.performWhenAllCommitted(PsiDocumentManagerBase.java:628)
	at com.intellij.psi.impl.PsiDocumentManagerBase.performWhenAllCommitted(PsiDocumentManagerBase.java:618)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.common.ValueLookupManager.showHint(ValueLookupManager.java:172)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.common.ValueLookupManager.lambda$requestHint$0(ValueLookupManager.java:135)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:128)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:916)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.util.Alarm$Request$schedule$1$1.invokeSuspend(Alarm.kt:403)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith$$$capture(ContinuationImpl.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.<init>(DebugProbesImpl.kt:531)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.createOwner(DebugProbesImpl.kt:510)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl.probeCoroutineCreated$kotlinx_coroutines_core(DebugProbesImpl.kt:497)
	at kotlin.coroutines.jvm.internal.DebugProbesKt.probeCoroutineCreated(DebugProbes.kt:7)
	at kotlin.coroutines.intrinsics.IntrinsicsKt__IntrinsicsJvmKt.createCoroutineUnintercepted(IntrinsicsJvm.kt:161)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
	at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
	at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
	at com.intellij.util.Alarm$Request.schedule(Alarm.kt:379)
	at com.intellij.util.Alarm.add(Alarm.kt:251)
	at com.intellij.util.Alarm.doAddRequest(Alarm.kt:236)
	at com.intellij.util.Alarm.addRequest(Alarm.kt:183)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.common.ValueLookupManager.requestHint(ValueLookupManager.java:133)
	at com.intellij.platform.debugger.impl.frontend.evaluate.quick.common.ValueLookupManager.mouseMoved(ValueLookupManager.java:107)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.intellij.util.EventDispatcher.dispatchVoidMethod(EventDispatcher.java:120)
	at com.intellij.util.EventDispatcher.lambda$createMulticaster$1(EventDispatcher.java:85)
	at jdk.proxy2/jdk.proxy2.$Proxy104.mouseMoved(Unknown Source)
	at com.intellij.openapi.editor.impl.EditorImpl$MyMouseMotionListener.mouseMoved(EditorImpl.java:4951)
	at java.desktop/java.awt.Component.processMouseMotionEvent(Component.java:6707)
	at java.desktop/javax.swing.JComponent.processMouseMotionEvent(JComponent.java:3412)
	at java.desktop/java.awt.Component.processEvent(Component.java:6431)
	at java.desktop/java.awt.Container.processEvent(Container.java:2266)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5032)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4860)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4963)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4590)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4518)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2810)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4860)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:783)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:728)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:755)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:753)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:752)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:675)
	at com.intellij.ide.IdeEventQueue.dispatchMouseEvent(IdeEventQueue.kt:621)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$21(IdeEventQueue.kt:564)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:128)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:564)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$18$lambda$17$lambda$16$lambda$15(IdeEventQueue.kt:355)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:857)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$18$lambda$17$lambda$16(IdeEventQueue.kt:354)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$2$lambda$1(IdeEventQueue.kt:1045)
	at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:128)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:916)
	at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
	at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$2(IdeEventQueue.kt:1045)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$3(IdeEventQueue.kt:1054)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:117)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1054)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$18(IdeEventQueue.kt:349)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:395)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)

```