### PR TITLE
fix: Support for full pattern

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/files/PathPatternMatcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/files/PathPatternMatcher.java
@@ -29,23 +29,190 @@ import java.util.Objects;
  */
 public class PathPatternMatcher {
 
-    record Parts(@NotNull List<String> parts, @NotNull List<Integer> cols) {}
-
-    private List<PathMatcher> pathMatchers;
     private final @NotNull String pattern;
     private final @Nullable Path basePath;
-
+    private List<PathMatcher> pathMatchers;
     public PathPatternMatcher(@NotNull String pattern,
                               @Nullable Path basePath) {
-        if (basePath != null) {
-            if (pattern.startsWith(basePath.toString())) {
-                // ex:  "globPattern": "C:\\Users\\XXX\\IdeaProjects\\test-rust/**/*.rs"
-                // basePath="C:\\Users\\XXX\\IdeaProjects\\test-rust/"
-                basePath = null;
-            }
-        }
         this.pattern = pattern;
         this.basePath = basePath;
+    }
+
+    /**
+     * Creates a PathPatternMatcher by automatically extracting the base path from the pattern.
+     * <p>
+     * The base path is the portion of the pattern before any glob characters (*, ?, [, {).
+     * The pattern is then adjusted to be relative to this base path.
+     *
+     * @param fullPattern the glob pattern with optional absolute base path
+     * @return a new PathPatternMatcher with extracted base path and relative pattern
+     */
+    public static @NotNull PathPatternMatcher fromPattern(@NotNull final String fullPattern,
+                                                          @Nullable Path defaultBasePath) {
+        // Find the first occurrence of glob characters: * ? [ {
+        int firstGlobChar = findFirstGlobCharacter(fullPattern);
+
+        if (firstGlobChar == -1) {
+            // No glob characters, treat entire string as pattern
+            return new PathPatternMatcher(fullPattern, null);
+        }
+
+        if (firstGlobChar == 0) {
+            // Pattern starts with a glob character (e.g., "**/*.rs")
+            return new PathPatternMatcher(fullPattern, defaultBasePath);
+        }
+
+        // Find the last path separator before the first glob character
+        String beforeGlob = fullPattern.substring(0, firstGlobChar);
+
+        // Support both forward slash and backslash
+        int lastSeparator = Math.max(
+                beforeGlob.lastIndexOf('/'),
+                beforeGlob.lastIndexOf('\\')
+        );
+
+        if (lastSeparator == -1) {
+            // No separator found before glob, no valid base path
+            return new PathPatternMatcher(fullPattern, defaultBasePath);
+        }
+
+        // Extract base path (everything before the last separator before glob)
+        String basePathStr = fullPattern.substring(0, lastSeparator);
+
+        // Extract relative pattern (everything after the base path)
+        // Skip the separator itself (lastSeparator + 1)
+        String relativePattern = fullPattern.substring(lastSeparator + 1);
+
+        try {
+            // Normalize separators for Path
+            Path basePath = Paths.get(basePathStr.replace('\\', '/'));
+            return new PathPatternMatcher(relativePattern, basePath);
+        } catch (Exception e) {
+            // If path creation fails, return with original pattern and no base
+            return new PathPatternMatcher(fullPattern, defaultBasePath);
+        }
+    }
+
+    /**
+     * Finds the index of the first glob metacharacter in the string.
+     * Glob characters: * ? [ {
+     *
+     * @param pattern the pattern to search
+     * @return the index of the first glob character, or -1 if none found
+     */
+    private static int findFirstGlobCharacter(@NotNull String pattern) {
+        int minIndex = Integer.MAX_VALUE;
+
+        int asterisk = pattern.indexOf('*');
+        if (asterisk != -1 && asterisk < minIndex) {
+            minIndex = asterisk;
+        }
+
+        int question = pattern.indexOf('?');
+        if (question != -1 && question < minIndex) {
+            minIndex = question;
+        }
+
+        int bracket = pattern.indexOf('[');
+        if (bracket != -1 && bracket < minIndex) {
+            minIndex = bracket;
+        }
+
+        int brace = pattern.indexOf('{');
+        if (brace != -1 && brace < minIndex) {
+            minIndex = brace;
+        }
+
+        return minIndex == Integer.MAX_VALUE ? -1 : minIndex;
+    }
+
+    /**
+     * Expand the given pattern. ex: ** /foo -> foo, ** /foo.
+     *
+     * @param pattern the pattern
+     * @return the given pattern.
+     */
+    static List<String> expandPatterns(String pattern) {
+        Parts parts = getParts(pattern);
+        if (parts != null) {
+            // tokenize pattern ex : **/foo/** --> [**/, foo, /**]
+            List<String> expanded = new ArrayList<>();
+            // generate combinations array with 0,1 according to the number of **/, /**
+            // ex: **/foo/** (number=2) --> [[0, 0], [0, 1], [1, 0], [1, 1]
+            List<int[]> combinations = generateCombinations(parts.cols().size());
+            for (int[] combination : combinations) {
+                // Clone tokenized pattern (ex : [**/, foo, /**])
+                List<String> expand = new ArrayList<>(parts.parts());
+                for (int i = 0; i < combination.length; i++) {
+                    // Loop for current combination (ex : [0, 1])
+                    if (combination[i] == 0) {
+                        // When 0,  replace **/, /** with ""
+                        // ex : [**/, foo, /**] --> ["", foo, "/**"]
+                        int col = parts.cols().get(i);
+                        expand.set(col, "");
+                    }
+                }
+                // ["", foo, "/**"] --> foo/**
+                expanded.add(String.join("", expand));
+            }
+            return expanded;
+        }
+        return Collections.singletonList(pattern);
+    }
+
+    private static Parts getParts(String pattern) {
+        int from = 0;
+        int index = getNextIndex(pattern, from);
+        if (index != -1) {
+            List<Integer> cols = new ArrayList<>();
+            List<String> parts = new ArrayList<>();
+            while (index != -1) {
+                String s = pattern.substring(from, index);
+                if (!s.isEmpty()) {
+                    parts.add(s);
+                }
+                cols.add(parts.size());
+                from = index + 3;
+                parts.add(pattern.substring(index, from));
+                index += 3;
+                index = getNextIndex(pattern, index);
+            }
+            parts.add(pattern.substring(from));
+            return new Parts(parts, cols);
+        }
+        return null;
+    }
+
+    private static int getNextIndex(String pattern, int fromIndex) {
+        int startSlashIndex = pattern.indexOf("**/", fromIndex);
+        int endSlashIndex = pattern.indexOf("/**", fromIndex);
+        if (startSlashIndex != -1 || endSlashIndex != -1) {
+            if (startSlashIndex == -1) {
+                return endSlashIndex;
+            }
+            if (endSlashIndex == -1) {
+                return startSlashIndex;
+            }
+            return Math.min(startSlashIndex, endSlashIndex);
+        }
+        return -1;
+    }
+
+    public static List<int[]> generateCombinations(int N) {
+        List<int[]> combinations = new ArrayList<>();
+        generateCombinationsHelper(N, new int[N], 0, combinations);
+        return combinations;
+    }
+
+    private static void generateCombinationsHelper(int N, int[] combination, int index, List<int[]> combinations) {
+        if (index == N) {
+            combinations.add(combination.clone());
+        } else {
+            combination[index] = 0;
+            generateCombinationsHelper(N, combination, index + 1, combinations);
+            combination[index] = 1;
+            generateCombinationsHelper(N, combination, index + 1, combinations);
+        }
     }
 
     public @NotNull String getPattern() {
@@ -109,96 +276,6 @@ public class PathPatternMatcher {
         this.pathMatchers = pathMatchers;
     }
 
-    /**
-     * Expand the given pattern. ex: ** /foo -> foo, ** /foo.
-     *
-     * @param pattern the pattern
-     * @return the given pattern.
-     */
-    static List<String> expandPatterns(String pattern) {
-        Parts parts = getParts(pattern);
-        if (parts != null) {
-            // tokenize pattern ex : **/foo/** --> [**/, foo, /**]
-            List<String> expanded = new ArrayList<>();
-            // generate combinations array with 0,1 according to the number of **/, /**
-            // ex: **/foo/** (number=2) --> [[0, 0], [0, 1], [1, 0], [1, 1]
-            List<int[]> combinations = generateCombinations(parts.cols().size());
-            for (int[] combination : combinations) {
-                // Clone tokenized pattern (ex : [**/, foo, /**])
-                List<String> expand = new ArrayList<>(parts.parts());
-                for (int i = 0; i < combination.length; i++) {
-                    // Loop for current combination (ex : [0, 1])
-                    if (combination[i] == 0) {
-                        // When 0,  replace **/, /** with ""
-                        // ex : [**/, foo, /**] --> ["", foo, "/**"]
-                        int col = parts.cols().get(i);
-                        expand.set(col, "");
-                    }
-                }
-                // ["", foo, "/**"] --> foo/**
-                expanded.add(String.join("", expand));
-            }
-            return expanded;
-        }
-        return Collections.singletonList(pattern);
-    }
-
-
-    private static Parts getParts(String pattern) {
-        int from = 0;
-        int index = getNextIndex(pattern, from);
-        if (index != -1) {
-            List<Integer> cols = new ArrayList<>();
-            List<String> parts = new ArrayList<>();
-            while (index != -1) {
-                String s = pattern.substring(from, index);
-                if (!s.isEmpty()) {
-                    parts.add(s);
-                }
-                cols.add(parts.size());
-                from = index + 3;
-                parts.add(pattern.substring(index, from));
-                index += 3;
-                index = getNextIndex(pattern, index);
-            }
-            parts.add(pattern.substring(from));
-            return new Parts(parts, cols);
-        }
-        return null;
-    }
-
-    private static int getNextIndex(String pattern, int fromIndex) {
-        int startSlashIndex = pattern.indexOf("**/", fromIndex);
-        int endSlashIndex = pattern.indexOf("/**", fromIndex);
-        if (startSlashIndex != -1 || endSlashIndex != -1) {
-            if (startSlashIndex == -1) {
-                return endSlashIndex;
-            }
-            if (endSlashIndex == -1) {
-                return startSlashIndex;
-            }
-            return Math.min(startSlashIndex, endSlashIndex);
-        }
-        return -1;
-    }
-
-    public static List<int[]> generateCombinations(int N) {
-        List<int[]> combinations = new ArrayList<>();
-        generateCombinationsHelper(N, new int[N], 0, combinations);
-        return combinations;
-    }
-
-    private static void generateCombinationsHelper(int N, int[] combination, int index, List<int[]> combinations) {
-        if (index == N) {
-            combinations.add(combination.clone());
-        } else {
-            combination[index] = 0;
-            generateCombinationsHelper(N, combination, index + 1, combinations);
-            combination[index] = 1;
-            generateCombinationsHelper(N, combination, index + 1, combinations);
-        }
-    }
-
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -212,5 +289,8 @@ public class PathPatternMatcher {
             return Objects.equals(pattern, other.getPattern());
         }
         return false;
+    }
+
+    record Parts(@NotNull List<String> parts, @NotNull List<Integer> cols) {
     }
 }

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/files/ExpandPatternsTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/files/ExpandPatternsTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.features.files;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Test with pattern expansion.
+**/
+public class ExpandPatternsTest {
+
+    @Test
+    public void noExpansion() {
+        assertExpandPatterns("foo", "foo");
+    }
+
+    @Test
+    public void oneExpansion() {
+        assertExpandPatterns("**/foo", "foo", "**/foo");
+    }
+
+    @Test
+    public void twoExpansion() {
+        assertExpandPatterns("**/foo/**", "foo", "**/foo", "foo/**", "**/foo/**");
+    }
+
+    @Test
+    public void sixExpansion() {
+        assertExpandPatterns("{**/node_modules/**,**/.git/**,**/bower_components/**}",
+                "{node_modules,.git,bower_components}",
+                "{node_modules,.git,bower_components/**}",
+                "{node_modules,.git,**/bower_components}",
+                "{node_modules,.git,**/bower_components/**}",
+                "{node_modules,.git/**,bower_components}",
+                "{node_modules,.git/**,bower_components/**}",
+                "{node_modules,.git/**,**/bower_components}",
+                "{node_modules,.git/**,**/bower_components/**}",
+                "{node_modules,**/.git,bower_components}",
+                "{node_modules,**/.git,bower_components/**}",
+                "{node_modules,**/.git,**/bower_components}",
+                "{node_modules,**/.git,**/bower_components/**}",
+                "{node_modules,**/.git/**,bower_components}",
+                "{node_modules,**/.git/**,bower_components/**}",
+                "{node_modules,**/.git/**,**/bower_components}",
+                "{node_modules,**/.git/**,**/bower_components/**}",
+                "{node_modules/**,.git,bower_components}",
+                "{node_modules/**,.git,bower_components/**}",
+                "{node_modules/**,.git,**/bower_components}",
+                "{node_modules/**,.git,**/bower_components/**}",
+                "{node_modules/**,.git/**,bower_components}",
+                "{node_modules/**,.git/**,bower_components/**}",
+                "{node_modules/**,.git/**,**/bower_components}",
+                "{node_modules/**,.git/**,**/bower_components/**}",
+                "{node_modules/**,**/.git,bower_components}",
+                "{node_modules/**,**/.git,bower_components/**}",
+                "{node_modules/**,**/.git,**/bower_components}",
+                "{node_modules/**,**/.git,**/bower_components/**}",
+                "{node_modules/**,**/.git/**,bower_components}",
+                "{node_modules/**,**/.git/**,bower_components/**}",
+                "{node_modules/**,**/.git/**,**/bower_components}",
+                "{node_modules/**,**/.git/**,**/bower_components/**}",
+                "{**/node_modules,.git,bower_components}",
+                "{**/node_modules,.git,bower_components/**}",
+                "{**/node_modules,.git,**/bower_components}",
+                "{**/node_modules,.git,**/bower_components/**}",
+                "{**/node_modules,.git/**,bower_components}",
+                "{**/node_modules,.git/**,bower_components/**}",
+                "{**/node_modules,.git/**,**/bower_components}",
+                "{**/node_modules,.git/**,**/bower_components/**}",
+                "{**/node_modules,**/.git,bower_components}",
+                "{**/node_modules,**/.git,bower_components/**}",
+                "{**/node_modules,**/.git,**/bower_components}",
+                "{**/node_modules,**/.git,**/bower_components/**}",
+                "{**/node_modules,**/.git/**,bower_components}",
+                "{**/node_modules,**/.git/**,bower_components/**}",
+                "{**/node_modules,**/.git/**,**/bower_components}",
+                "{**/node_modules,**/.git/**,**/bower_components/**}",
+                "{**/node_modules/**,.git,bower_components}",
+                "{**/node_modules/**,.git,bower_components/**}",
+                "{**/node_modules/**,.git,**/bower_components}",
+                "{**/node_modules/**,.git,**/bower_components/**}",
+                "{**/node_modules/**,.git/**,bower_components}",
+                "{**/node_modules/**,.git/**,bower_components/**}",
+                "{**/node_modules/**,.git/**,**/bower_components}",
+                "{**/node_modules/**,.git/**,**/bower_components/**}",
+                "{**/node_modules/**,**/.git,bower_components}",
+                "{**/node_modules/**,**/.git,bower_components/**}",
+                "{**/node_modules/**,**/.git,**/bower_components}",
+                "{**/node_modules/**,**/.git,**/bower_components/**}",
+                "{**/node_modules/**,**/.git/**,bower_components}",
+                "{**/node_modules/**,**/.git/**,bower_components/**}",
+                "{**/node_modules/**,**/.git/**,**/bower_components}",
+                "{**/node_modules/**,**/.git/**,**/bower_components/**}");
+    }
+
+    private static void assertExpandPatterns(String pattern, String... expectedPatterns) {
+        List<String> actual = PathPatternMatcher.expandPatterns(pattern);
+        Collections.sort(actual);
+        List<String> expected = Arrays.asList(expectedPatterns);
+        Collections.sort(expected);
+        assertArrayEquals("'" + pattern + "' pattern expansion should match [\"" + String.join("\",\"", actual) + "\"]",
+                actual.toArray(new String[0]), expected.toArray(new String[0]));
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/features/files/PathPatternMatcherTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/features/files/PathPatternMatcherTest.java
@@ -1,118 +1,320 @@
-/*******************************************************************************
- * Copyright (c) 2024 Red Hat, Inc.
- * Distributed under license by Red Hat, Inc. All rights reserved.
- * This program is made available under the terms of the
- * Eclipse Public License v2.0 which accompanies this distribution,
- * and is available at https://www.eclipse.org/legal/epl-v20.html
- *
- * Contributors:
- * Red Hat, Inc. - initial API and implementation
- ******************************************************************************/
 package com.redhat.devtools.lsp4ij.features.files;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.assertArrayEquals;
-
-/**
- * Test with pattern expansion.
-**/
-public class PathPatternMatcherTest {
+class PathPatternMatcherTest {
 
     @Test
-    public void noExpansion() {
-        assertExpandPatterns("foo", "foo");
+    @DisplayName("Pattern with Windows absolute path and glob")
+    void testWindowsAbsolutePathWithGlob() {
+        String pattern = "C:\\Users\\XXX\\IdeaProjects\\test-rust/**/*.rs";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.rs", matcher.getPattern());
+        assertNotNull(matcher.getBasePath());
+        assertEquals(Paths.get("C:/Users/XXX/IdeaProjects/test-rust"), matcher.getBasePath());
     }
 
     @Test
-    public void oneExpansion() {
-        assertExpandPatterns("**/foo", "foo", "**/foo");
+    @DisplayName("Pattern with Unix absolute path and glob")
+    void testUnixAbsolutePathWithGlob() {
+        String pattern = "/home/user/project/**/*.java";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.java", matcher.getPattern());
+        assertNotNull(matcher.getBasePath());
+        assertEquals(Paths.get("/home/user/project"), matcher.getBasePath());
     }
 
     @Test
-    public void twoExpansion() {
-        assertExpandPatterns("**/foo/**", "foo", "**/foo", "foo/**", "**/foo/**");
+    @DisplayName("Pattern with relative path and glob")
+    void testRelativePathWithGlob() {
+        String pattern = "src/main/java/**/*.kt";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.kt", matcher.getPattern());
+        assertNotNull(matcher.getBasePath());
+        assertEquals(Paths.get("src/main/java"), matcher.getBasePath());
     }
 
     @Test
-    public void sixExpansion() {
-        assertExpandPatterns("{**/node_modules/**,**/.git/**,**/bower_components/**}",
-                "{node_modules,.git,bower_components}",
-                "{node_modules,.git,bower_components/**}",
-                "{node_modules,.git,**/bower_components}",
-                "{node_modules,.git,**/bower_components/**}",
-                "{node_modules,.git/**,bower_components}",
-                "{node_modules,.git/**,bower_components/**}",
-                "{node_modules,.git/**,**/bower_components}",
-                "{node_modules,.git/**,**/bower_components/**}",
-                "{node_modules,**/.git,bower_components}",
-                "{node_modules,**/.git,bower_components/**}",
-                "{node_modules,**/.git,**/bower_components}",
-                "{node_modules,**/.git,**/bower_components/**}",
-                "{node_modules,**/.git/**,bower_components}",
-                "{node_modules,**/.git/**,bower_components/**}",
-                "{node_modules,**/.git/**,**/bower_components}",
-                "{node_modules,**/.git/**,**/bower_components/**}",
-                "{node_modules/**,.git,bower_components}",
-                "{node_modules/**,.git,bower_components/**}",
-                "{node_modules/**,.git,**/bower_components}",
-                "{node_modules/**,.git,**/bower_components/**}",
-                "{node_modules/**,.git/**,bower_components}",
-                "{node_modules/**,.git/**,bower_components/**}",
-                "{node_modules/**,.git/**,**/bower_components}",
-                "{node_modules/**,.git/**,**/bower_components/**}",
-                "{node_modules/**,**/.git,bower_components}",
-                "{node_modules/**,**/.git,bower_components/**}",
-                "{node_modules/**,**/.git,**/bower_components}",
-                "{node_modules/**,**/.git,**/bower_components/**}",
-                "{node_modules/**,**/.git/**,bower_components}",
-                "{node_modules/**,**/.git/**,bower_components/**}",
-                "{node_modules/**,**/.git/**,**/bower_components}",
-                "{node_modules/**,**/.git/**,**/bower_components/**}",
-                "{**/node_modules,.git,bower_components}",
-                "{**/node_modules,.git,bower_components/**}",
-                "{**/node_modules,.git,**/bower_components}",
-                "{**/node_modules,.git,**/bower_components/**}",
-                "{**/node_modules,.git/**,bower_components}",
-                "{**/node_modules,.git/**,bower_components/**}",
-                "{**/node_modules,.git/**,**/bower_components}",
-                "{**/node_modules,.git/**,**/bower_components/**}",
-                "{**/node_modules,**/.git,bower_components}",
-                "{**/node_modules,**/.git,bower_components/**}",
-                "{**/node_modules,**/.git,**/bower_components}",
-                "{**/node_modules,**/.git,**/bower_components/**}",
-                "{**/node_modules,**/.git/**,bower_components}",
-                "{**/node_modules,**/.git/**,bower_components/**}",
-                "{**/node_modules,**/.git/**,**/bower_components}",
-                "{**/node_modules,**/.git/**,**/bower_components/**}",
-                "{**/node_modules/**,.git,bower_components}",
-                "{**/node_modules/**,.git,bower_components/**}",
-                "{**/node_modules/**,.git,**/bower_components}",
-                "{**/node_modules/**,.git,**/bower_components/**}",
-                "{**/node_modules/**,.git/**,bower_components}",
-                "{**/node_modules/**,.git/**,bower_components/**}",
-                "{**/node_modules/**,.git/**,**/bower_components}",
-                "{**/node_modules/**,.git/**,**/bower_components/**}",
-                "{**/node_modules/**,**/.git,bower_components}",
-                "{**/node_modules/**,**/.git,bower_components/**}",
-                "{**/node_modules/**,**/.git,**/bower_components}",
-                "{**/node_modules/**,**/.git,**/bower_components/**}",
-                "{**/node_modules/**,**/.git/**,bower_components}",
-                "{**/node_modules/**,**/.git/**,bower_components/**}",
-                "{**/node_modules/**,**/.git/**,**/bower_components}",
-                "{**/node_modules/**,**/.git/**,**/bower_components/**}");
+    @DisplayName("Pattern starting with ** (no base path)")
+    void testPatternStartingWithGlob() {
+        String pattern = "**/*.txt";
+        Path defaultBase = Paths.get("/default/path");
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, defaultBase);
+        
+        assertEquals("**/*.txt", matcher.getPattern());
+        assertEquals(defaultBase, matcher.getBasePath());
     }
 
-    private static void assertExpandPatterns(String pattern, String... expectedPatterns) {
-        List<String> actual = PathPatternMatcher.expandPatterns(pattern);
-        Collections.sort(actual);
-        List<String> expected = Arrays.asList(expectedPatterns);
-        Collections.sort(expected);
-        assertArrayEquals("'" + pattern + "' pattern expansion should match [\"" + String.join("\",\"", actual) + "\"]",
-                actual.toArray(new String[0]), expected.toArray(new String[0]));
+    @Test
+    @DisplayName("Pattern starting with * (no base path)")
+    void testPatternStartingWithAsterisk() {
+        String pattern = "*.rs";
+        Path defaultBase = Paths.get("/default");
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, defaultBase);
+        
+        assertEquals("*.rs", matcher.getPattern());
+        assertEquals(defaultBase, matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with single level wildcard")
+    void testSingleLevelWildcard() {
+        String pattern = "/usr/local/bin/*.sh";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("*.sh", matcher.getPattern());
+        assertEquals(Paths.get("/usr/local/bin"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with question mark wildcard")
+    void testQuestionMarkWildcard() {
+        String pattern = "C:\\test\\folder\\file?.txt";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("file?.txt", matcher.getPattern());
+        assertEquals(Paths.get("C:/test/folder"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with bracket wildcard")
+    void testBracketWildcard() {
+        String pattern = "/var/log/app[123].log";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("app[123].log", matcher.getPattern());
+        assertEquals(Paths.get("/var/log"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with brace wildcard")
+    void testBraceWildcard() {
+        String pattern = "/etc/config/{prod,dev,test}.yml";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("{prod,dev,test}.yml", matcher.getPattern());
+        assertEquals(Paths.get("/etc/config"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with multiple glob types")
+    void testMultipleGlobTypes() {
+        String pattern = "C:\\projects\\myapp\\**/*.{java,kt,rs}";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.{java,kt,rs}", matcher.getPattern());
+        assertEquals(Paths.get("C:/projects/myapp"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with mixed separators (backslash and forward slash)")
+    void testMixedSeparators() {
+        String pattern = "C:\\Users/XXX/project\\src/**/*.java";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.java", matcher.getPattern());
+        assertNotNull(matcher.getBasePath());
+        // Should handle mixed separators
+    }
+
+    @Test
+    @DisplayName("Pattern with no glob characters")
+    void testNoGlobCharacters() {
+        String pattern = "/home/user/file.txt";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("/home/user/file.txt", matcher.getPattern());
+        assertNull(matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with glob at the very beginning")
+    void testGlobAtBeginning() {
+        String pattern = "**/src/main/**/*.java";
+        Path defaultBase = Paths.get("/project");
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, defaultBase);
+        
+        assertEquals("**/src/main/**/*.java", matcher.getPattern());
+        assertEquals(defaultBase, matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Empty pattern")
+    void testEmptyPattern() {
+        String pattern = "";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("", matcher.getPattern());
+        assertNull(matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with only separator and glob")
+    void testOnlySeparatorAndGlob() {
+        String pattern = "/*.txt";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("*.txt", matcher.getPattern());
+        // Root path "/" is extracted but might be null depending on implementation
+    }
+
+    @Test
+    @DisplayName("Deep nested path with glob")
+    void testDeepNestedPath() {
+        String pattern = "/a/b/c/d/e/f/g/h/**/*.xml";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.xml", matcher.getPattern());
+        assertEquals(Paths.get("/a/b/c/d/e/f/g/h"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Windows drive letter only")
+    void testWindowsDriveLetterOnly() {
+        String pattern = "C:/**/*.dll";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.dll", matcher.getPattern());
+        // C: might result in special handling
+    }
+
+    @Test
+    @DisplayName("Pattern with trailing slash before glob")
+    void testTrailingSlashBeforeGlob() {
+        String pattern = "/home/user/project//**/*.js";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.js", matcher.getPattern());
+        assertEquals(Paths.get("/home/user/project"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with UNC path (Windows network)")
+    void testUNCPath() {
+        String pattern = "\\\\server\\share\\folder/**/*.doc";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.doc", matcher.getPattern());
+        assertNotNull(matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with only filename glob")
+    void testOnlyFilenameGlob() {
+        String pattern = "test*.java";
+        Path defaultBase = Paths.get("/src");
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, defaultBase);
+        
+        assertEquals("test*.java", matcher.getPattern());
+        assertEquals(defaultBase, matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Default base path is used when pattern has no path component")
+    void testDefaultBasePathUsed() {
+        String pattern = "*.rs";
+        Path defaultBase = Paths.get("/my/default/path");
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, defaultBase);
+        
+        assertNotNull(matcher.getBasePath());
+        assertEquals(defaultBase, matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with consecutive asterisks")
+    void testConsecutiveAsterisks() {
+        String pattern = "/path/to/***/*.txt";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("***/*.txt", matcher.getPattern());
+        assertEquals(Paths.get("/path/to"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with dot in directory name")
+    void testDotInDirectoryName() {
+        String pattern = "/home/user/.config/**/*.conf";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.conf", matcher.getPattern());
+        assertEquals(Paths.get("/home/user/.config"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with spaces in path")
+    void testSpacesInPath() {
+        String pattern = "/home/my documents/project/**/*.pdf";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.pdf", matcher.getPattern());
+        assertEquals(Paths.get("/home/my documents/project"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with Unicode characters in path")
+    void testUnicodeInPath() {
+        String pattern = "/home/utilisateur/projét/**/*.txt";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.txt", matcher.getPattern());
+        assertEquals(Paths.get("/home/utilisateur/projét"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Complex real-world pattern - Rust project")
+    void testRealWorldRustProject() {
+        String pattern = "C:\\Users\\Developer\\RustProjects\\my-app\\src/**/*.rs";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.rs", matcher.getPattern());
+        assertEquals(Paths.get("C:/Users/Developer/RustProjects/my-app/src"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Complex real-world pattern - Java Maven project")
+    void testRealWorldJavaMavenProject() {
+        String pattern = "/home/dev/projects/my-service/src/main/java/**/*.java";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.java", matcher.getPattern());
+        assertEquals(Paths.get("/home/dev/projects/my-service/src/main/java"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Complex real-world pattern - Node.js project")
+    void testRealWorldNodeJsProject() {
+        String pattern = "D:\\workspace\\my-node-app\\src\\**\\*.{ts,js}";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**\\*.{ts,js}", matcher.getPattern());
+        assertEquals(Paths.get("D:/workspace/my-node-app/src"), matcher.getBasePath());
+    }
+
+    @Test
+    @DisplayName("Pattern with multiple consecutive separators")
+    void testMultipleConsecutiveSeparators() {
+        String pattern = "/home//user///project/**/*.txt";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.txt", matcher.getPattern());
+        // Should handle multiple separators gracefully
+    }
+
+    @Test
+    @DisplayName("Null default base path")
+    void testNullDefaultBasePath() {
+        String pattern = "**/*.java";
+        PathPatternMatcher matcher = PathPatternMatcher.fromPattern(pattern, null);
+        
+        assertEquals("**/*.java", matcher.getPattern());
+        assertNull(matcher.getBasePath());
     }
 }


### PR DESCRIPTION
Support for:

```json
"watchers": [
          {
            "globPattern": "C:\\Users\\AngeloZerr\\IdeaProjects\\test-rust/**/*.rs"
          }
]
```