### PR TITLE
Update Exe name for Scala Language Server

### DIFF
--- a/src/main/resources/templates/lsp/metals/installer.json
+++ b/src/main/resources/templates/lsp/metals/installer.json
@@ -41,7 +41,7 @@
           "name": "Configure Scala Language Server command",
           "command": {
             "windows": "${workingDir}/metals.bat",
-            "default": "${workingDir}/metal"
+            "default": "${workingDir}/metals"
           },
           "update": true
         }


### PR DESCRIPTION
the old name is a typo