### PR TITLE
fix: wait to start server during language server restart

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -253,7 +253,7 @@ public class LanguageServerWrapper implements Disposable {
         numberOfRestartAttempts = 0;
         serverError = null;
         setEnabled(true);
-        if (serverStatus != ServerStatus.installed && serverStatus != ServerStatus.installing && serverStatus != ServerStatus.stopped) {
+        if (serverStatus != ServerStatus.installed && serverStatus != ServerStatus.installing) {
             stop().thenRun(this::restartImpl);
         } else {
             restartImpl();

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -255,8 +255,9 @@ public class LanguageServerWrapper implements Disposable {
         setEnabled(true);
         if (serverStatus != ServerStatus.installed && serverStatus != ServerStatus.installing && serverStatus != ServerStatus.stopped) {
             stop().thenRun(this::restartImpl);
-        } else
+        } else {
             restartImpl();
+        }
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -273,7 +273,7 @@ public class LanguageServerWrapper implements Disposable {
                     // 2. refresh code vision, inlay hints, folding for all opened editors
                     // which edit the files associated to the language server.
                     LanguageServiceAccessor.getInstance(getProject()).
-                                           sendDidOpenAndRefreshEditorFeatureForOpenedFiles(serverDefinition, getProject());
+                            sendDidOpenAndRefreshEditorFeatureForOpenedFiles(serverDefinition, getProject());
                 });
     }
 


### PR DESCRIPTION
This PR makes the following change to the restart function in LSP Wrapper:
- Waits for server to stop before starting

This fixes an edge case discovered whilst working on [GroovyScript Plugin](https://github.com/IntegerLimit/GroovyScriptPlugin): due to the server taking long to process the `shutdown` request, stopping the server takes until the timeout runs out (5 seconds), resulting in the following sequence of events if the server was restarted:
- Server `stop` called
- Server `start` called, server starts
- Connection Provider `stop` called, server stops again

Furthermore, even if the server is in the `stopped` state, starting the server via the console would always result in these events. The only method of recovering from this (prior to this fix) is to disable and re-enable the language server through external means (IDE restart, settings change).

This PR is confirmed to fix the above issue.