### PR TITLE
docs: add Fish Shell for JetBrains to LSP4IJ users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Here are some projects that use LSP4IJ:
  * [poryscript-idea](https://github.com/okafke/poryscript-idea)
  * [t-ruby](https://github.com/type-ruby/t-ruby)
  * [Rovo LSP - IntelliJ](https://github.com/arthurdw/rovo)
+ * [Fish Shell for JetBrains](https://github.com/tox-dev/jetbrains-fish)
 
 ## Requirements
 


### PR DESCRIPTION
Add [Fish Shell for JetBrains](https://github.com/tox-dev/jetbrains-fish) to the "Who is using LSP4IJ?" section in the README.

This is a Fish Shell plugin for JetBrains IDEs that uses LSP4IJ for language server integration.

Resolves https://github.com/tox-dev/jetbrains-fish/issues/41