### PR TITLE
fix: use isExistingFormatterOverrideable to know which language server must be used to format.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPFormattingFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPFormattingFeature.java
@@ -71,7 +71,7 @@ public class LSPFormattingFeature extends AbstractLSPDocumentFeature {
      * @return true to use the language server for code formatting and false to use plugin-provided/built-in formatters.
      * @apiNote This method will only be called with files that contain a language supported by this language server.
      */
-    protected boolean isExistingFormatterOverrideable(@NotNull PsiFile file) {
+    public boolean isExistingFormatterOverrideable(@NotNull PsiFile file) {
         return false;
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/ClientConfigurationSettings.java
@@ -171,6 +171,8 @@ public class ClientConfigurationSettings {
      */
     public static class ClientConfigurationFormatSettings {
 
+        public @Nullable Boolean enabled;
+
         public @Nullable Integer tabSize;
 
         public @Nullable Boolean insertSpaces;

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedFormattingFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/launching/UserDefinedFormattingFeature.java
@@ -36,6 +36,12 @@ public class UserDefinedFormattingFeature extends LSPFormattingFeature {
     }
 
     @Override
+    public boolean isEnabled(@NotNull PsiFile file) {
+        var format = getClientConfigurationFormatSettings();
+        return format != null && format.enabled != null ? format.enabled : super.isEnabled(file);
+    }
+
+    @Override
     public @Nullable Integer getTabSize(@NotNull PsiFile file, @Nullable Editor editor) {
         var format = getClientConfigurationFormatSettings();
         return format != null && format.tabSize != null ? format.tabSize : super.getTabSize(file, editor);
@@ -48,7 +54,7 @@ public class UserDefinedFormattingFeature extends LSPFormattingFeature {
     }
 
     @Override
-    protected boolean isExistingFormatterOverrideable(@NotNull PsiFile file) {
+    public boolean isExistingFormatterOverrideable(@NotNull PsiFile file) {
         var format = getClientConfigurationFormatSettings();
         return format != null && format.existingFormatterOverrideable != null ? format.existingFormatterOverrideable : super.isExistingFormatterOverrideable(file);
     }

--- a/src/main/resources/jsonSchema/clientSettings.schema.json
+++ b/src/main/resources/jsonSchema/clientSettings.schema.json
@@ -122,6 +122,11 @@
       "title": "Client-side formatter configuration",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Server-side formatting enabled",
+          "description": "Server-side formatting enabled"
+        },
         "tabSize": {
           "type": "integer",
           "title": "Size of a tab in spaces.",
@@ -135,7 +140,7 @@
         "existingFormatterOverrideable": {
           "type": "boolean",
           "title": "Returns true to use the language server for code formatting and false to use plugin-provided/built-in formatters.",
-          "description": "Prefer spaces over tabs."
+          "description": "Returns true to use the language server for code formatting and false to use plugin-provided/built-in formatters."
         },
         "onTypeFormatting": {
           "type": "object",


### PR DESCRIPTION
fix: use isExistingFormatterOverrideable to know which language server must be used to format.

See https://github.com/redhat-developer/lsp4ij/issues/1372#issuecomment-3552227964