### PR TITLE
fix: Equality must not contain null but got: [null, CODE_VISION, false]

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/editor/EditorFeatureManager.java
@@ -140,7 +140,7 @@ public class EditorFeatureManager implements Disposable {
                     }
                     return new RefreshEditorFeatureContext(pf, runnables, editors);
                 })
-                .coalesceBy(file, featureType, clearLSPCache)
+                .coalesceBy(file != null ? file : psiFile, featureType, clearLSPCache)
                 .finishOnUiThread(ModalityState.any(), context -> {
                     if (context == null) {
                         // No opened editors associated from any language servers.


### PR DESCRIPTION
fix: Equality must not contain null but got: [null, CODE_VISION, false]

Fixes #1405