### PR TITLE
fix: Enable LSP diagnostics and document links for read-only files

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -435,6 +435,7 @@
         <externalAnnotator
                 id="LSPDiagnosticAnnotator"
                 language=""
+                applyExternalAnnotatorsWhenInactive="true"
                 implementationClass="com.redhat.devtools.lsp4ij.features.diagnostics.LSPDiagnosticAnnotator"/>
         <localInspection id="LSPLocalInspectionTool"
                          language=""
@@ -465,6 +466,7 @@
         <externalAnnotator
                 id="LSPDocumentLinkAnnotator"
                 language=""
+                applyExternalAnnotatorsWhenInactive="true"
                 implementationClass="com.redhat.devtools.lsp4ij.features.documentLink.LSPDocumentLinkAnnotator"/>
         <gotoDeclarationHandler
                 id="LSPDocumentLinkGotoDeclarationHandler"


### PR DESCRIPTION
Fixes LSPDiagnosticAnnotator and LSPDocumentLinkAnnotator not being invoked for read-only files (e.g., from JARs) by adding the applyExternalAnnotatorsWhenInactive="true" attribute to both externalAnnotator declarations in plugin.xml.