### PR TITLE
feat: expose createLauncherBuilder in LSPClientFeatures for custom Me…

### DIFF
--- a/docs/LSPApi.md
+++ b/docs/LSPApi.md
@@ -30,6 +30,7 @@ The [LSPClientFeatures](https://github.com/redhat-developer/lsp4ij/blob/main/src
 - [LSP breadcrumbs feature](#lsp-breadcrumbs-feature)
 - [LSP editor behavior feature](#lsp-editor-behavior-feature)
 - [JSON-RPC communication feature](#json-rpc-communication-feature)
+- [Custom launcher builder](#custom-launcher-builder)
 - [Language server installer](#language-server-installer)
 
 You can extend these default features by:
@@ -789,6 +790,102 @@ You can customize JSON-RPC communication behavior by overriding the `isUseIntAsJ
 | boolean isUseIntAsJsonRpcId() | Returns `true` if JSON-RPC id should be sent as integer instead of string and `false` otherwise. | `false`       |
 
 This feature is useful when working with language servers that require integer IDs for JSON-RPC messages instead of the default string IDs used by LSP4J.
+
+## Custom Launcher Builder
+
+You can customize how the JSON-RPC launcher is built by overriding the `createLauncherBuilder()` method in your `LSPClientFeatures` subclass. This gives you full control over the lsp4j `Launcher.Builder`, including the ability to replace the default `MessageProducer` that reads LSP messages from the server's output stream.
+
+| Method signature                                                        | Description                                                                                                          | Default Behaviour                                                       |
+|-------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `<S extends LanguageServer> Launcher.Builder<S> createLauncherBuilder()` | Returns the `Launcher.Builder` used to create the JSON-RPC launcher for communicating with the language server. | Returns a `DefaultLauncherBuilder` that reads messages from the standard input stream. |
+
+The [DefaultLauncherBuilder](https://github.com/redhat-developer/lsp4ij/blob/main/src/main/java/com/redhat/devtools/lsp4ij/server/DefaultLauncherBuilder.java) provides a protected `createMessageProducer()` method that you can override to inject a custom `MessageProducer`:
+
+| Method signature                                                                                                                                        | Description                                                                                     | Default Behaviour                                        |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| `MessageProducer createMessageProducer(InputStream input, MessageJsonHandler jsonHandler, MessageIssueHandler issueHandler)` | Creates the `MessageProducer` that feeds JSON-RPC messages into the lsp4j processing pipeline. | Returns an `ExtendedStreamMessageProducer` that reads from the input stream. |
+
+### Use case: Non-standard message transport
+
+This API is useful when your language server does not communicate via standard `stdin`/`stdout` streams with Content-Length framing. For example, the Dart Analysis Server uses a legacy JSON protocol and requires a proxy layer that translates between the legacy protocol and LSP. Instead of piping responses through a stream, the proxy can feed parsed messages directly into lsp4j via a custom `MessageProducer` backed by a queue.
+
+Here is how the Dart plugin uses this API:
+
+**Step 1:** Create a custom `MessageProducer` that accepts messages via a queue instead of reading from a stream:
+
+```java
+public class DartMessageProducer implements MessageProducer {
+
+    private final LinkedBlockingQueue<String> queue = new LinkedBlockingQueue<>();
+    private final MessageJsonHandler jsonHandler;
+
+    public DartMessageProducer(MessageJsonHandler jsonHandler) {
+        this.jsonHandler = jsonHandler;
+    }
+
+    /** Called by the proxy layer to enqueue a JSON-RPC message. */
+    public void enqueue(String json) {
+        queue.add(json);
+    }
+
+    @Override
+    public void listen(MessageConsumer callback) {
+        try {
+            while (true) {
+                String json = queue.take();
+                Message message = jsonHandler.parseMessage(new StringReader(json));
+                callback.consume(message);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void close() {
+        // no-op
+    }
+}
+```
+
+**Step 2:** Create a custom `DefaultLauncherBuilder` subclass that overrides `createMessageProducer()`:
+
+```java
+class DartLauncherBuilder<S extends LanguageServer> extends DefaultLauncherBuilder<S> {
+
+    DartLauncherBuilder(@NotNull LSPClientFeatures clientFeatures) {
+        super(clientFeatures);
+    }
+
+    @Override
+    protected @NotNull MessageProducer createMessageProducer(@NotNull InputStream input,
+                                                              @NotNull MessageJsonHandler jsonHandler,
+                                                              @NotNull MessageIssueHandler issueHandler) {
+        DartMessageProducer producer = new DartMessageProducer(jsonHandler);
+        // Register the producer so the proxy layer can enqueue responses into it.
+        Project project = getClientFeatures().getProject();
+        DartMessageProducerRegistry.register(project, producer);
+        return producer;
+    }
+}
+```
+
+**Step 3:** Override `createLauncherBuilder()` in your `LSPClientFeatures` subclass:
+
+```java
+public class DartLSPClientFeatures extends LSPClientFeatures {
+
+    public DartLSPClientFeatures() {
+        super.setCompletionFeature(new DartLSPCompletionFeature());
+        super.setDiagnosticFeature(new DartLSPDiagnosticFeature());
+    }
+
+    @Override
+    public <S extends LanguageServer> @NotNull Launcher.Builder<S> createLauncherBuilder() {
+        return new DartLauncherBuilder<>(this);
+    }
+}
+```
 
 ## Language server installer
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -400,7 +400,7 @@ public class LanguageServerWrapper implements Disposable {
                             }
                         });
 
-                        Launcher<LanguageServer> launcher = serverDefinition.createLauncherBuilder(getClientFeatures()) //
+                        Launcher<LanguageServer> launcher = getClientFeatures().createLauncherBuilder() //
                                 .setLocalService(languageClient)//
                                 .setRemoteInterface(serverDefinition.getServerInterface())//
                                 .setInput(provider.getInputStream())//

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPClientFeatures.java
@@ -19,8 +19,10 @@ import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
 import com.redhat.devtools.lsp4ij.ServerStatus;
 import com.redhat.devtools.lsp4ij.installation.ServerInstallationStatus;
 import com.redhat.devtools.lsp4ij.installation.ServerInstaller;
+import com.redhat.devtools.lsp4ij.server.DefaultLauncherBuilder;
 import com.redhat.devtools.lsp4ij.server.capabilities.TextDocumentServerCapabilityRegistry;
 import com.redhat.devtools.lsp4ij.server.definition.LanguageServerDefinition;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentRegistrationOptions;
@@ -308,6 +310,22 @@ public class LSPClientFeatures implements Disposable, FileUriSupport {
      */
     public boolean isUseIntAsJsonRpcId() {
         return false;
+    }
+
+    /**
+     * Creates the {@link Launcher.Builder} used to build the LSP launcher.
+     *
+     * <p>The default implementation returns a {@link DefaultLauncherBuilder}.
+     * Subclasses can override this to return a custom builder — for example,
+     * a subclass of {@link DefaultLauncherBuilder} that overrides
+     * {@link DefaultLauncherBuilder#createMessageProducer} to provide a custom
+     * {@link org.eclipse.lsp4j.jsonrpc.MessageProducer}.</p>
+     *
+     * @param <S> the language server interface type.
+     * @return the launcher builder.
+     */
+    public <S extends LanguageServer> @NotNull Launcher.Builder<S> createLauncherBuilder() {
+        return new DefaultLauncherBuilder<>(this);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/DefaultLauncherBuilder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/DefaultLauncherBuilder.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.server;
+
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
+import com.redhat.devtools.lsp4ij.internal.ExtendedConcurrentMessageProcessor;
+import com.redhat.devtools.lsp4ij.internal.ExtendedStreamMessageProducer;
+import com.redhat.devtools.lsp4ij.internal.capabilities.CodeLensOptionsAdapter;
+import org.eclipse.lsp4j.CodeLensOptions;
+import org.eclipse.lsp4j.jsonrpc.*;
+import org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.InputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * Default implementation of {@link Launcher.Builder} for lsp4ij that:
+ * <ul>
+ *   <li>Uses {@link ExtendedStreamMessageProducer} for error-propagating message reading</li>
+ *   <li>Uses {@link ExtendedConcurrentMessageProcessor} for error-propagating message processing</li>
+ *   <li>Supports integer JSON-RPC IDs via {@link LSPClientFeatures#isUseIntAsJsonRpcId()}</li>
+ *   <li>Registers {@link CodeLensOptionsAdapter} for backward compatibility with legacy servers</li>
+ * </ul>
+ *
+ * <p>Subclasses can override {@link #createMessageProducer} to provide a custom
+ * {@link MessageProducer} (e.g., for non-stdio message sources).</p>
+ *
+ * @param <S> the language server interface type
+ */
+public class DefaultLauncherBuilder<S extends LanguageServer> extends Launcher.Builder<S> {
+
+    private final @NotNull LSPClientFeatures clientFeatures;
+
+    public DefaultLauncherBuilder(@NotNull LSPClientFeatures clientFeatures) {
+        this.clientFeatures = clientFeatures;
+        configureGson(builder -> {
+            // Add a custom CodeLensOptionsAdapter to support old language server
+            // which declares codeLensProvider with a boolean instead of Json object.
+            builder.registerTypeAdapter(CodeLensOptions.class, new CodeLensOptionsAdapter());
+        });
+    }
+
+    /**
+     * Returns the {@link LSPClientFeatures} associated with this builder.
+     *
+     * @return the client features.
+     */
+    @NotNull
+    protected LSPClientFeatures getClientFeatures() {
+        return clientFeatures;
+    }
+
+    @Override
+    public Launcher<S> create() {
+        // Validate input
+        if (input == null)
+            throw new IllegalStateException("Input stream must be configured.");
+        if (output == null)
+            throw new IllegalStateException("Output stream must be configured.");
+        if (localServices == null)
+            throw new IllegalStateException("Local service must be configured.");
+        if (remoteInterfaces == null)
+            throw new IllegalStateException("Remote interface must be configured.");
+
+        // Create the JSON handler, remote endpoint and remote proxy
+        MessageJsonHandler jsonHandler = createJsonHandler();
+        RemoteEndpoint remoteEndpoint = createRemoteEndpoint(jsonHandler);
+        S remoteProxy = createProxy(remoteEndpoint);
+
+        // Create the message processor
+        MessageProducer reader = createMessageProducer(input, jsonHandler, remoteEndpoint);
+        MessageConsumer messageConsumer = wrapMessageConsumer(remoteEndpoint);
+        ConcurrentMessageProcessor msgProcessor = createMessageProcessor(reader, messageConsumer, remoteProxy);
+        ExecutorService execService = executorService != null ? executorService : Executors.newCachedThreadPool();
+        return createLauncher(execService, remoteProxy, remoteEndpoint, msgProcessor);
+    }
+
+    /**
+     * Creates the {@link MessageProducer} that reads incoming LSP messages.
+     *
+     * <p>The default implementation returns an {@link ExtendedStreamMessageProducer}
+     * that reads from the given input stream. Subclasses can override this method
+     * to provide a custom message source (e.g., a queue-based producer for
+     * non-stdio transports).</p>
+     *
+     * @param input        the input stream to read messages from.
+     * @param jsonHandler  the JSON handler for message parsing.
+     * @param issueHandler the handler for message issues.
+     * @return the message producer.
+     */
+    protected @NotNull MessageProducer createMessageProducer(@NotNull InputStream input,
+                                                              @NotNull MessageJsonHandler jsonHandler,
+                                                              @NotNull MessageIssueHandler issueHandler) {
+        return new ExtendedStreamMessageProducer(input, jsonHandler, issueHandler);
+    }
+
+    @Override
+    protected ConcurrentMessageProcessor createMessageProcessor(MessageProducer reader,
+                                                                 MessageConsumer messageConsumer,
+                                                                 S remoteProxy) {
+        return new ExtendedConcurrentMessageProcessor(reader, messageConsumer);
+    }
+
+    @Override
+    protected RemoteEndpoint createRemoteEndpoint(MessageJsonHandler jsonHandler) {
+        boolean useIntAsId = clientFeatures.isUseIntAsJsonRpcId();
+        if (!useIntAsId) {
+            // Use JSON-RPC as String (default behavior of LSP4J)
+            return super.createRemoteEndpoint(jsonHandler);
+        }
+
+        // Override the remote endpoint to use JSON-RPC id as int
+        MessageConsumer outgoingMessageStream = new StreamMessageConsumer(output, jsonHandler);
+        outgoingMessageStream = wrapMessageConsumer(outgoingMessageStream);
+        Endpoint localEndpoint = ServiceEndpoints.toEndpoint(localServices);
+        RemoteEndpoint remoteEndpoint;
+        if (exceptionHandler == null)
+            remoteEndpoint = new RemoteEndpointWithIdAsInt(outgoingMessageStream, localEndpoint);
+        else
+            remoteEndpoint = new RemoteEndpointWithIdAsInt(outgoingMessageStream, localEndpoint, exceptionHandler);
+        jsonHandler.setMethodProvider(remoteEndpoint);
+        return remoteEndpoint;
+    }
+
+    /**
+     * Custom RemoteEndpoint that uses integer IDs instead of string IDs for JSON-RPC messages.
+     */
+    private static class RemoteEndpointWithIdAsInt extends RemoteEndpoint {
+
+        private final AtomicInteger nextRequestId = new AtomicInteger();
+
+        public RemoteEndpointWithIdAsInt(MessageConsumer out,
+                                         Endpoint localEndpoint,
+                                         Function<Throwable, ResponseError> exceptionHandler) {
+            super(out, localEndpoint, exceptionHandler);
+        }
+
+        public RemoteEndpointWithIdAsInt(MessageConsumer out,
+                                         Endpoint localEndpoint) {
+            super(out, localEndpoint);
+        }
+
+        @Override
+        protected RequestMessage createRequestMessage(String method, Object parameter) {
+            RequestMessage requestMessage = new RequestMessage();
+            // Use int as JSON-RPC id instead of String (by default from LSP4J)
+            requestMessage.setId(nextRequestId.incrementAndGet());
+            requestMessage.setMethod(method);
+            requestMessage.setParams(parameter);
+            return requestMessage;
+        }
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/DefaultLauncherBuilder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/DefaultLauncherBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Red Hat, Inc.
+ * Copyright (c) 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
@@ -30,19 +30,9 @@ import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.semanticTokens.DefaultSemanticTokensColorsProvider;
 import com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorsProvider;
 import com.redhat.devtools.lsp4ij.installation.ServerInstaller;
-import com.redhat.devtools.lsp4ij.internal.ExtendedConcurrentMessageProcessor;
-import com.redhat.devtools.lsp4ij.internal.ExtendedStreamMessageProducer;
-import com.redhat.devtools.lsp4ij.internal.capabilities.CodeLensOptionsAdapter;
+import com.redhat.devtools.lsp4ij.server.DefaultLauncherBuilder;
 import com.redhat.devtools.lsp4ij.settings.contributors.LanguageServerSettingsContributor;
-import org.eclipse.lsp4j.CodeLensOptions;
-import org.eclipse.lsp4j.jsonrpc.*;
-import org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor;
-import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
-import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer;
-import org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer;
-import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
-import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
-import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -54,10 +44,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 /**
  * Base class for Language server definition.
@@ -216,93 +202,19 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
     }
 
     /**
-     * Custom RemoteEndpoint that uses integer IDs instead of string IDs for JSON-RPC messages.
+     * Creates the {@link Launcher.Builder} used to build the LSP launcher.
+     *
+     * <p>The default implementation returns a {@link DefaultLauncherBuilder}. Subclasses
+     * can override this to return a custom builder, but the preferred extension point
+     * is {@link LSPClientFeatures#createLauncherBuilder()} which avoids requiring
+     * a custom {@link LanguageServerDefinition}.</p>
+     *
+     * @param clientFeatures the client features.
+     * @param <S>            the language server interface type.
+     * @return the launcher builder.
      */
-    private static class RemoteEndpointWithIdAsInt extends RemoteEndpoint {
-
-        private final AtomicInteger nextRequestId = new AtomicInteger();
-
-        public RemoteEndpointWithIdAsInt(MessageConsumer out,
-                                         Endpoint localEndpoint,
-                                         Function<Throwable, ResponseError> exceptionHandler) {
-            super(out, localEndpoint, exceptionHandler);
-        }
-
-        public RemoteEndpointWithIdAsInt(MessageConsumer out,
-                                         Endpoint localEndpoint) {
-            super(out, localEndpoint);
-        }
-
-        @Override
-        protected RequestMessage createRequestMessage(String method, Object parameter) {
-            RequestMessage requestMessage = new RequestMessage();
-            // Use int as JSON-RPC id instead of String (by default from LSP4J)
-            requestMessage.setId(nextRequestId.incrementAndGet());
-            requestMessage.setMethod(method);
-            requestMessage.setParams(parameter);
-            return requestMessage;
-        }
-    }
-
     public <S extends LanguageServer> Launcher.Builder<S> createLauncherBuilder(@NotNull LSPClientFeatures clientFeatures) {
-
-        return new Launcher.Builder<S>() {
-
-            public Launcher<S> create() {
-                // Validate input
-                if (input == null)
-                    throw new IllegalStateException("Input stream must be configured.");
-                if (output == null)
-                    throw new IllegalStateException("Output stream must be configured.");
-                if (localServices == null)
-                    throw new IllegalStateException("Local service must be configured.");
-                if (remoteInterfaces == null)
-                    throw new IllegalStateException("Remote interface must be configured.");
-
-                // Create the JSON handler, remote endpoint and remote proxy
-                MessageJsonHandler jsonHandler = createJsonHandler();
-                RemoteEndpoint remoteEndpoint = createRemoteEndpoint(jsonHandler);
-                S remoteProxy = createProxy(remoteEndpoint);
-
-                // Create the message processor
-                StreamMessageProducer reader = new ExtendedStreamMessageProducer(input, jsonHandler, remoteEndpoint);
-                MessageConsumer messageConsumer = wrapMessageConsumer(remoteEndpoint);
-                ConcurrentMessageProcessor msgProcessor = createMessageProcessor(reader, messageConsumer, remoteProxy);
-                ExecutorService execService = executorService != null ? executorService : Executors.newCachedThreadPool();
-                return createLauncher(execService, remoteProxy, remoteEndpoint, msgProcessor);
-            }
-
-            @Override
-            protected ConcurrentMessageProcessor createMessageProcessor(MessageProducer reader, MessageConsumer messageConsumer, S remoteProxy) {
-                return new ExtendedConcurrentMessageProcessor(reader, messageConsumer);
-            }
-
-            @Override
-            protected RemoteEndpoint createRemoteEndpoint(MessageJsonHandler jsonHandler) {
-
-                boolean useIntAsId = clientFeatures.isUseIntAsJsonRpcId();
-                if (!useIntAsId) {
-                    // Use JSON-RPC as String (default behavior of LSP4J)
-                    return super.createRemoteEndpoint(jsonHandler);
-                }
-
-                // Override the remote endpoint to use JSON-RPC id as int
-                MessageConsumer outgoingMessageStream = new StreamMessageConsumer(output, jsonHandler);
-                outgoingMessageStream = wrapMessageConsumer(outgoingMessageStream);
-                Endpoint localEndpoint = ServiceEndpoints.toEndpoint(localServices);
-                RemoteEndpoint remoteEndpoint;
-                if (exceptionHandler == null)
-                    remoteEndpoint = new RemoteEndpointWithIdAsInt(outgoingMessageStream, localEndpoint);
-                else
-                    remoteEndpoint = new RemoteEndpointWithIdAsInt(outgoingMessageStream, localEndpoint, exceptionHandler);
-                jsonHandler.setMethodProvider(remoteEndpoint);
-                return remoteEndpoint;
-            }
-        }.configureGson(builder -> {
-            // Add a custom CodeLensOptionsAdapter to support old language server
-            // which declares codeLenProvider with a boolean instead of Json object.
-            builder.registerTypeAdapter(CodeLensOptions.class, new CodeLensOptionsAdapter());
-        });
+        return new DefaultLauncherBuilder<>(clientFeatures);
     }
 
     public boolean supportsCurrentEditMode(@NotNull Project project) {


### PR DESCRIPTION
## Summary

Closes https://github.com/redhat-developer/lsp4ij/issues/1444

- Extract the anonymous `Launcher.Builder` from `LanguageServerDefinition.createLauncherBuilder` into a new `DefaultLauncherBuilder` class with a protected `createMessageProducer()` method
- Add `LSPClientFeatures.createLauncherBuilder()` so plugins can customize the launcher by overriding this method in their `LSPClientFeatures` subclass
- `LanguageServerWrapper` now calls through `LSPClientFeatures.createLauncherBuilder()` instead of `LanguageServerDefinition.createLauncherBuilder()` directly

## Motivation

There is currently no way for plugins to customize the `MessageProducer` used in the lsp4j launcher pipeline through `LSPClientFeatures` or the `<server>` extension point. The `<server factoryClass="...">` extension point wraps the factory in `ExtensionLanguageServerDefinition`, which does not delegate `createLauncherBuilder`.

This forces plugins that need a custom `MessageProducer` to resort to programmatic registration via `LanguageServersRegistry.addServerDefinition()`.

## Use case

The [Dart plugin](https://github.com/nicholasgasior/intellij-plugins/pull/1) bridges lsp4ij with the Dart Analysis Server via a legacy protocol proxy. DAS responses arrive as JSON strings through a listener callback, not through an `InputStream`. A custom `MessageProducer` backed by a `LinkedBlockingQueue<String>` feeds these responses directly into lsp4j's pipeline.

With this PR, the Dart plugin can cleanly override `createMessageProducer` via `LSPClientFeatures`:

```java
public class DartLSPClientFeatures extends LSPClientFeatures {
    @Override
    public <S extends LanguageServer> Launcher.Builder<S> createLauncherBuilder() {
        return new DartLauncherBuilder<>(this);
    }
}

class DartLauncherBuilder<S extends LanguageServer> extends DefaultLauncherBuilder<S> {
    @Override
    protected MessageProducer createMessageProducer(InputStream input,
                                                     MessageJsonHandler jsonHandler,
                                                     MessageIssueHandler issueHandler) {
        return new DartMessageProducer(jsonHandler); // queue-based, no Content-Length framing
    }
}
````

## Tested

* All 74 existing tests pass
* Integration tested with the Dart plugin — hover works end-to-end using the new API with no programmatic registration workaround needed
* Logs confirming the custom DartMessageProducer is active in the pipeline via the new API:

```text
★★★ LSP-over-legacy: Virtual server starting for project: techcare_assessment_app ★★★
★★★ LSP-over-legacy: Sent fake initialize response to lsp4ij ★★★
★★★ DartMessageProducer: Forwarding DAS response to lsp4ij ★★★
★★★ LSP-over-legacy: Received hover request via lsp4ij ★★★
★★★ LSP-over-legacy: Sending hover response back to lsp4ij ★★★
★★★ DartMessageProducer: Forwarding DAS response to lsp4ij ★★★
```

## Test plan

* All existing tests pass (74/74)
* Integration tested with Dart plugin using LSPClientFeatures.createLauncherBuilder() override
* Hover works end-to-end with custom MessageProducer
* No programmatic registration workaround needed

