### PR TITLE
fix: dap: avoid slow VFS refresh on EDT

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredLocalFileSourcePosition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredLocalFileSourcePosition.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.files;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.LightVirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Local file-based {@link com.intellij.xdebugger.XSourcePosition} that resolves {@link VirtualFile} off the EDT.
+ *
+ * LocalFileSystem.findFileByPath() can touch PersistentFS and triggers SlowOperations warnings on the EDT.
+ * This implementation returns a lightweight placeholder until the VFS lookup completes on a pooled thread.
+ */
+public final class DeferredLocalFileSourcePosition extends DeferredSourcePositionBase {
+
+    private final @NotNull Path filePath;
+    private final int line;
+    private volatile @Nullable VirtualFile placeholderFile;
+
+    private final AtomicBoolean resolutionStarted = new AtomicBoolean(false);
+    private volatile @Nullable VirtualFile resolvedFile;
+    private volatile int offset = -1;
+
+    public DeferredLocalFileSourcePosition(@NotNull Path filePath, int line) {
+        this.filePath = filePath;
+        this.line = line;
+
+        startResolveAsync();
+    }
+
+    @Override
+    public int getLine() {
+        return line;
+    }
+
+    @Override
+    public int getOffset() {
+        return offset;
+    }
+
+    @Override
+    public @NotNull VirtualFile getFile() {
+        VirtualFile file = resolvedFile;
+        if (file != null) {
+            return file;
+        }
+
+        startResolveAsync();
+
+        if (!ApplicationManager.getApplication().isDispatchThread()) {
+            resolveNow();
+            file = resolvedFile;
+            if (file != null) {
+                return file;
+            }
+        }
+
+        VirtualFile placeholder = placeholderFile;
+        if (placeholder != null) {
+            return placeholder;
+        }
+        String name = filePath.getFileName() != null ? filePath.getFileName().toString() : filePath.toString();
+        placeholder = new LightVirtualFile(name);
+        placeholderFile = placeholder;
+        return placeholder;
+    }
+
+    private void startResolveAsync() {
+        if (!resolutionStarted.compareAndSet(false, true)) {
+            return;
+        }
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            try {
+                resolveNow();
+            } finally {
+                resolveFuture.complete(null);
+            }
+        });
+    }
+
+    private void resolveNow() {
+        if (resolvedFile != null) {
+            return;
+        }
+        VirtualFile file = LocalFileSystem.getInstance().findFileByPath(filePath.toString());
+        if (file == null || !file.isValid()) {
+            return;
+        }
+        int resolvedOffset = ReadAction.compute(() -> computeOffset(file, line));
+        resolvedFile = file;
+        offset = resolvedOffset;
+        markResolved();
+        resolveFuture.complete(null);
+    }
+
+    private static int computeOffset(@NotNull VirtualFile file, int line) {
+        Document document = FileDocumentManager.getInstance().getDocument(file);
+        if (document == null) {
+            return -1;
+        }
+        int l = Math.max(0, line);
+        int offset = l < document.getLineCount() ? document.getLineStartOffset(l) : -1;
+        if (offset >= document.getTextLength()) {
+            offset = document.getTextLength() - 1;
+        }
+        return offset;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredSourcePosition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredSourcePosition.java
@@ -12,20 +12,10 @@ package com.redhat.devtools.lsp4ij.dap.client.files;
 
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
-import com.intellij.openapi.fileEditor.FileNavigator;
-import com.intellij.openapi.fileEditor.OpenFileDescriptor;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NotNullLazyValue;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.pom.Navigatable;
-import com.intellij.xdebugger.XSourcePosition;
-import com.intellij.xdebugger.impl.XSourcePositionEx;
 import com.redhat.devtools.lsp4ij.dap.client.DAPClient;
-import kotlinx.coroutines.flow.Flow;
-import kotlinx.coroutines.flow.MutableStateFlow;
-import kotlinx.coroutines.flow.StateFlowKt;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
@@ -46,15 +36,7 @@ import java.util.concurrent.CompletableFuture;
  * @param <T> the type of parameters required to load the source (e.g., DAP request parameters)
  * @param <F> the type of VirtualFile handled by this position
  */
-public abstract class DeferredSourcePosition<T, F extends VirtualFile> implements XSourcePositionEx {
-
-    /**
-     * Flow to notify when the position has been successfully resolved.
-     * <p>
-     * Initially set to {@code false}. When the source is loaded and the line is resolved,
-     * the value becomes {@code true}.
-     */
-    private final MutableStateFlow<Boolean> resolvedFlow = StateFlowKt.MutableStateFlow(false);
+public abstract class DeferredSourcePosition<T, F extends VirtualFile> extends DeferredSourcePositionBase {
 
     /** The virtual file associated with this position. */
     private final F file;
@@ -67,12 +49,6 @@ public abstract class DeferredSourcePosition<T, F extends VirtualFile> implement
 
     /** Lazy value that computes the offset only when needed, once the line is known. */
     private NotNullLazyValue<Integer> offset;
-
-    /**
-     * Future representing the asynchronous task responsible for loading the source
-     * and resolving the corresponding line number.
-     */
-    private final @NotNull CompletableFuture<Void> loadFuture;
 
     /**
      * Creates a deferred source position that will load and resolve the position asynchronously.
@@ -88,26 +64,33 @@ public abstract class DeferredSourcePosition<T, F extends VirtualFile> implement
         this.modificationCount = file.getModificationCount();
 
         // Start the asynchronous process to load the source and resolve the line.
-        loadFuture = loadAndResolveLineAsync(parameters, file, client)
-                .thenAccept(line -> {
-                    this.line = line;
-                    // Compute the offset lazily, based on the resolved line
-                    this.offset = NotNullLazyValue.atomicLazy(() -> ReadAction.compute(() -> {
-                        int column = 0; // Default column to 0 for now, may be extended later
-                        Document document = FileDocumentManager.getInstance().getDocument(file);
-                        if (document == null) {
-                            return -1;
-                        } else {
-                            int l = Math.max(0, line);
-                            int c = Math.max(0, column);
-                            int offset = l < document.getLineCount() ? document.getLineStartOffset(l) + c : -1;
-                            if (offset >= document.getTextLength()) {
-                                offset = document.getTextLength() - 1;
-                            }
-                            return offset;
+        loadAndResolveLineAsync(parameters, file, client)
+                .whenComplete((resolvedLine, error) -> {
+                    try {
+                        if (error != null || resolvedLine == null) {
+                            return;
                         }
-                    }));
-                    resolvedFlow.setValue(true); // Mark as resolved
+                        this.line = resolvedLine;
+                        // Compute the offset lazily, based on the resolved line.
+                        this.offset = NotNullLazyValue.atomicLazy(() -> ReadAction.compute(() -> {
+                            int column = 0; // Default column to 0 for now, may be extended later
+                            Document document = FileDocumentManager.getInstance().getDocument(file);
+                            if (document == null) {
+                                return -1;
+                            } else {
+                                int l = Math.max(0, resolvedLine);
+                                int c = Math.max(0, column);
+                                int offset = l < document.getLineCount() ? document.getLineStartOffset(l) + c : -1;
+                                if (offset >= document.getTextLength()) {
+                                    offset = document.getTextLength() - 1;
+                                }
+                                return offset;
+                            }
+                        }));
+                        markResolved();
+                    } finally {
+                        resolveFuture.complete(null);
+                    }
                 });
     }
 
@@ -151,116 +134,9 @@ public abstract class DeferredSourcePosition<T, F extends VirtualFile> implement
     }
 
     /**
-     * Creates a navigatable object that will wait for the source position to be resolved
-     * before navigating to it.
-     *
-     * @param project the current project
-     * @return a {@link Navigatable} that can handle deferred navigation
-     */
-    @Override
-    public @NotNull Navigatable createNavigatable(@NotNull Project project) {
-        return new DeferredNavigatable(project, this, loadFuture);
-    }
-
-    /**
-     * Returns a flow that indicates whether the position is resolved.
-     * <p>
-     * Can be used to update the UI reactively as soon as the position is available.
-     */
-    @Override
-    public @NotNull Flow<Boolean> getPositionUpdateFlow() {
-        return resolvedFlow;
-    }
-
-    /**
-     * @return true if the source and line number are resolved, false otherwise
-     */
-    private boolean isResolved() {
-        return resolvedFlow.getValue();
-    }
-
-    /**
      * @return the modification count captured when this position was created
      */
     public long getModificationCount() {
         return modificationCount;
-    }
-
-    /**
-     * A deferred navigatable descriptor that waits for the source position to be resolved
-     * before navigating in the editor.
-     * <p>
-     * This is used so that navigation attempts (e.g., user clicks) do not fail
-     * if the source is still being loaded.
-     */
-    public class DeferredNavigatable extends OpenFileDescriptor {
-
-        /** The associated source position. */
-        private final XSourcePosition position;
-
-        /** Future used to wait for the position resolution before navigating. */
-        private final CompletableFuture<Void> loadFuture;
-
-        private DeferredNavigatable(@NotNull Project project,
-                                    @NotNull XSourcePosition position,
-                                    @NotNull CompletableFuture<Void> future) {
-            super(project, position.getFile());
-            this.position = position;
-            this.loadFuture = future;
-        }
-
-        /**
-         * Navigates to the resolved position.
-         * <p>
-         * If the position is not ready yet, it will wait for the future to complete first.
-         */
-        @Override
-        public void navigate(boolean requestFocus) {
-            if (isResolved()) {
-                doNavigate(requestFocus);
-            } else {
-                loadFuture.thenAccept(unused -> doNavigate(requestFocus));
-            }
-        }
-
-        private void doNavigate(boolean requestFocus) {
-            OpenFileDescriptor descriptor = new OpenFileDescriptor(getProject(), getFile(), position.getOffset());
-            FileNavigator.getInstance().navigate(descriptor, requestFocus);
-        }
-
-        /**
-         * Navigates in a specific editor to the resolved position.
-         * <p>
-         * If the position is not ready yet, it will wait for the future to complete first.
-         */
-        @Override
-        public void navigateIn(@NotNull Editor e) {
-            if (isResolved()) {
-                doNavigateIn(e);
-            } else {
-                loadFuture.thenAccept(unused -> doNavigateIn(e));
-            }
-        }
-
-        private void doNavigateIn(@NotNull Editor e) {
-            OpenFileDescriptor descriptor = new OpenFileDescriptor(getProject(), getFile(), position.getOffset());
-            descriptor.navigateIn(e);
-        }
-
-        /**
-         * @return true if navigation is possible (file is valid)
-         */
-        @Override
-        public boolean canNavigate() {
-            return this.position.getFile().isValid();
-        }
-
-        /**
-         * @return true if navigation to the source is possible
-         */
-        @Override
-        public boolean canNavigateToSource() {
-            return this.canNavigate();
-        }
     }
 }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredSourcePositionBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/files/DeferredSourcePositionBase.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.dap.client.files;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileNavigator;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.pom.Navigatable;
+import com.intellij.xdebugger.impl.XSourcePositionEx;
+import kotlinx.coroutines.flow.Flow;
+import kotlinx.coroutines.flow.MutableStateFlow;
+import kotlinx.coroutines.flow.StateFlowKt;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Base class for an {@link com.intellij.xdebugger.XSourcePosition} whose final location is resolved asynchronously.
+ * The debugger UI listens to {@link #getPositionUpdateFlow()} to refresh the execution point highlighting.
+ */
+abstract class DeferredSourcePositionBase implements XSourcePositionEx {
+
+    private final MutableStateFlow<Boolean> resolvedFlow = StateFlowKt.MutableStateFlow(false);
+    protected final @NotNull CompletableFuture<Void> resolveFuture = new CompletableFuture<>();
+
+    protected final void markResolved() {
+        resolvedFlow.setValue(true);
+    }
+
+    protected final boolean isResolved() {
+        return resolvedFlow.getValue();
+    }
+
+    @Override
+    public final @NotNull Flow<Boolean> getPositionUpdateFlow() {
+        return resolvedFlow;
+    }
+
+    @Override
+    public @NotNull Navigatable createNavigatable(@NotNull Project project) {
+        return new DeferredNavigatable(project, this);
+    }
+
+    private static final class DeferredNavigatable extends OpenFileDescriptor {
+
+        private final @NotNull DeferredSourcePositionBase position;
+
+        private DeferredNavigatable(@NotNull Project project, @NotNull DeferredSourcePositionBase position) {
+            super(project, position.getFile());
+            this.position = position;
+        }
+
+        @Override
+        public void navigate(boolean requestFocus) {
+            if (position.isResolved()) {
+                doNavigate(requestFocus);
+            } else {
+                position.resolveFuture.thenRun(() -> {
+                    if (!position.isResolved()) {
+                        return;
+                    }
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        if (position.isResolved()) {
+                            doNavigate(requestFocus);
+                        }
+                    });
+                });
+            }
+        }
+
+        private void doNavigate(boolean requestFocus) {
+            VirtualFile file = position.getFile();
+            if (!file.isValid()) {
+                return;
+            }
+            FileNavigator.getInstance().navigate(createDescriptor(file), requestFocus);
+        }
+
+        @Override
+        public void navigateIn(@NotNull Editor e) {
+            if (position.isResolved()) {
+                doNavigateIn(e);
+            } else {
+                position.resolveFuture.thenRun(() -> {
+                    if (!position.isResolved()) {
+                        return;
+                    }
+                    ApplicationManager.getApplication().invokeLater(() -> {
+                        if (position.isResolved()) {
+                            doNavigateIn(e);
+                        }
+                    });
+                });
+            }
+        }
+
+        private void doNavigateIn(@NotNull Editor editor) {
+            VirtualFile file = position.getFile();
+            if (!file.isValid()) {
+                return;
+            }
+            createDescriptor(file).navigateIn(editor);
+        }
+
+        private @NotNull OpenFileDescriptor createDescriptor(@NotNull VirtualFile file) {
+            int offset = position.getOffset();
+            if (offset != -1) {
+                return new OpenFileDescriptor(getProject(), file, offset);
+            }
+            return new OpenFileDescriptor(getProject(), file, Math.max(0, position.getLine()), 0);
+        }
+
+        @Override
+        public boolean canNavigate() {
+            return position.getFile().isValid();
+        }
+
+        @Override
+        public boolean canNavigateToSource() {
+            return canNavigate();
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFileEditor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyFileEditor.java
@@ -23,7 +23,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.pom.Navigatable;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.redhat.devtools.lsp4ij.dap.client.files.DeferredSourcePosition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -146,7 +145,8 @@ public class DisassemblyFileEditor implements TextEditor {
 
     @Override
     public boolean canNavigateTo(@NotNull Navigatable navigatable) {
-        return navigatable instanceof DeferredSourcePosition<?,?>.DeferredNavigatable;
+        return navigatable instanceof OpenFileDescriptor
+                && file.equals(((OpenFileDescriptor) navigatable).getFile());
     }
 
     @Override


### PR DESCRIPTION
Fixes slow-operation warnings when resolving DAP stack frame source positions.\n\n- Replace VfsUtil.findFile(..., true) with LocalFileSystem.findFileByPath (no VFS refresh).\n- If getSourcePosition() is called on the EDT, return XSourcePositionEx and compute offset asynchronously; notify via positionUpdateFlow (same strategy as DeferredSourcePosition).\n- Non-EDT path stays synchronous (XDebuggerUtil.createPosition).\n\nRefs #1409.\nSupersedes #1410.