### PR TITLE
fix: java.lang.IllegalStateException: End size 4 is less than fixed size 5

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -225,7 +225,8 @@ public class LanguageServerWrapper implements Disposable {
      */
     private synchronized void stopAndRefreshEditorFeature(boolean refreshEditorFeature, boolean disable) {
         // Collect opened files before stopping the language server
-        List<VirtualFile> openedFiles = refreshEditorFeature ? openedDocuments.values()
+        List<VirtualFile> openedFiles = refreshEditorFeature ?
+                new ArrayList<>(openedDocuments.values())
                 .stream()
                 .map(OpenedDocument::getFile)
                 .toList() : Collections.emptyList();


### PR DESCRIPTION
fix: java.lang.IllegalStateException: End size 4 is less than fixed size 5