### PR TITLE
docs: Add intellij-lumos to 'Who is using LSP4IJ' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Here are some projects that use LSP4IJ:
  * [Intellij KCL](https://github.com/kcl-lang/intellij-kcl)
  * [Ruff for PyCharm](https://github.com/koxudaxi/ruff-pycharm-plugin)
  * [Intellij Gleam](https://github.com/themartdev/intellij-gleam)
+ * [intellij-lumos](https://github.com/getlumos/intellij-lumos)
  * [Liberty Tools for IntelliJ](https://github.com/OpenLiberty/liberty-tools-intellij)
  * [Vespa Schema Language Support](https://github.com/vespa-engine/vespa/tree/master/integration/schema-language-server/clients/intellij)
  * [Jimmer DTO LSP](https://github.com/Enaium/jimmer-dto-lsp)


### PR DESCRIPTION
## Summary

This PR adds **intellij-lumos** to the list of projects using LSP4IJ.

## About intellij-lumos

**intellij-lumos** is an IntelliJ IDEA and Rust Rover plugin that provides LSP integration for the LUMOS schema language.

- **Project**: https://github.com/getlumos/intellij-lumos
- **LUMOS Website**: https://lumos-lang.org
- **What is LUMOS**: A type-safe schema language for Solana development that bridges TypeScript ↔ Rust with guaranteed Borsh serialization compatibility

## Integration Details

The plugin uses LSP4IJ to connect with the `lumos-lsp` server, providing:
- Syntax diagnostics
- Auto-completion
- Hover documentation
- Go to definition
- Symbol references

## Additional Context

This PR was requested in https://github.com/getlumos/intellij-lumos/issues/12 by the lsp4ij team.

Thank you for building LSP4IJ - it made our IntelliJ integration straightforward! 🙏