### PR TITLE
feat: Support for disassembly syntax coloration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Here are some projects that use LSP4IJ:
  * [intellij-cangjie](https://github.com/lin-qingying/intellij-cangjie)
 ## Requirements
 
-* Intellij IDEA 2023.3 or more recent (we **try** to support the last 4 major IDEA releases)
+* Intellij IDEA 2024.2 or more recent (we **try** to support the last 4 major IDEA releases)
 * Java JDK (or JRE) 17 or more recent
 
 ## Contributing

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,12 @@ pluginRepositoryUrl=https://github.com/redhat-developer/lsp4ij
 pluginVersion=0.17.1-SNAPSHOT
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild=233
+pluginSinceBuild=242
 #pluginUntilBuild=243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
-platformVersion=2023.3
+platformVersion=2024.2
 platformBundledPlugins=org.jetbrains.plugins.textmate,com.intellij.properties,org.jetbrains.plugins.terminal
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFile.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFile.java
@@ -14,6 +14,7 @@ package com.redhat.devtools.lsp4ij.dap.disassembly;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.util.SimpleModificationTracker;
 import com.redhat.devtools.lsp4ij.dap.client.DAPClient;
 import com.redhat.devtools.lsp4ij.dap.client.files.DAPFile;
@@ -63,6 +64,8 @@ public class DisassemblyFile extends DAPFile {
      * All disassembled instructions loaded so far.
      */
     private final List<DisassembledInstructionEntry> disassembledInstructions = new ArrayList<>();
+    private @NotNull
+    @NlsSafe String presentableName;
 
     /**
      * Creates a new DisassemblyFile for the given configuration and project.
@@ -74,7 +77,13 @@ public class DisassemblyFile extends DAPFile {
     public DisassemblyFile(@NotNull String configName,
                            @NotNull String path,
                            @NotNull Project project) {
-        super("Disassembly (" + configName + ")", path, DisassemblyFileType.INSTANCE, project);
+        super("Disassembly (" + configName + ").disasm", path, DisassemblyFileType.INSTANCE, project);
+        presentableName = "Disassembly (" + configName + ")";
+    }
+
+    @Override
+    public @NotNull @NlsSafe String getPresentableName() {
+        return presentableName;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyTextMateBundleProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyTextMateBundleProvider.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ * Angelo Zerr - implementation of DAP disassembly editor support
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.disassembly;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.extensions.PluginId;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.textmate.api.TextMateBundleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * TextMate bundle provider for Disassembly file.
+ */
+public class DisassemblyTextMateBundleProvider implements TextMateBundleProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DisassemblyTextMateBundleProvider.class);
+
+    private static final String RESOURCE_PATH = "/textmate";
+    private static final String BUNDLE_NAME = "disasm";
+
+    @NotNull
+    @Override
+    public List<PluginBundle> getBundles() {
+        Path bundlePath = getBundlePath();
+        PluginBundle pluginBundle = new PluginBundle(BUNDLE_NAME, bundlePath);
+        return List.of(pluginBundle);
+    }
+
+    private Path getBundlePath() {
+        try {
+            IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId("com.redhat.devtools.lsp4ij"));
+            String version = plugin.getVersion();
+            String path = plugin.getPluginPath() + "/bundles/" + version;
+            return copyResourceDirectory(path, List.of("package.json", "syntaxes/disassembly.json"));
+        } catch (IOException ex) {
+            LOGGER.error("Bundles error: " + ex);
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    private Path copyResourceDirectory(@NotNull String target, List<String> fileNames) throws IOException {
+        Path targetPath = Paths.get(target);
+        if (Files.notExists(targetPath)) {
+            Files.createDirectories(targetPath);
+        }
+        for (String fileName: fileNames) {
+            Path pathToCopyFile = new File(target + "/" + fileName).toPath();
+            if (Files.notExists(pathToCopyFile)) {
+                var dir = pathToCopyFile.getParent();
+                if (Files.notExists(dir)) {
+                    Files.createDirectories(dir);
+                }
+                Files.copy(
+                        Objects.requireNonNull(DisassemblyTextMateBundleProvider.class.getResourceAsStream(RESOURCE_PATH + "/" + fileName)),
+                        pathToCopyFile);
+            }
+        }
+        return targetPath;
+    }
+}

--- a/src/main/resources/META-INF/plugin-textmate.xml
+++ b/src/main/resources/META-INF/plugin-textmate.xml
@@ -1,3 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <idea-plugin>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <textmate.bundleProvider implementation="com.redhat.devtools.lsp4ij.dap.disassembly.DisassemblyTextMateBundleProvider"/>
+        <!--
+         We have to explicitly register textmate as the highlight provider because of a bug in how jetbrains textmate
+         works (and it's incredibly poorly documented). See jetbrains-plugin-fss for prior art
+         https://github.com/qligier/jetbrains-plugin-fss/blob/905622be4058fda8014f874af4acae46f24cc556/src/main/resources/META-INF/plugin.xml#L51-L53
+       -->
+        <editorHighlighterProvider
+                filetype="Disassembly"
+                implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateEditorHighlighterProvider"/>
+        <lang.syntaxHighlighterFactory
+                language="Disassembly"
+                implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateSyntaxHighlighterFactory"/>
+    </extensions>
+
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -279,7 +279,7 @@
     <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>
     <depends optional="true" config-file="plugin-terminal.xml">org.jetbrains.plugins.terminal</depends>
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="233.*"/>
+    <idea-version since-build="242.*"/>
 
     <!-- Server Installer support -->
     <extensionPoints>

--- a/src/main/resources/textmate/package.json
+++ b/src/main/resources/textmate/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "vscode-lldb",
+  "displayName": "CodeLLDB",
+  "version": "@VERSION@",
+  "publisher": "vadimcn",
+  "description": "A native debugger powered by LLDB.  Debug C++, Rust and other compiled languages.",
+  "license": "MIT",
+  "author": {
+    "name": "vadimcn"
+  },
+  "contributes": {
+    "languages": [
+      {
+        "id": "lldb.disassembly",
+        "aliases": [
+          "Disassembly"
+        ],
+        "extensions": [
+          ".disasm"
+        ]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "lldb.disassembly",
+        "scopeName": "source.disassembly",
+        "path": "./syntaxes/disassembly.json"
+      }
+    ]
+  }
+}

--- a/src/main/resources/textmate/syntaxes/disassembly.json
+++ b/src/main/resources/textmate/syntaxes/disassembly.json
@@ -1,0 +1,32 @@
+
+{
+    "name": "LLDB Disassembly",
+    "scopeName": "source.disassembly",
+    "uuid": "db74b3e8-fa2c-4b4e-b973-1ecc54d45ed0",
+    "patterns": [
+        {
+            "comment": "Address, bytes and opcode",
+            "name": "meta.instruction",
+            "match": "^([A-Za-z0-9]+):\\s([A-Z0-9]{2}\\s)+>?\\s+(\\w+)",
+            "captures": {
+                "1": { "name": "constant.numeric" },
+                "3": { "name": "keyword.opcode" }
+            }
+        },
+        {
+            "comment": "Numeric constant",
+            "name": "constant.numeric",
+            "match": "(\\$|\\b)((0x)|[0-9])[A-Za-z0-9]+\\b"
+        },
+        {
+            "comment": "Register",
+            "name": "variable.language",
+            "match": "%[A-Za-z][A-Za-z0-9]*"
+        },
+        {
+            "comment": "End of line comment",
+            "name": "comment.line.semicolon",
+            "match": ";.*$"
+        }
+    ]
+}


### PR DESCRIPTION
This PR supports Disassembly file syntax coloration with TextMate by using TextMateBundleProvider API available since 2024.2. 
The PR upgrade the IntelliJ version `from 2023.2 to 2024.2`.

Here the result:

<img width="1414" height="786" alt="image" src="https://github.com/user-attachments/assets/05d023ad-b69f-4116-928b-b4d2beabac20" />

<img width="1398" height="767" alt="image" src="https://github.com/user-attachments/assets/38930bcc-324e-47d0-a7c1-39126cf5b5ff" />
