### PR TITLE
feat: disable spell checking in DAP Disassembly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,11 @@ dependencies {
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
         plugins(properties("platformPlugins").map { it.split(',') })
 
+        if (ideaVersionInt >= 252) {
+            // Since 2025.2, JetBrains moved spellchecker in a new "intellij.spellchecker" module
+            bundledModule("intellij.spellchecker")
+        }
+
         pluginVerifier()
         zipSigner()
         testFramework(TestFrameworkType.Platform)

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DAPFile.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DAPFile.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.dap.client.files;
 
+import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -59,8 +60,9 @@ public abstract class DAPFile extends LightVirtualFile {
 
     public DAPFile(@NlsSafe String name,
                    @NotNull String path,
+                   @NotNull FileType fileType,
                    @NotNull Project project) {
-        super(name, DisassemblyFileType.INSTANCE, "", LocalTimeCounter.currentTime());
+        super(name, fileType, "", LocalTimeCounter.currentTime());
         this.project = project;
         this.path = path;
         this.url = DAPFileSystem.PROTOCOL + ":///" + getPath();

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/SourceReferenceFile.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/SourceReferenceFile.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.dap.client.files;
 
+import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,6 +38,6 @@ public class SourceReferenceFile extends DAPFile {
     public SourceReferenceFile(String name,
                                @NotNull String path,
                                @NotNull Project project) {
-        super(name, path, project);
+        super(name, path, PlainTextFileType.INSTANCE, project);
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFile.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFile.java
@@ -74,7 +74,7 @@ public class DisassemblyFile extends DAPFile {
     public DisassemblyFile(@NotNull String configName,
                            @NotNull String path,
                            @NotNull Project project) {
-        super("Disassembly (" + configName + ")", path, project);
+        super("Disassembly (" + configName + ")", path, DisassemblyFileType.INSTANCE, project);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFileType.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFileType.java
@@ -11,10 +11,15 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.dap.disassembly;
 
-import com.intellij.openapi.fileTypes.ex.FakeFileType;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
 
 /**
  * A special IntelliJ file type used to represent a disassembly view
@@ -28,12 +33,16 @@ import org.jetbrains.annotations.NotNull;
  *     <li>Is specifically associated with instances of {@link DisassemblyFile}.</li>
  * </ul>
  */
-public class DisassemblyFileType extends FakeFileType {
+public class DisassemblyFileType extends LanguageFileType {
 
     /**
      * Singleton instance of the disassembly file type.
      */
     public static final DisassemblyFileType INSTANCE = new DisassemblyFileType();
+
+    protected DisassemblyFileType() {
+        super(DisassemblyLanguage.INSTANCE);
+    }
 
     @Override
     public @NotNull String getName() {
@@ -43,6 +52,11 @@ public class DisassemblyFileType extends FakeFileType {
     @Override
     public @NotNull String getDefaultExtension() {
         return "";
+    }
+
+    @Override
+    public @Nullable Icon getIcon() {
+        return AllIcons.FileTypes.Archive;
     }
 
     /**
@@ -67,12 +81,12 @@ public class DisassemblyFileType extends FakeFileType {
     }
 
     @Override
-    public boolean isMyFileType(@NotNull VirtualFile file) {
-        return file instanceof DisassemblyFile;
+    public boolean isReadOnly() {
+        return true;
     }
 
     @Override
-    public boolean isBinary() {
-        return false;
+    public @NonNls @Nullable String getCharset(@NotNull VirtualFile file, byte @NotNull [] content) {
+        return super.getCharset(file, content);
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyLanguage.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyLanguage.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly;
+
+import com.intellij.lang.Language;
+
+/**
+ * Disassembly language.
+ */
+public class DisassemblyLanguage extends Language {
+    public static final DisassemblyLanguage INSTANCE = new DisassemblyLanguage();
+
+    private DisassemblyLanguage() {
+        super("Disassembly");
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblySpellcheckingStrategy.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblySpellcheckingStrategy.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.spellchecker.tokenizer.SpellcheckingStrategy;
+import com.intellij.spellchecker.tokenizer.Tokenizer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Disassembly spell checking strategy.
+ */
+public class DisassemblySpellcheckingStrategy extends SpellcheckingStrategy {
+
+    @Override
+    public @NotNull Tokenizer<?> getTokenizer(@NotNull PsiElement element) {
+        return EMPTY_TOKENIZER;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyFileViewProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyFileViewProvider.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly.psi;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.SingleRootFileViewProvider;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Disassembly file view provider.
+ */
+public class DisassemblyFileViewProvider extends SingleRootFileViewProvider {
+
+    public DisassemblyFileViewProvider(@NotNull PsiManager manager,
+                                       @NotNull VirtualFile file) {
+        super(manager, file);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyFileViewProviderFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyFileViewProviderFactory.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly.psi;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.FileViewProviderFactory;
+import com.intellij.psi.PsiManager;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Disassembly file view provider factory.
+ */
+public class DisassemblyFileViewProviderFactory implements FileViewProviderFactory  {
+
+    @Override
+    public @NotNull FileViewProvider createFileViewProvider(@NotNull VirtualFile file,
+                                                            Language language,
+                                                            @NotNull PsiManager manager,
+                                                            boolean eventSystemEnabled) {
+        return new DisassemblyFileViewProvider(manager, file);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyParser.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyParser.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly.psi;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.PsiBuilder;
+import com.intellij.lang.PsiParser;
+import com.intellij.psi.tree.IElementType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Disassembly Psi parser.
+ */
+class DisassemblyParser implements PsiParser {
+  @NotNull
+  @Override
+  public ASTNode parse(@NotNull IElementType root, PsiBuilder builder) {
+    PsiBuilder.Marker mark = builder.mark();
+    while (!builder.eof()) {
+      builder.advanceLexer();
+    }
+    mark.done(root);
+    return builder.getTreeBuilt();
+  }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyParserDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyParserDefinition.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly.psi;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.ParserDefinition;
+import com.intellij.lang.PsiParser;
+import com.intellij.lexer.EmptyLexer;
+import com.intellij.lexer.Lexer;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IFileElementType;
+import com.intellij.psi.tree.TokenSet;
+import com.redhat.devtools.lsp4ij.dap.disassembly.DisassemblyLanguage;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Disassembly parser definition.
+ */
+public class DisassemblyParserDefinition implements ParserDefinition {
+
+    private final static IFileElementType FILE_ELEMENT_TYPE = new IFileElementType("Disassembly", DisassemblyLanguage.INSTANCE);
+
+    @NotNull
+    @Override
+    public Lexer createLexer(Project project) {
+        return new EmptyLexer();
+    }
+
+    @Override
+    public @NotNull PsiParser createParser(Project project) {
+        return new DisassemblyParser();
+    }
+
+    @Override
+    public @NotNull IFileElementType getFileNodeType() {
+        return FILE_ELEMENT_TYPE;
+    }
+
+    @NotNull
+    @Override
+    public TokenSet getCommentTokens() {
+        return TokenSet.EMPTY;
+    }
+
+    @NotNull
+    @Override
+    public TokenSet getStringLiteralElements() {
+        return TokenSet.EMPTY;
+    }
+
+    @NotNull
+    @Override
+    public PsiElement createElement(ASTNode node) {
+        return new DisassemblyPsiElement(node.getElementType());
+    }
+
+    @Override
+    public @NotNull SpaceRequirements spaceExistenceTypeBetweenTokens(ASTNode left, ASTNode right) {
+        return SpaceRequirements.MAY;
+    }
+
+    @Override
+    public @NotNull PsiFile createFile(@NotNull FileViewProvider viewProvider) {
+        return new PsiDisassemblyFile(viewProvider);
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyPsiElement.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/DisassemblyPsiElement.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly.psi;
+
+import com.intellij.psi.impl.source.tree.CompositePsiElement;
+import com.intellij.psi.tree.IElementType;
+
+/**
+ * Disassembly Psi element.
+ */
+class DisassemblyPsiElement extends CompositePsiElement {
+  protected DisassemblyPsiElement(IElementType type) {
+    super(type);
+  }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/PsiDisassemblyFile.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/psi/PsiDisassemblyFile.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly.psi;
+
+import com.intellij.extapi.psi.PsiFileBase;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.psi.FileViewProvider;
+import com.redhat.devtools.lsp4ij.dap.disassembly.DisassemblyFileType;
+import com.redhat.devtools.lsp4ij.dap.disassembly.DisassemblyLanguage;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Disassembly Psi file.
+ */
+public class PsiDisassemblyFile extends PsiFileBase {
+
+    protected PsiDisassemblyFile(@NotNull FileViewProvider viewProvider) {
+        super(viewProvider, DisassemblyLanguage.INSTANCE);
+    }
+
+    @Override
+    public @NotNull FileType getFileType() {
+        return DisassemblyFileType.INSTANCE;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1036,10 +1036,21 @@
         <!-- Disassembly support-->
         <fileType
                 name="Disassembly"
+                language="Disassembly"
+                fieldName="INSTANCE"
                 implementationClass="com.redhat.devtools.lsp4ij.dap.disassembly.DisassemblyFileType"/>
         <fileEditorProvider
                 id="lsp.disassembly"
                 implementation="com.redhat.devtools.lsp4ij.dap.disassembly.DisassemblyFileEditorProvider"/>
+        <lang.fileViewProviderFactory
+                language="Disassembly"
+                implementationClass="com.redhat.devtools.lsp4ij.dap.disassembly.psi.DisassemblyFileViewProviderFactory"/>
+        <lang.parserDefinition
+                language="Disassembly"
+                implementationClass="com.redhat.devtools.lsp4ij.dap.disassembly.psi.DisassemblyParserDefinition"/>
+        <spellchecker.support
+                language="Disassembly"
+                implementationClass="com.redhat.devtools.lsp4ij.dap.disassembly.DisassemblySpellcheckingStrategy"/>
         <xdebugger.breakpointType
                 implementation="com.redhat.devtools.lsp4ij.dap.disassembly.breakpoints.DisassemblyBreakpointType"/>
     </extensions>


### PR DESCRIPTION
feat: disable spell checking in DAP Disassembly

This PR removes spell checking warning (displayed in green):

<img width="1755" height="741" alt="image" src="https://github.com/user-attachments/assets/c506ffc6-7684-415e-a112-f3d6eca48dc9" />


//cc @fbricon 