### PR TITLE
fix: resolve DAP stack frame source off EDT

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/DAPStackFrame.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/DAPStackFrame.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.Nullable;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.redhat.devtools.lsp4ij.dap.DAPIJUtils.getValidFilePath;
 
@@ -48,7 +49,10 @@ public class DAPStackFrame extends XStackFrame {
 
     private final @NotNull StackFrame stackFrame;
     private final @NotNull DAPClient client;
-    private @Nullable XSourcePosition sourcePosition;
+    private volatile @Nullable XSourcePosition sourcePosition;
+    // Track async resolution to avoid repeating EDT VFS work.
+    private final AtomicBoolean sourcePositionResolved = new AtomicBoolean(false);
+    private final AtomicBoolean sourcePositionScheduled = new AtomicBoolean(false);
     private @Nullable DisassemblyDeferredSourcePosition disassemblyInstructionSourcePosition;
     private XDebuggerEvaluator evaluator;
     private CompletableFuture<DebugVariableContext> variablesContext;
@@ -80,28 +84,64 @@ public class DAPStackFrame extends XStackFrame {
     @Override
     public @Nullable XSourcePosition getSourcePosition() {
         var source = stackFrame.getSource();
-        if (sourcePosition == null && source != null) {
-            sourcePosition = doGetSourcePosition(source, stackFrame.getLine() - 1);
+        if (source != null && !sourcePositionResolved.get()) {
+            sourcePosition = resolveSourcePosition(source, stackFrame.getLine() - 1);
         }
         return sourcePosition;
     }
 
-    private @Nullable XSourcePosition doGetSourcePosition(@NotNull Source source, int line) {
+    private @Nullable XSourcePosition resolveSourcePosition(@NotNull Source source, int line) {
         int sourceReference = source.getSourceReference() != null ? source.getSourceReference() : 0;
         if (sourceReference > 0) {
-            // If the value &gt; 0 the contents of the source must be retrieved through
+            // If the value > 0 the contents of the source must be retrieved through
             // the SourceRequest (even if a path is specified).
             var file = DAPFileRegistry.getInstance().getOrCreateDAPFile(client.getConfigName(), getValidSourceName(source), client.getProject());
             if (file.shouldReload(getClient().getSessionId())) {
+                sourcePositionResolved.set(true);
                 return new DAPSourceReferencePosition(file, sourceReference, line, client);
             }
+            sourcePositionResolved.set(true);
             return XDebuggerUtil.getInstance().createPosition(file, line);
         }
 
         Path filePath = getValidFilePath(source);
         if (filePath == null) {
+            sourcePositionResolved.set(true);
             return null;
         }
+
+        // Avoid VFS lookups on EDT; resolve asynchronously and refresh the UI when ready.
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            scheduleSourcePositionResolve(filePath, line);
+            return sourcePosition;
+        }
+
+        var resolved = resolveFilePosition(filePath, line);
+        sourcePositionResolved.set(true);
+        return resolved;
+    }
+
+    private void scheduleSourcePositionResolve(@NotNull Path filePath, int line) {
+        if (!sourcePositionScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        ApplicationManager.getApplication().executeOnPooledThread(() ->
+                ApplicationManager.getApplication().runReadAction(() -> {
+                    var resolved = resolveFilePosition(filePath, line);
+                    sourcePosition = resolved;
+                    sourcePositionResolved.set(true);
+                    sourcePositionScheduled.set(false);
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        var session = getClient().getSession();
+                        if (session.isStopped()) {
+                            return;
+                        }
+                        session.rebuildViews();
+                    });
+                }));
+    }
+
+    private @Nullable XSourcePosition resolveFilePosition(@NotNull Path filePath, int line) {
         try {
             VirtualFile file = VfsUtil.findFile(filePath, true);
             return XDebuggerUtil.getInstance().createPosition(file, line);


### PR DESCRIPTION
**Title**
SlowOperations warning on EDT when rendering DAP stack frames (DAPStackFrame.getSourcePosition uses VFS lookup)

**Summary**
  When debugging with LSP4IJ DAP, the IDE logs a SlowOperations warning because DAPStackFrame.getSourcePosition() performs a synchronous VfsUtil.findFile(...) lookup on the EDT during
  frame list rendering. This is triggered by the XDebugger UI and happens even in normal debugging workflows.

**Exception**
```
  SEVERE - #c.i.u.SlowOperations - Slow operations are prohibited on EDT
  ...
  at com.intellij.openapi.vfs.VfsUtil.findFile(VfsUtil.java:202)
  at com.redhat.devtools.lsp4ij.dap.client.DAPStackFrame.doGetSourcePosition(DAPStackFrame.java:106)
  at com.redhat.devtools.lsp4ij.dap.client.DAPStackFrame.getSourcePosition(DAPStackFrame.java:84)
  ...
```

**Root cause**
  DAPStackFrame.doGetSourcePosition() calls VfsUtil.findFile(...) on the EDT when resolving file‑backed stack frames, which triggers SlowOperations warnings.

**Fix**
  I've moved the file lookup off the EDT and cache the result, refreshing the debug views once the source position is resolved. This avoids EDT slow ops while preserving behavior.

**How it’s fixed**
  - If on EDT, schedule a background read action to resolve VfsUtil.findFile(...)
  - Cache XSourcePosition once resolved
  - Refresh debug views after resolution

**Environment**
  - IntelliJ IDEA 2024.2.x
  - LSP4IJ plugin
  - Debugging via DAP

With this fix and locally installed plugin - I don't see this exception anymore
