### PR TITLE
build: migrate to Gradle 8.6 to start LSP4IJ plugin with 2025.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,14 +13,14 @@ pluginSinceBuild=233
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
-platformVersion=2025.1
+platformVersion=2025.2
 platformBundledPlugins=org.jetbrains.plugins.textmate,com.intellij.properties,org.jetbrains.plugins.terminal
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 platformPlugins=com.redhat.devtools.intellij.telemetry:1.2.1.62
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion=8.5
+gradleVersion=8.6
 channel=nightly
 # Align LSP4J with JetBrains LSP-API
 # org.eclipse.lsp4j.debug:0.14.0 0.21.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ junit-jupiter = "5.10.3"
 
 # plugins
 testlogger = "3.2.0"
-kotlin = "2.0.20"
+kotlin = "2.2.0"
 changelog = "2.2.1"
-gradleIntelliJPlugin = "2.2.1"
+gradleIntelliJPlugin = "2.9.0"
 kover = "0.8.3"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
build: migrate to Gradle 8.6 to start LSP4IJ plugin with 2025.2

Thanks so much to @sbouchet to have helped me to do this PR!