### PR TITLE
fix: Environment variables of a DAP launch config are ignored

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPRunConfiguration.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/DAPRunConfiguration.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.dap.DebugMode;
 import com.redhat.devtools.lsp4ij.dap.DebugServerWaitStrategy;
 import com.redhat.devtools.lsp4ij.dap.configurations.options.AttachConfigurable;
+import com.redhat.devtools.lsp4ij.dap.configurations.options.EnvironmentVariablesDataConfigurable;
 import com.redhat.devtools.lsp4ij.dap.configurations.options.FileOptionConfigurable;
 import com.redhat.devtools.lsp4ij.dap.configurations.options.WorkingDirectoryConfigurable;
 import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
@@ -34,7 +35,7 @@ import java.util.List;
 /**
  * Default Debug Adapter Protocol (DAP) run configuration.
  */
-public class DAPRunConfiguration extends DAPRunConfigurationBase<DAPRunConfigurationOptions> implements FileOptionConfigurable, WorkingDirectoryConfigurable, AttachConfigurable, DebuggableFile {
+public class DAPRunConfiguration extends DAPRunConfigurationBase<DAPRunConfigurationOptions> implements FileOptionConfigurable, WorkingDirectoryConfigurable, AttachConfigurable, EnvironmentVariablesDataConfigurable, DebuggableFile {
 
     public static final String DEBUG_ADAPTER_CONFIGURATION = "Debug Adapter Configuration";
 
@@ -86,10 +87,12 @@ public class DAPRunConfiguration extends DAPRunConfigurationBase<DAPRunConfigura
         getOptions().setCommand(command);
     }
 
+    @Override
     public @NotNull EnvironmentVariablesData getEnvData() {
         return envData;
     }
 
+    @Override
     public void setEnvData(@NotNull EnvironmentVariablesData envData) {
         this.envData = envData;
     }
@@ -294,6 +297,7 @@ public class DAPRunConfiguration extends DAPRunConfigurationBase<DAPRunConfigura
         configuration.setServerId(getServerId());
         configuration.setServerName(getServerName());
         configuration.setCommand(getCommand());
+        configuration.setEnvData(getEnvData());
         configuration.setDebugServerWaitStrategy(getDebugServerWaitStrategy());
         configuration.setConnectTimeout(getConnectTimeout());
         configuration.setDebugServerReadyPattern(getDebugServerReadyPattern());

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/options/EnvironmentVariablesDataConfigurable.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/configurations/options/EnvironmentVariablesDataConfigurable.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.configurations.options;
+
+import com.intellij.execution.configuration.EnvironmentVariablesData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface to be implemented by classes that are configurable with a {@link com.intellij.execution.configuration.EnvironmentVariablesData} option.
+ * This interface provides methods to get and set the environment variables data associated with the object.
+ */
+public interface EnvironmentVariablesDataConfigurable {
+
+    /**
+     * Gets the environment variables data associated with this configuration.
+     *
+     * @return the environment variables data as a String, or null.
+     */
+    @NotNull
+    EnvironmentVariablesData getEnvData();
+
+    /**
+     * Sets the environment variables data associated with this configuration.
+     *
+     * @param envData the environment variables data to set, or null.
+     */
+    void setEnvData(@NotNull EnvironmentVariablesData envData);
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DefaultDebugAdapterDescriptor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DefaultDebugAdapterDescriptor.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.dap.descriptors;
 
 import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RunConfigurationOptions;
 import com.intellij.execution.process.ProcessHandler;
@@ -22,6 +23,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.dap.DebugMode;
 import com.redhat.devtools.lsp4ij.dap.client.LaunchUtils;
 import com.redhat.devtools.lsp4ij.dap.configurations.DAPRunConfigurationOptions;
+import com.redhat.devtools.lsp4ij.dap.configurations.options.EnvironmentVariablesDataConfigurable;
 import com.redhat.devtools.lsp4ij.dap.configurations.options.FileOptionConfigurable;
 import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
 import com.redhat.devtools.lsp4ij.installation.CommandLineUpdater;
@@ -84,11 +86,24 @@ public class DefaultDebugAdapterDescriptor extends DebugAdapterDescriptor {
                     command = userDefinedServer.getCommandLine();
                 }
             }
-            // TODO : store env configuration in the options
+            // Environment variables
             Map<String, String> userEnvironmentVariables = new HashMap<>();
             boolean includeSystemEnvironmentVariables = true;
+            var envData = getEnvData();
+            if (envData != null) {
+                userEnvironmentVariables.putAll(envData.getEnvs());
+                includeSystemEnvironmentVariables = envData.isPassParentEnvs();
+            }
+
             String resolvedCommandLine = resolveCommandLine(command, environment.getProject());
             return createStartServerCommandLine(resolvedCommandLine, userEnvironmentVariables, includeSystemEnvironmentVariables);
+        }
+        return null;
+    }
+
+    protected @Nullable EnvironmentVariablesData getEnvData() {
+        if (environment.getRunProfile() instanceof EnvironmentVariablesDataConfigurable runConfiguration) {
+            return runConfiguration.getEnvData();
         }
         return null;
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/templates/DAPTemplateDeserializer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/templates/DAPTemplateDeserializer.java
@@ -12,8 +12,11 @@ package com.redhat.devtools.lsp4ij.dap.descriptors.templates;
 
 import com.google.common.reflect.TypeToken;
 import com.google.gson.*;
+import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.redhat.devtools.lsp4ij.templates.ServerTemplateJsonDeserializer;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.lang.reflect.Type;
 import java.util.Map;
 
@@ -45,6 +48,7 @@ public class DAPTemplateDeserializer extends ServerTemplateJsonDeserializer<DAPT
                 Map<String, String> programArgsMap = gson.fromJson(programArgs, mapType);
                 dapTemplate.setProgramArgs(programArgsMap);
             }
