### PR TITLE
fix: report definition request errors correctly

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPDefinitionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPDefinitionSupport.java
@@ -85,7 +85,7 @@ public class LSPDefinitionSupport extends AbstractLSPDocumentFeatureSupport<LSPD
         updateTextDocumentUri(params.getTextDocument(), file, languageServer);
         return cancellationSupport.execute(languageServer
                         .getTextDocumentService()
-                        .definition(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DECLARATION)
+                        .definition(params), languageServer, LSPRequestConstants.TEXT_DOCUMENT_DEFINITION)
                 .thenApplyAsync(locations -> LSPIJUtils.getLocations(locations, languageServer));
     }
 }


### PR DESCRIPTION
## What

Use the `textDocument/definition` request constant when handling definition request failures.

## Why

LSPDefinitionSupport calls TextDocumentService.definition(...), but passed the `textDocument/declaration` label to CancellationSupport. As a result, definition failures were logged or reported as declaration failures.

## Verification

- ./gradlew compileJava