### PR TITLE
fix: "goto > Declaration or Usages" to show references when ⌘B on definitions

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPReferenceCollector.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPReferenceCollector.java
@@ -1,0 +1,48 @@
+package com.redhat.devtools.lsp4ij.features.references;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.lsp4ij.LSPFileSupport;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.waitUntilDone;
+
+public final class LSPReferenceCollector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LSPReferenceCollector.class);
+
+    public static List<LocationData> collect(@NotNull PsiFile psiFile,
+                                             @NotNull Document document,
+                                             int offset) {
+        LSPReferenceSupport referenceSupport = LSPFileSupport.getSupport(psiFile).getReferenceSupport();
+        var params = new LSPReferenceParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
+        CompletableFuture<List<LocationData>> referencesFuture = referenceSupport.getReferences(params);
+        try {
+            waitUntilDone(referencesFuture, psiFile);
+        } catch (CancellationException ex) {
+            referenceSupport.cancel();
+        } catch (ExecutionException e) {
+            LOGGER.error("Error while consuming LSP 'textDocument/references' request", e);
+        }
+
+        if (isDoneNormally(referencesFuture)) {
+            List<LocationData> locations = referencesFuture.getNow(null);
+            if (locations != null) {
+                return locations;
+            }
+        }
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
IntelliJ's "Go to > Declaration or Usages" (⌘B) shortcut is a commonly used shortcut that, in general, should display usages when triggered from the declaration itself.

In the LSP handler, we only call `textDocument/definition`, so pressing `⌘B` on a declaration has no effect (tested with LuaLS).

A few things to note:
- As discussed in #531, this change tentatively aims to instruct `LSPGotoDeclarationHandler` to fall back to `textDocument/references`: if the definition we receive overlaps the caret, we reuse the same reference list and popup that the "Go to → LSP References" command uses. 
- Ctrl-hover still just underlines the symbol, but a click now opens the rich usages panel instead of silently failing.
- To avoid duplicating code, we introduced a tiny `LSPReferenceCollector` helper and pointed both the standalone reference action and the new fallback at it.

> PS: I'm not an expert in LSP4IJ, so this is a tentative implementation. I tested it, and it works, but my main goal here is to restart the conversation on this issue and work out a solution, as this is a much-desired feature.