### PR TITLE
fix: Fixed an issue with DAP code fragment creation for languages with dialects (fixes #1118 and #1456)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProvider.java
@@ -14,6 +14,7 @@ import com.intellij.lang.Language;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.impl.DocumentImpl;
 import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.LanguageFileType;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
@@ -66,6 +67,13 @@ public class DAPDebuggerEditorsProvider extends XDebuggerEditorsProviderBase {
             // Get file type / language of the file which is debugging when debugger is suspended.
             fileType = file.getFileType();
             language = file.getLanguage();
+            // If the file's language is a more specific dialect of the file type's language, degrade to the file type's
+            if (fileType instanceof LanguageFileType languageFileType) {
+                Language fileTypeLanguage = languageFileType.getLanguage();
+                if (!language.is(fileTypeLanguage) && language.isKindOf(fileTypeLanguage)) {
+                    language = fileTypeLanguage;
+                }
+            }
         }
         return createExpressionCodeFragment(project, text, fileType, language);
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
@@ -37,11 +37,27 @@ public class DAPExpressionCodeFragment extends PsiFileBase {
                                      @Nullable DAPDebugProcess debugProcess,
                                      @NotNull Project project) {
         super(new SingleRootFileViewProvider(PsiManager.getInstance(project),
-                new LightVirtualFile("DAPExpressionCodeFragment." + fileType.getDefaultExtension(), language, text)),
+                createLightVirtualFile(text, fileType, language)),
                 language);
         this.fileType = fileType;
         this.debugProcess = debugProcess;
         ((SingleRootFileViewProvider) getViewProvider()).forceCachedPsi(this);
+    }
+
+    @NotNull
+    private static LightVirtualFile createLightVirtualFile(@NotNull CharSequence text,
+                                                           @NotNull FileType fileType,
+                                                           @NotNull Language language) {
+        String codeFragmentFilename = "DAPExpressionCodeFragment." + fileType.getDefaultExtension();
+
+        // If this is a dialect, use the base language so that the code fragment supports all dialects needed during
+        // debugging, even if in a least common denominator manner
+        Language baseLanguage = language.getBaseLanguage();
+        if ((baseLanguage != null) && !baseLanguage.is(language)) {
+            return new LightVirtualFile(codeFragmentFilename, baseLanguage, text);
+        } else {
+            return new LightVirtualFile(codeFragmentFilename, fileType, text);
+        }
     }
 
     @NotNull

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
@@ -37,7 +37,7 @@ public class DAPExpressionCodeFragment extends PsiFileBase {
                                      @Nullable DAPDebugProcess debugProcess,
                                      @NotNull Project project) {
         super(new SingleRootFileViewProvider(PsiManager.getInstance(project),
-                new LightVirtualFile("DAPExpressionCodeFragment." + fileType.getDefaultExtension(), fileType, text)),
+                new LightVirtualFile("DAPExpressionCodeFragment." + fileType.getDefaultExtension(), language, text)),
                 language);
         this.fileType = fileType;
         this.debugProcess = debugProcess;

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/evaluation/DAPExpressionCodeFragment.java
@@ -37,27 +37,11 @@ public class DAPExpressionCodeFragment extends PsiFileBase {
                                      @Nullable DAPDebugProcess debugProcess,
                                      @NotNull Project project) {
         super(new SingleRootFileViewProvider(PsiManager.getInstance(project),
-                createLightVirtualFile(text, fileType, language)),
+                new LightVirtualFile("DAPExpressionCodeFragment." + fileType.getDefaultExtension(), fileType, text)),
                 language);
         this.fileType = fileType;
         this.debugProcess = debugProcess;
         ((SingleRootFileViewProvider) getViewProvider()).forceCachedPsi(this);
