### PR TITLE
fix: zero-width diagnostic at end-of-line incorrectly highlights preceding token

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJUtils.java
@@ -786,15 +786,19 @@ public class LSPIJUtils {
                 // No adjustment, the TextRange with start/end offset is invalid
                 return null;
             }
+            // When the offset is at the end of the line, return
+            // a zero-width range so the annotation renders via
+            // afterEndOfLine() instead of expanding to a token.
+            if (isEndOfLine(document, range.getEnd().getLine(), start)) {
+                return new TextRange(start, end);
+            }
             // Select token at current offset, if possible
             TextRange tokenRange = getWordRangeAt(document, file, start);
             if (tokenRange != null) {
                 return tokenRange;
             }
-            // Adjust the end offset if the offset is not at the end of the line.
-            if (!isEndOfLine(document, range.getEnd().getLine(), start)) {
-                end++;
-            }
+            // Adjust the end offset.
+            end++;
             return new TextRange(start, end);
         } catch (IndexOutOfBoundsException e) {
             // Language server reports invalid diagnostic, ignore it.


### PR DESCRIPTION
When a language server sends a zero-width diagnostic range at end-of-line (e.g. missing semicolon after an identifier), `toTextRange` expands it to the preceding token via `getWordRangeAt` before checking `isEndOfLine`. This causes the wrong token to be highlighted.

Solution:
Move the `isEndOfLine` check before the word expansion so zero-width end-of-line diagnostics return a zero-width `TextRange` and render via `afterEndOfLine()` instead.

Before:
<img width="102" height="75" alt="image" src="https://github.com/user-attachments/assets/56941646-9a96-408f-b6bb-b60a57a3e3ce" />

After:
<img width="107" height="71" alt="image" src="https://github.com/user-attachments/assets/06e8bcee-eb36-4e97-acf0-7ccdde55c4bd" />

`textDocument/publishDiagnostics` response:
```json
"diagnostics": [
  {
    "range": {
      "start": {
        "line": 2,
        "character": 11
      },
      "end": {
        "line": 2,
        "character": 11
      }
    },
    "severity": 1,
    "code": "parse.expected_token",
    "source": "phynix",
    "message": "\u0027;\u0027 expected",
    "tags": []
  }
]
```

Matches IDE behaviour (PhpStorm):
<img width="605" height="280" alt="image" src="https://github.com/user-attachments/assets/9627ed6c-1b85-4d99-9090-568d3f267d0a" />
