### PR TITLE
fix: tab size (Code Style -> Other File Types) does not take effect on formating code using html language server

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPFormattingFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPFormattingFeature.java
@@ -318,7 +318,7 @@ public class LSPFormattingFeature extends AbstractLSPDocumentFeature {
      */
     public @Nullable Integer getTabSize(@NotNull PsiFile file,
                                         @Nullable Editor editor) {
-        return 4; //editor != null ? LSPIJUtils.getTabSize(editor) : null;
+        return editor != null ? LSPIJUtils.getTabSize(editor) : null;
     }
 
     /**


### PR DESCRIPTION
fix: tab size (Code Style -> Other File Types) does not take effect on formating code using html language server

Fixes #1368