+            dapTemplate.setEnvData(deserializeEnvData(jsonObject));
         }
 
         JsonElement connectTimeout = jsonObject.get(CONNECT_TIMEOUT_JSON_PROPERTY);

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/NewDebugAdapterServerDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/settings/ui/NewDebugAdapterServerDialog.java
@@ -108,6 +108,7 @@ public class NewDebugAdapterServerDialog extends DialogWrapper {
         // Update command
         String command = getCommandLine(template);
         this.debugAdapterServerPanel.setCommandLine(command);
+        this.debugAdapterServerPanel.setEnvData(template.getEnvData());
 
         // Update wait for trace
         this.debugAdapterServerPanel.getDebugServerWaitStrategyPanel().update(null,

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplateDeserializer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplateDeserializer.java
@@ -43,6 +43,7 @@ public class LanguageServerTemplateDeserializer extends ServerTemplateJsonDeseri
             Map<String, String> programArgsMap = gson.fromJson(programArgs, mapType);
             languageServerTemplate.setProgramArgs(programArgsMap);
         }
+        languageServerTemplate.setEnvData(deserializeEnvData(jsonObject));
 
         boolean expandConfiguration = JSONUtils.getBoolean(jsonObject, EXPAND_CONFIGURATION_JSON_PROPERTY);
         languageServerTemplate.setExpandConfiguration(expandConfiguration);

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/NewLanguageServerDialog.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/ui/NewLanguageServerDialog.java
@@ -213,6 +213,7 @@ public class NewLanguageServerDialog extends DialogWrapper {
         // Update command
         String command = getCommandLine(template);
         languageServerPanel.setCommandLine(command);
+        languageServerPanel.setEnvData(template.getEnvData());
 
         // Update mappings
         var mappingsPanel = this.languageServerPanel.getMappingsPanel();

--- a/src/main/java/com/redhat/devtools/lsp4ij/templates/ServerTemplate.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/templates/ServerTemplate.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.templates;
 
+import com.intellij.execution.configuration.EnvironmentVariablesData;
 import com.intellij.lang.Language;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
@@ -52,6 +53,11 @@ public abstract class ServerTemplate {
     public static final String URL_JSON_PROPERTY = "url";
     public static final String DEFAULT_JSON_PROPERTY = "default";
 
+    // Env
+    public static final String ENV_JSON_PROPERTY = "env";
+    public static final String ENV_INCLUDE_SYSTEM_JSON_PROPERTY = "includeSystemEnvironmentVariables";
+    public static final String ENV_VARIABLES_JSON_PROPERTY = "variables";
+
     // File mappings
     public static final String LANGUAGE_ID_JSON_PROPERTY = "languageId";
     public static final String FILE_TYPE_JSON_PROPERTY = "fileType";
@@ -64,6 +70,7 @@ public abstract class ServerTemplate {
     private String name;
     private @Nullable String url;
     private Map<String /* OS */, String /* program args */> programArgs;
+    private @Nullable EnvironmentVariablesData envData;
 
     private List<ServerMappingSettings> fileTypeMappings;
     private List<ServerMappingSettings> languageMappings;
@@ -123,6 +130,14 @@ public abstract class ServerTemplate {
 
     public void setProgramArgs(Map<String, String> programArgs) {
         this.programArgs = programArgs;
+    }
+
+    public @Nullable EnvironmentVariablesData getEnvData() {
+        return envData;
+    }
+
+    public void setEnvData(@Nullable EnvironmentVariablesData envData) {
+        this.envData = envData;
     }
 
     // ---------- Commons Methods for file mappings

--- a/src/main/resources/templates/dap/buildx-dockerfile/template.json
+++ b/src/main/resources/templates/dap/buildx-dockerfile/template.json
@@ -4,6 +4,12 @@
   "launch": {
     "default": "docker buildx dap build"
   },
+  "env": {
+    "includeSystemEnvironmentVariables": true,
+    "variables": {
+      "BUILDX_EXPERIMENTAL": "1"
+    }
+  },
   "fileTypeMappings": [
     {
       "fileType": {


### PR DESCRIPTION
fix: Environment variables of a DAP launch config are ignored

Fixes #1298