-    }
-
-    @NotNull
-    private static LightVirtualFile createLightVirtualFile(@NotNull CharSequence text,
-                                                           @NotNull FileType fileType,
-                                                           @NotNull Language language) {
-        String codeFragmentFilename = "DAPExpressionCodeFragment." + fileType.getDefaultExtension();
-
-        // If this is a dialect, use the base language so that the code fragment supports all dialects needed during
-        // debugging, even if in a least common denominator manner
-        Language baseLanguage = language.getBaseLanguage();
-        if ((baseLanguage != null) && !baseLanguage.is(language)) {
-            return new LightVirtualFile(codeFragmentFilename, baseLanguage, text);
-        } else {
-            return new LightVirtualFile(codeFragmentFilename, fileType, text);
-        }
     }
 
     @NotNull

--- a/src/test/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProviderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProviderTest.java
@@ -1,3 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
 package com.redhat.devtools.lsp4ij.dap;
 
 import com.intellij.json.JsonFileType;

--- a/src/test/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProviderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProviderTest.java
@@ -1,0 +1,47 @@
+package com.redhat.devtools.lsp4ij.dap;
+
+import com.intellij.json.JsonFileType;
+import com.intellij.json.JsonLanguage;
+import com.intellij.json.json5.Json5Language;
+import com.intellij.openapi.fileTypes.MockLanguageFileType;
+import com.intellij.openapi.fileTypes.PlainTextFileType;
+import com.intellij.openapi.fileTypes.PlainTextLanguage;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
+import com.intellij.testFramework.LightPlatformTestCase;
+import com.intellij.testFramework.LightVirtualFile;
+
+public class DAPDebuggerEditorsProviderTest extends LightPlatformTestCase {
+
+    public void testWithSimpleLanguage() {
+        PsiFile textFile = createFile("test.txt", "Hello, world.");
+        assertEquals(PlainTextFileType.INSTANCE, textFile.getFileType());
+        assertEquals(PlainTextLanguage.INSTANCE, textFile.getLanguage());
+
+        DAPDebuggerEditorsProvider debuggerEditorsProvider = new DAPDebuggerEditorsProvider(PlainTextFileType.INSTANCE, null);
+
+        PsiFile codeFragment = debuggerEditorsProvider.createExpressionCodeFragment(getProject(), "", textFile, true);
+        assertEquals(PlainTextFileType.INSTANCE, codeFragment.getFileType());
+        assertEquals(PlainTextLanguage.INSTANCE, codeFragment.getLanguage());
+    }
+
+    public void testWithDialectLanguage() {
+        // Create a file with the dialect language
+        PsiFile dialectFile = PsiFileFactory.getInstance(getProject()).createFileFromText("test.json", Json5Language.INSTANCE, "{}");
+        VirtualFile dialectVirtualFile = dialectFile.getVirtualFile();
+        // Force the file type to be the base instead of the one inferred from the dialect language used above
+        ((LightVirtualFile) dialectVirtualFile).setFileType(JsonFileType.INSTANCE);
+        assertEquals(JsonFileType.INSTANCE, dialectFile.getFileType());
+        assertEquals(Json5Language.INSTANCE, dialectFile.getLanguage());
+
+        // This should also use the base file type
+        DAPDebuggerEditorsProvider debuggerEditorsProvider = new DAPDebuggerEditorsProvider(MockLanguageFileType.INSTANCE, null);
+
+        // If the original issue exists, this will fail with "JSON5 doesn't participate in view provider..."
+        PsiFile codeFragment = debuggerEditorsProvider.createExpressionCodeFragment(getProject(), "", dialectFile, true);
+        assertEquals(JsonFileType.INSTANCE, codeFragment.getFileType());
+        // It should have degraded to the base language
+        assertEquals(JsonLanguage.INSTANCE, codeFragment.getLanguage());
+    }
+}

--- a/src/test/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProviderTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/dap/DAPDebuggerEditorsProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Red Hat, Inc.
+ * Copyright (c) 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,


### PR DESCRIPTION
If the _file_'s language is a more specific dialect of the _file type_'s language, the less specific language is used for the code fragment. Otherwise the original error will be raised when the file's view provider doesn't support the dialect variant.