### PR TITLE
fix: NPE when server is not started and files change

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -723,6 +723,10 @@ public class LanguageServerWrapper implements Disposable {
     }
 
     public boolean isSaveSupported() {
+        if (this.serverCapabilities == null) {
+            // Language server is not started, save is not supported
+            return false;
+        }
         var saveOptions = getSyncOptions().getSave();
         return saveOptions != null && (saveOptions.isLeft() && saveOptions.getLeft()) || (saveOptions.isRight() && saveOptions.getRight() != null);
     }


### PR DESCRIPTION
Prevent from the following NPE:

```
2025-11-03 15:53:24,008 [  25760] SEVERE - #c.i.o.v.n.AsyncEventSupport - Cannot invoke "org.eclipse.lsp4j.ServerCapabilities.getTextDocumentSync()" because "this.serverCapabilities" is null
java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.ServerCapabilities.getTextDocumentSync()" because "this.serverCapabilities" is null
	at com.redhat.devtools.lsp4ij.LanguageServerWrapper.createSyncOptions(LanguageServerWrapper.java:732)
	at com.redhat.devtools.lsp4ij.LanguageServerWrapper.getSyncOptions(LanguageServerWrapper.java:721)
	at com.redhat.devtools.lsp4ij.LanguageServerWrapper.isSaveSupported(LanguageServerWrapper.java:726)
	at com.redhat.devtools.lsp4ij.features.files.AbstractLSPFileListener.getSupportedEvents(AbstractLSPFileListener.java:111)
	at com.redhat.devtools.lsp4ij.features.files.AbstractLSPFileListener.prepareChange(AbstractLSPFileListener.java:80)
	at com.intellij.openapi.vfs.newvfs.AsyncEventSupport.lambda$runAsyncListeners$0(AsyncEventSupport.java:90)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction$lambda$2(AnyThreadWriteThreadingSupport.kt:217)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction(AnyThreadWriteThreadingSupport.kt:228)

```