### PR TITLE
docs: add rovo to projects that use lsp4ij

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Here are some projects that use LSP4IJ:
  * [intellij-cangjie](https://github.com/lin-qingying/intellij-cangjie)
  * [poryscript-idea](https://github.com/okafke/poryscript-idea)
  * [t-ruby](https://github.com/type-ruby/t-ruby)
+ * [Rovo LSP - IntelliJ](https://github.com/arthurdw/rovo)
+
 ## Requirements
 
 * Intellij IDEA 2024.2 or more recent (we **try** to support the last 4 major IDEA releases)


### PR DESCRIPTION
Closes https://github.com/Arthurdw/rovo/issues/13

Rovo uses lsp4ij to have the extension communicate with the Rovo LSP.