### PR TITLE
docs: add agnix to 'Who is using LSP4IJ'

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Here are some projects that use LSP4IJ:
  * [OPA IDEA Plugin](https://github.com/open-policy-agent/opa-idea-plugin)
  * [aer Local Apex Debugger](https://www.octoberswimmer.com/tools/aer/docs/intellij-debugging/)
  * [Rider Unreal Angelscript](https://github.com/scriptacus/rider-unreal-angelscript)
+ * [agnix](https://github.com/agent-sh/agnix)
 
 ## Requirements
 


### PR DESCRIPTION
Hi @angelozerr, thanks for the ping in agent-sh/agnix#889! Adding agnix to the list as requested.

## About agnix

[agnix](https://github.com/agent-sh/agnix) is a linter for AI agent configuration files - Skills, Hooks, MCP servers, CLAUDE.md/AGENTS.md memory files, `.cursor/rules/*.mdc`, and more. It validates against 418 rules sourced from official tool docs and ships a JetBrains plugin built on LSP4IJ.

- **JetBrains Marketplace**: https://plugins.jetbrains.com/plugin/30087-agnix
- **Repo**: https://github.com/agent-sh/agnix

Thanks for LSP4IJ - it made shipping first-class JetBrains support straightforward.