### PR TITLE
fix: don't use internal OpenFileDescriptor#navigateInEditor

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredSourcePosition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredSourcePosition.java
@@ -244,7 +244,7 @@ public abstract class DeferredSourcePosition<T, F extends VirtualFile> implement
 
         private void doNavigateIn(@NotNull Editor e) {
             OpenFileDescriptor descriptor = new OpenFileDescriptor(getProject(), getFile(), position.getOffset());
-            navigateInEditor(descriptor, e);
+            descriptor.navigateIn(e);
         }
 
         /**


### PR DESCRIPTION
fix: don't use internal OpenFileDescriptor#navigateInEditor