### PR TITLE
fix: package.json tooltip shows npm lib name instead of npm lib version  (installed, latest)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenDocumentationProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/viewProvider/LSPSemanticTokenDocumentationProvider.java
@@ -92,7 +92,11 @@ public class LSPSemanticTokenDocumentationProvider extends AbstractDocumentation
             }
         }
 
-        return getFallbackDocumentation(sourceElement, targetElement);
+        // Don't return result of getFallbackDocumentation because LSPSemanticTokenDocumentationProvider could be
+        // process before some other provider which will generate a proper documentation
+        // see https://github.com/redhat-developer/lsp4ij/issues/1240
+        // return getFallbackDocumentation(sourceElement, targetElement);
+        return null;
     }
 
     @Nullable

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -443,7 +443,6 @@
                 implementation="com.redhat.devtools.lsp4ij.features.documentLink.LSPDocumentLinkGotoDeclarationHandler"/>
         <lang.documentationProvider
                 language=""
-                order="last"
                 implementationClass="com.redhat.devtools.lsp4ij.features.documentLink.LSPDocumentLinkDocumentationProvider"/>
 
         <!-- LSP textDocument/documentSymbol request support -->
@@ -618,7 +617,6 @@
                 implementationClass="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenPsiElementManipulator"/>
         <lang.documentationProvider
                 language=""
-                order="last"
                 implementationClass="com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokenDocumentationProvider"/>
 
         <!-- We cannot register one for plain text abstract file types, so we have to do that dynamically. Do so when a project is opened. -->


### PR DESCRIPTION
fix: package.json tooltip shows npm lib name instead of npm lib version  (installed, latest)

Fix #1240