### PR TITLE
fix: Rename template id to match the Markdown file

### DIFF
--- a/src/main/resources/templates/dap/buildx-dockerfile/template.json
+++ b/src/main/resources/templates/dap/buildx-dockerfile/template.json
@@ -1,5 +1,5 @@
 {
-  "id": "docker-buildx-dockerfile",
+  "id": "buildx-dockerfile",
   "name": "Docker: Dockerfile Build Debugging",
   "launch": {
     "default": "docker buildx dap build"


### PR DESCRIPTION
LSP4IJ uses the id in `template.json` to map to the Markdown file when using the "Need help with install, config, or usage? Click here" link so we need the id to be `buildx-dockerfile` so it opens the `buildx-dockefile.md` file.