### PR TITLE
feat: support dynamic plugin unloading via disposable listeners and cleanup logic

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -159,16 +159,33 @@ public class LanguageServerWrapper implements Disposable {
         VirtualFileManager.getInstance().addAsyncFileListener(fileListener, this);
 
         String projectName = sanitize(!serverDefinition.isSingleton() ? ("@" + project.getName()) : "");  //$NON-NLS-1$//$NON-NLS-2$
+
+        // Worker threads must not inherit the plugin classloader, or they pin it and block dynamic unload.
+        var workerCtxClassLoader = ApplicationManager.class.getClassLoader();
         String dispatcherThreadNameFormat = "LS-" + serverDefinition.getId() + projectName + "#dispatcher"; //$NON-NLS-1$ //$NON-NLS-2$
-        this.dispatcher = Executors
-                .newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(dispatcherThreadNameFormat).build());
+        this.dispatcher = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                .setNameFormat(dispatcherThreadNameFormat)
+                .setDaemon(true)
+                .setThreadFactory(r -> {
+                    var t = new Thread(r);
+                    t.setContextClassLoader(workerCtxClassLoader);
+                    return t;
+                })
+                .build());
 
         // Executor service passed through to the LSP4j layer when we attempt to start the LS. It will be used
         // to create a listener that sits on the input stream and processes inbound messages (responses, or server-initiated
         // requests).
         String listenerThreadNameFormat = "LS-" + serverDefinition.getId() + projectName + "#listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
-        this.listener = Executors
-                .newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(listenerThreadNameFormat).build());
+        this.listener = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+                .setNameFormat(listenerThreadNameFormat)
+                .setDaemon(true)
+                .setThreadFactory(r -> {
+                    var t = new Thread(r);
+                    t.setContextClassLoader(workerCtxClassLoader);
+                    return t;
+                })
+                .build());
         updateStatus(ServerStatus.none);
 
         // When project is disposed, we dispose the language server
@@ -213,6 +230,20 @@ public class LanguageServerWrapper implements Disposable {
         // If we don't do this then a full test run will generate a lot of threads because we create new
         // instances of this class for each test
         this.listener.shutdownNow();
+
+        // Wait briefly for threads to actually exit.
+        try {
+            if (!this.dispatcher.awaitTermination(2, TimeUnit.SECONDS)) {
+                LOGGER.warn("Dispatcher executor for language server '{}' did not terminate within 2s; classloader unload may be blocked",
+                        serverDefinition.getId());
+            }
+            if (!this.listener.awaitTermination(2, TimeUnit.SECONDS)) {
+                LOGGER.warn("Listener executor for language server '{}' did not terminate within 2s; classloader unload may be blocked",
+                        serverDefinition.getId());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     public synchronized void stopAndDisable() {
@@ -445,7 +476,7 @@ public class LanguageServerWrapper implements Disposable {
                         return initializingContext;
                     })
                     .thenApply(initializingContext -> {
-                        messageBusConnection = ApplicationManager.getApplication().getMessageBus().connect();
+                        messageBusConnection = ApplicationManager.getApplication().getMessageBus().connect(this);
                         messageBusConnection.subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, fileListener);
 
                         fileOperationsManager = new FileOperationsManager(this);
@@ -567,7 +598,7 @@ public class LanguageServerWrapper implements Disposable {
     }
 
     private void startStopTimer() {
-        timer = new Timer("Stop Language Server Timer"); //$NON-NLS-1$
+        timer = new Timer("Stop Language Server Timer", true); //$NON-NLS-1$
         updateStatus(ServerStatus.stopping);
         timer.schedule(new TimerTask() {
             @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -121,7 +121,7 @@ public class LanguageServerWrapper implements Disposable {
     private LanguageServer languageServer;
     private LanguageClientImpl languageClient;
     private ServerCapabilities serverCapabilities;
-    private Timer timer;
+    private final Alarm stopAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
     private ServerStatus serverStatus;
     private boolean disposed;
     private LanguageServerException serverError;
@@ -572,9 +572,8 @@ public class LanguageServerWrapper implements Disposable {
     }
 
     private void removeStopTimer(boolean stopping) {
-        if (timer != null) {
-            timer.cancel();
-            timer = null;
+        if (stopAlarm.getActiveRequestCount() > 0) {
+            stopAlarm.cancelAllRequests();
             if (!stopping) {
                 updateStatus(ServerStatus.started);
             }
@@ -598,19 +597,15 @@ public class LanguageServerWrapper implements Disposable {
     }
 
     private void startStopTimer() {
-        timer = new Timer("Stop Language Server Timer", true); //$NON-NLS-1$
         updateStatus(ServerStatus.stopping);
-        timer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                try {
-                    stop();
-                } catch (Throwable t) {
-                    //Need to catch time task exceptions, or it will cancel the timer
-                    LOGGER.error("Failed to stop language server {}", LanguageServerWrapper.this.serverDefinition.getId(), t);
-                }
+        int delayMs = (int) TimeUnit.SECONDS.toMillis(serverDefinition.getLastDocumentDisconnectedTimeout());
+        stopAlarm.addRequest(() -> {
+            try {
+                stop();
+            } catch (Throwable t) {
+                LOGGER.error("Failed to stop language server {}", serverDefinition.getId(), t);
             }
-        }, TimeUnit.SECONDS.toMillis(this.serverDefinition.getLastDocumentDisconnectedTimeout()));
+        }, delayMs);
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -121,7 +121,7 @@ public class LanguageServerWrapper implements Disposable {
     private LanguageServer languageServer;
     private LanguageClientImpl languageClient;
     private ServerCapabilities serverCapabilities;
-    private final Alarm stopAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
+    private volatile @Nullable Alarm stopAlarm = null;
     private ServerStatus serverStatus;
     private boolean disposed;
     private LanguageServerException serverError;
@@ -597,13 +597,24 @@ public class LanguageServerWrapper implements Disposable {
     private void startStopTimer() {
         updateStatus(ServerStatus.stopping);
         int delayMs = (int) TimeUnit.SECONDS.toMillis(serverDefinition.getLastDocumentDisconnectedTimeout());
-        stopAlarm.addRequest(() -> {
+        getStopAlarm().addRequest(() -> {
             try {
                 stop();
             } catch (Throwable t) {
                 LOGGER.error("Failed to stop language server {}", serverDefinition.getId(), t);
             }
         }, delayMs);
+    }
+
+    private @NotNull Alarm getStopAlarm() {
+        if (stopAlarm == null) {
+            synchronized (this) {
+                if (stopAlarm == null) {
+                    stopAlarm = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
+                }
+            }
+        }
+        return stopAlarm;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -165,7 +165,6 @@ public class LanguageServerWrapper implements Disposable {
         String dispatcherThreadNameFormat = "LS-" + serverDefinition.getId() + projectName + "#dispatcher"; //$NON-NLS-1$ //$NON-NLS-2$
         this.dispatcher = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
                 .setNameFormat(dispatcherThreadNameFormat)
-                .setDaemon(true)
                 .setThreadFactory(r -> {
                     var t = new Thread(r);
                     t.setContextClassLoader(workerCtxClassLoader);
@@ -179,7 +178,6 @@ public class LanguageServerWrapper implements Disposable {
         String listenerThreadNameFormat = "LS-" + serverDefinition.getId() + projectName + "#listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
         this.listener = Executors.newCachedThreadPool(new ThreadFactoryBuilder()
                 .setNameFormat(listenerThreadNameFormat)
-                .setDaemon(true)
                 .setThreadFactory(r -> {
                     var t = new Thread(r);
                     t.setContextClassLoader(workerCtxClassLoader);

--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServersRegistry.java
@@ -15,9 +15,14 @@ import com.intellij.codeInsight.hints.declarative.InlayProviderInfo;
 import com.intellij.lang.Language;
 import com.intellij.lang.findUsages.EmptyFindUsagesProvider;
 import com.intellij.lang.findUsages.LanguageFindUsages;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.extensions.ExtensionPointListener;
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.extensions.PluginDescriptor;
 import com.intellij.openapi.fileTypes.*;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
@@ -42,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
@@ -51,7 +57,7 @@ import static com.redhat.devtools.lsp4ij.templates.ServerMappingSettings.toServe
 /**
  * Language servers registry.
  */
-public class LanguageServersRegistry {
+public class LanguageServersRegistry implements Disposable {
     private static final Logger LOGGER = LoggerFactory.getLogger(LanguageServersRegistry.class);
 
     public static LanguageServersRegistry getInstance() {
@@ -60,23 +66,30 @@ public class LanguageServersRegistry {
 
     private @Nullable Set<Language> supportedLanguages;
 
-    private final Map<String, LanguageServerDefinition> serverDefinitions = new HashMap<>();
+    // Concurrent: mutated by EP listener callbacks on any thread; read from many call sites.
+    private final Map<String, LanguageServerDefinition> serverDefinitions = new ConcurrentHashMap<>();
 
-    private final List<LanguageServerFileAssociation> fileAssociations = new ArrayList<>();
+    private final List<LanguageServerFileAssociation> fileAssociations = new CopyOnWriteArrayList<>();
 
     private final Map<String /* languageId (ex : typescript) */,
-            List<String> /* file extensions (ex : ts) */> languageIdFileExtensionsCache = new HashMap<>();
+            List<String> /* file extensions (ex : ts) */> languageIdFileExtensionsCache = new ConcurrentHashMap<>();
 
     private final Collection<LanguageServerDefinitionListener> listeners = new CopyOnWriteArrayList<>();
 
-    private final Map<String, List<InlayProviderInfo>> declarativeInlayHintsProviders = new HashMap<>();
+    // Volatile + replaced wholesale so readers never see a half-rebuilt state.
+    private volatile Map<String, List<InlayProviderInfo>> declarativeInlayHintsProviders = Map.of();
 
-    private final List<ProviderInfo<?>> inlayHintsProviders = new ArrayList<>();
+    private volatile List<ProviderInfo<?>> inlayHintsProviders = List.of();
 
-    private final Set<Language> customLanguageFindUsages = new HashSet<>();
+    private final Set<Language> customLanguageFindUsages = ConcurrentHashMap.newKeySet();
+
+    // Tracks our registrations with the platform-side LanguageFindUsages so we can unregister
+    // them; otherwise the platform retains a hard ref to the contributing plugin's Language.
+    private final Map<Language, LSPFindUsagesProvider> registeredFindUsagesProviders = new ConcurrentHashMap<>();
 
     private LanguageServersRegistry() {
         initialize();
+        registerExtensionPointListeners();
     }
 
     private void initialize() {
@@ -86,6 +99,62 @@ public class LanguageServersRegistry {
         // Load language servers / mappings from user settings
         loadServersAndMappingFromSettings();
         updateLanguages();
+    }
+
+    private void registerExtensionPointListeners() {
+        registerEpListener(ServerExtensionPointBean.EP_NAME,
+                this::handleServerExtensionAdded,
+                this::handleServerExtensionRemoved);
+        registerEpListener(LanguageMappingExtensionPointBean.EP_NAME,
+                this::handleLanguageMappingAdded,
+                this::handleLanguageMappingRemoved);
+        registerEpListener(FileTypeMappingExtensionPointBean.EP_NAME,
+                this::handleFileTypeMappingAdded,
+                this::handleFileTypeMappingRemoved);
+        registerEpListener(FileNamePatternMappingExtensionPointBean.EP_NAME,
+                this::handleFileNamePatternMappingAdded,
+                this::handleFileNamePatternMappingRemoved);
+        registerEpListener(SemanticTokensColorsProviderExtensionPointBean.EP_NAME,
+                this::handleSemanticTokensColorsProviderAdded,
+                this::handleSemanticTokensColorsProviderRemoved);
+    }
+
+    private <T> void registerEpListener(@NotNull ExtensionPointName<T> epName,
+                                        @NotNull java.util.function.Consumer<T> onAdded,
+                                        @NotNull java.util.function.Consumer<T> onRemoved) {
+        epName.getPoint().addExtensionPointListener(new ExtensionPointListener<T>() {
+            @Override
+            public void extensionAdded(@NotNull T extension, @NotNull PluginDescriptor pluginDescriptor) {
+                try {
+                    onAdded.accept(extension);
+                } catch (Exception e) {
+                    LOGGER.error("Error while handling extensionAdded for {}", epName.getName(), e);
+                }
+            }
+
+            @Override
+            public void extensionRemoved(@NotNull T extension, @NotNull PluginDescriptor pluginDescriptor) {
+                try {
+                    onRemoved.accept(extension);
+                } catch (Exception e) {
+                    LOGGER.error("Error while handling extensionRemoved for {}", epName.getName(), e);
+                }
+            }
+        }, /* invokeForLoadedExtensions */ false, /* parentDisposable */ this);
+    }
+
+    @Override
+    public void dispose() {
+        // Undo platform-side LanguageFindUsages registrations: on lsp4ij's own unload, no
+        // updateLanguages() call would otherwise prune them.
+        for (var entry : registeredFindUsagesProviders.entrySet()) {
+            try {
+                LanguageFindUsages.INSTANCE.removeExplicitExtension(entry.getKey(), entry.getValue());
+            } catch (Exception e) {
+                LOGGER.warn("Error while unregistering LSPFindUsagesProvider for language '{}'", entry.getKey().getID(), e);
+            }
+        }
+        registeredFindUsagesProviders.clear();
     }
 
     private void loadServersAndMappingsFromExtensionPoint() {
@@ -335,32 +404,47 @@ public class LanguageServersRegistry {
 
     private void updateDeclarativeInlayHintsProviders(Set<Language> distinctLanguages) {
         LSPInlayHintsProvider lspInlayHintsProvider = new LSPInlayHintsProvider();
-        declarativeInlayHintsProviders.clear();
+        Map<String, List<InlayProviderInfo>> next = new HashMap<>();
         for (Language language : distinctLanguages) {
             List<InlayProviderInfo> hints = new ArrayList<>();
             hints.add(new InlayProviderInfo(lspInlayHintsProvider, LSPInlayHintsProvider.PROVIDER_ID, Collections.emptySet(), true, LanguageServerBundle.message("lsp.hints.declarative.provider.name")));
-            declarativeInlayHintsProviders.put(language.getID(), hints);
+            next.put(language.getID(), hints);
         }
+        declarativeInlayHintsProviders = Map.copyOf(next);
     }
 
     private void updateInlayHintsProviders(Set<Language> distinctLanguages) {
         LSPColorProvider lspColorProvider = new LSPColorProvider();
-        inlayHintsProviders.clear();
+        List<ProviderInfo<?>> next = new ArrayList<>(distinctLanguages.size());
         for (Language language : distinctLanguages) {
-            inlayHintsProviders.add(new ProviderInfo<>(language, lspColorProvider));
+            next.add(new ProviderInfo<>(language, lspColorProvider));
         }
+        inlayHintsProviders = List.copyOf(next);
     }
 
     private void updateFindUsagesProvider(Set<Language> distinctLanguages) {
         customLanguageFindUsages.clear();
-        // Associate the LSP find usage provider
-        // for all languages associated with a language server.
-        // and which does not already define a provider for the language.
+        // Drop platform registrations for languages no longer backed by any LSP server; otherwise
+        // LanguageFindUsages keeps a hard ref to the unloading plugin's Language.
+        var staleEntries = new ArrayList<Map.Entry<Language, LSPFindUsagesProvider>>();
+        for (var entry : registeredFindUsagesProviders.entrySet()) {
+            if (!distinctLanguages.contains(entry.getKey())) {
+                staleEntries.add(entry);
+            }
+        }
+        for (var entry : staleEntries) {
+            LanguageFindUsages.INSTANCE.removeExplicitExtension(entry.getKey(), entry.getValue());
+            registeredFindUsagesProviders.remove(entry.getKey());
+        }
         LSPFindUsagesProvider provider = new LSPFindUsagesProvider();
         for (Language language : distinctLanguages) {
+            if (registeredFindUsagesProviders.containsKey(language)) {
+                continue;
+            }
             var existingProviders = LanguageFindUsages.INSTANCE.allForLanguage(language);
             if (existingProviders.isEmpty() || (existingProviders.size() == 1 && existingProviders.get(0) instanceof EmptyFindUsagesProvider)) {
                 LanguageFindUsages.INSTANCE.addExplicitExtension(language, provider);
+                registeredFindUsagesProviders.put(language, provider);
             } else {
                 customLanguageFindUsages.add(language);
             }
@@ -582,6 +666,273 @@ public class LanguageServersRegistry {
                 .toList();
         fileAssociations.removeAll(mappingsToRemove);
         definition.removeAssociations();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Dynamic extension point handlers.
+    // Invoked by the platform when a plugin contributing one of the LSP extension points is
+    // loaded or unloaded at runtime. They keep the registry in sync without an IDE restart.
+    // ---------------------------------------------------------------------------------------
+
+    private void handleServerExtensionAdded(@NotNull ServerExtensionPointBean ext) {
+        String serverId = ext.id;
+        if (serverId == null || serverId.isEmpty()) {
+            return;
+        }
+        if (serverDefinitions.containsKey(serverId)) {
+            return;
+        }
+        var serverDefinition = new ExtensionLanguageServerDefinition(ext);
+        for (var stExt : SemanticTokensColorsProviderExtensionPointBean.EP_NAME.getExtensions()) {
+            if (serverId.equals(stExt.serverId)) {
+                try {
+                    serverDefinition.setSemanticTokensColorsProvider(stExt.getSemanticTokensColorsProvider());
+                } catch (Exception e) {
+                    LOGGER.warn("Error while creating custom semanticTokensColorsProvider for server id='{}'.", serverId, e);
+                }
+                break;
+            }
+        }
+        List<ServerMapping> mappings = collectMappingsFromExtensionPoints(serverId);
+        addServerDefinitionWithoutNotification(serverDefinition, mappings, false);
+        updateLanguages();
+        notifyServerAdded(Collections.singleton(serverDefinition));
+    }
+
+    private void handleServerExtensionRemoved(@NotNull ServerExtensionPointBean ext) {
+        String serverId = ext.id;
+        if (serverId == null || serverId.isEmpty()) {
+            return;
+        }
+        LanguageServerDefinition definition = serverDefinitions.remove(serverId);
+        if (definition == null) {
+            return;
+        }
+        removeAssociationsFor(definition);
+        updateLanguages();
+        notifyServerRemoved(Collections.singleton(definition));
+    }
+
+    private void handleLanguageMappingAdded(@NotNull LanguageMappingExtensionPointBean ext) {
+        Language language = Language.findLanguageByID(ext.language);
+        if (language == null) {
+            return;
+        }
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            // Mapping will be picked up later via collectMappingsFromExtensionPoints when the server arrives.
+            return;
+        }
+        var mapping = new ServerLanguageMapping(language, ext.serverId, ext.languageId, ext.getDocumentMatcher());
+        registerAssociation(definition, mapping);
+        updateLanguages();
+        notifyMappingsChanged(definition);
+    }
+
+    private void handleLanguageMappingRemoved(@NotNull LanguageMappingExtensionPointBean ext) {
+        Language language = Language.findLanguageByID(ext.language);
+        if (language == null) {
+            return;
+        }
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            return;
+        }
+        boolean removed = fileAssociations.removeIf(association ->
+                definition.equals(association.getServerDefinition())
+                        && language.equals(association.getLanguage()));
+        if (removed) {
+            // Drop the per-language ref inside the def too — otherwise it pins the plugin's Language.
+            definition.unregisterAssociation(language);
+            updateLanguages();
+            notifyMappingsChanged(definition);
+        }
+    }
+
+    private void handleFileTypeMappingAdded(@NotNull FileTypeMappingExtensionPointBean ext) {
+        FileType fileType = FileTypeManager.getInstance().findFileTypeByName(ext.fileType);
+        if (fileType == null) {
+            return;
+        }
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            return;
+        }
+        var mapping = new ServerFileTypeMapping(fileType, ext.serverId, ext.languageId, ext.getDocumentMatcher());
+        registerAssociation(definition, mapping);
+        updateLanguages();
+        notifyMappingsChanged(definition);
+    }
+
+    private void handleFileTypeMappingRemoved(@NotNull FileTypeMappingExtensionPointBean ext) {
+        FileType fileType = FileTypeManager.getInstance().findFileTypeByName(ext.fileType);
+        if (fileType == null) {
+            return;
+        }
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            return;
+        }
+        boolean removed = fileAssociations.removeIf(association ->
+                definition.equals(association.getServerDefinition())
+                        && fileType.equals(association.getFileType()));
+        if (removed) {
+            definition.unregisterAssociation(fileType);
+            updateLanguages();
+            notifyMappingsChanged(definition);
+        }
+    }
+
+    private void handleFileNamePatternMappingAdded(@NotNull FileNamePatternMappingExtensionPointBean ext) {
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            return;
+        }
+        List<String> patterns = Arrays.asList(ext.patterns.split(";"));
+        var mapping = new ServerFileNamePatternMapping(patterns, ext.serverId, ext.languageId, ext.getDocumentMatcher());
+        registerAssociation(definition, mapping);
+        updateLanguages();
+        notifyMappingsChanged(definition);
+    }
+
+    private void handleFileNamePatternMappingRemoved(@NotNull FileNamePatternMappingExtensionPointBean ext) {
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            return;
+        }
+        List<String> patterns = Arrays.asList(ext.patterns.split(";"));
+        // Set equality (not anyMatch on individual patterns) so overlapping pattern sets don't co-remove.
+        Set<String> targetPatternSet = Set.copyOf(patterns);
+        boolean removed = fileAssociations.removeIf(association -> {
+            if (!definition.equals(association.getServerDefinition())) return false;
+            var matchers = association.getFileNameMatchers();
+            if (matchers == null) return false;
+            Set<String> associationPatterns = matchers.stream()
+                    .map(FileNameMatcher::getPresentableString)
+                    .collect(Collectors.toUnmodifiableSet());
+            return associationPatterns.equals(targetPatternSet);
+        });
+        if (removed) {
+            definition.unregisterFileNamePatternAssociation(targetPatternSet, ext.languageId);
+            if (ext.languageId != null) {
+                List<String> languageExtensions = languageIdFileExtensionsCache.get(ext.languageId);
+                if (languageExtensions != null) {
+                    List<String> extensions = patterns.stream()
+                            .map(p -> {
+                                int idx = p.indexOf('.');
+                                return idx != -1 ? p.substring(idx + 1) : p;
+                            })
+                            .toList();
+                    languageExtensions.removeAll(extensions);
+                    if (languageExtensions.isEmpty()) {
+                        languageIdFileExtensionsCache.remove(ext.languageId);
+                    }
+                }
+            }
+            updateLanguages();
+            notifyMappingsChanged(definition);
+        }
+    }
+
+    private void handleSemanticTokensColorsProviderAdded(@NotNull SemanticTokensColorsProviderExtensionPointBean ext) {
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            return;
+        }
+        try {
+            definition.setSemanticTokensColorsProvider(ext.getSemanticTokensColorsProvider());
+        } catch (Exception e) {
+            LOGGER.warn("Error while creating custom semanticTokensColorsProvider for server id='{}'.", ext.serverId, e);
+        }
+    }
+
+    private void handleSemanticTokensColorsProviderRemoved(@NotNull SemanticTokensColorsProviderExtensionPointBean ext) {
+        LanguageServerDefinition definition = serverDefinitions.get(ext.serverId);
+        if (definition == null) {
+            return;
+        }
+        // Prefer any surviving provider for this server before falling back to the default.
+        for (var stExt : SemanticTokensColorsProviderExtensionPointBean.EP_NAME.getExtensions()) {
+            if (stExt == ext) {
+                continue;
+            }
+            if (ext.serverId.equals(stExt.serverId)) {
+                try {
+                    definition.setSemanticTokensColorsProvider(stExt.getSemanticTokensColorsProvider());
+                    return;
+                } catch (Exception e) {
+                    LOGGER.warn("Error while creating custom semanticTokensColorsProvider for server id='{}'.", stExt.serverId, e);
+                }
+            }
+        }
+        definition.setSemanticTokensColorsProvider(LanguageServerDefinition.DEFAULT_SEMANTIC_TOKENS_COLORS_PROVIDER);
+    }
+
+    private @NotNull List<ServerMapping> collectMappingsFromExtensionPoints(@NotNull String serverId) {
+        List<ServerMapping> result = new ArrayList<>();
+        for (var ext : LanguageMappingExtensionPointBean.EP_NAME.getExtensions()) {
+            if (!serverId.equals(ext.serverId)) continue;
+            Language language = Language.findLanguageByID(ext.language);
+            if (language != null) {
+                result.add(new ServerLanguageMapping(language, serverId, ext.languageId, ext.getDocumentMatcher()));
+            }
+        }
+        for (var ext : FileTypeMappingExtensionPointBean.EP_NAME.getExtensions()) {
+            if (!serverId.equals(ext.serverId)) continue;
+            FileType fileType = FileTypeManager.getInstance().findFileTypeByName(ext.fileType);
+            if (fileType != null) {
+                result.add(new ServerFileTypeMapping(fileType, serverId, ext.languageId, ext.getDocumentMatcher()));
+            }
+        }
+        for (var ext : FileNamePatternMappingExtensionPointBean.EP_NAME.getExtensions()) {
+            if (!serverId.equals(ext.serverId)) continue;
+            List<String> patterns = Arrays.asList(ext.patterns.split(";"));
+            result.add(new ServerFileNamePatternMapping(patterns, serverId, ext.languageId, ext.getDocumentMatcher()));
+        }
+        return result;
+    }
+
+    private void notifyServerAdded(@NotNull Collection<LanguageServerDefinition> definitions) {
+        for (Project project : ProjectManager.getInstance().getOpenProjects()) {
+            var event = new LanguageServerDefinitionListener.LanguageServerAddedEvent(project, definitions);
+            for (LanguageServerDefinitionListener listener : this.listeners) {
+                try {
+                    listener.handleAdded(event);
+                } catch (Exception e) {
+                    LOGGER.error("Error while notifying server added", e);
+                }
+            }
+        }
+    }
+
+    private void notifyServerRemoved(@NotNull Collection<LanguageServerDefinition> definitions) {
+        for (Project project : ProjectManager.getInstance().getOpenProjects()) {
+            var event = new LanguageServerDefinitionListener.LanguageServerRemovedEvent(project, definitions);
+            for (LanguageServerDefinitionListener listener : this.listeners) {
+                try {
+                    listener.handleRemoved(event);
+                } catch (Exception e) {
+                    LOGGER.error("Error while notifying server removed", e);
+                }
+            }
+        }
+    }
+
+    private void notifyMappingsChanged(@NotNull LanguageServerDefinition definition) {
+        for (Project project : ProjectManager.getInstance().getOpenProjects()) {
+            var event = new LanguageServerDefinitionListener.LanguageServerChangedEvent(
+                    LanguageServerDefinitionListener.LanguageServerDefinitionEvent.UpdatedBy.USER,
+                    project,
+                    definition,
+                    /* nameChanged */ false,
+                    /* commandChanged */ false,
+                    /* userEnvironmentVariablesChanged */ false,
+                    /* includeSystemEnvironmentVariablesChanged */ false,
+                    /* mappingsChanged */ true,
+                    /* clientConfigurationContentChanged */ false,
+                    /* installerConfigurationContentChanged */ false);
+            handleChangeEvent(event);
+        }
     }
 
     public LanguageServerDefinitionListener.@Nullable LanguageServerChangedEvent updateServerDefinition(@NotNull UpdateServerDefinitionRequest request,

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/indexing/ProjectIndexingDumbAndScanningStrategy.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/indexing/ProjectIndexingDumbAndScanningStrategy.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.client.indexing;
 
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.Topic;
@@ -42,7 +43,7 @@ import java.lang.reflect.Proxy;
  * </p>
  */
 @ApiStatus.Internal
-public class ProjectIndexingDumbAndScanningStrategy extends ProjectIndexingStrategyBase {
+public class ProjectIndexingDumbAndScanningStrategy extends ProjectIndexingStrategyBase implements Disposable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProjectIndexingDumbAndScanningStrategy.class);
 
@@ -99,14 +100,17 @@ public class ProjectIndexingDumbAndScanningStrategy extends ProjectIndexingStrat
             getTopicMethod.setAccessible(true);
             Topic topicInstance = (Topic) getTopicMethod.invoke(companionInstance);
 
-            // Subscribe the proxyInstance with the topicInstance
-            //ApplicationManager.getApplication().getMessageBus().connect(ProjectIndexingActivityHistoryListener.Companion.getTOPIC(), proxyInstance)
-            ApplicationManager.getApplication().getMessageBus().connect().subscribe(topicInstance, proxyInstance);
+            // Subscribe the proxyInstance with the topicInstance.
+            ApplicationManager.getApplication().getMessageBus().connect(this).subscribe(topicInstance, proxyInstance);
 
             enabled = true;
         } catch (Exception e) {
             LOGGER.error("Error while initializing ProjectIndexingDumbAndScanningStrategy", e);
         }
+    }
+
+    @Override
+    public void dispose() {
     }
 
     private @Nullable Project getProject(Object[] args) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/installation/definition/InstallerTaskRegistry.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/installation/definition/InstallerTaskRegistry.java
@@ -18,8 +18,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.StringReader;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Installer task registry.
@@ -34,14 +34,18 @@ public class InstallerTaskRegistry {
     private static final @NotNull String TASK_REF_JSON_PROPERTY = "ref";
 
 
-    private final @NotNull Map<String, InstallerTaskFactory> factories;
+    // Concurrent: EP listener callbacks mutate this on arbitrary threads, readers run on background tasks.
+    private final @NotNull Map<String, InstallerTaskFactory> factories = new ConcurrentHashMap<>();
 
     public InstallerTaskRegistry() {
-        factories = new HashMap<>();
     }
 
     public void registerFactory(String type, InstallerTaskFactory factory) {
         factories.put(type, factory);
+    }
+
+    public void unregisterFactory(String type) {
+        factories.remove(type);
     }
 
     public @NotNull ServerInstallerDescriptor loadInstaller(@NotNull String json) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/installation/definition/ServerInstallerManager.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/installation/definition/ServerInstallerManager.java
@@ -14,13 +14,18 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.extensions.ExtensionPointListener;
+import com.intellij.openapi.extensions.PluginDescriptor;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.redhat.devtools.lsp4ij.ServerMessageHandler;
 import com.redhat.devtools.lsp4ij.installation.PrintableProgressIndicator;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manages the installation of Language Servers(LSP) and Debug Adapter Protocol (DAP) servers
@@ -38,18 +43,44 @@ import org.jetbrains.annotations.NotNull;
  * {@link #getInstance()}.
  * </p>
  */
-public class ServerInstallerManager extends InstallerTaskRegistry {
+public class ServerInstallerManager extends InstallerTaskRegistry implements Disposable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServerInstallerManager.class);
 
     private ServerInstallerManager() {
         super();
         var beans = InstallerTaskFactoryPointBean.EP_NAME.getExtensions();
         for (InstallerTaskFactoryPointBean bean : beans) {
-            try {
-                super.registerFactory(bean.type, bean.getInstance());
-            } catch (Exception e) {
-                // Do nothing
-            }
+            registerFactoryFromBean(bean);
         }
+        InstallerTaskFactoryPointBean.EP_NAME.getPoint().addExtensionPointListener(
+                new ExtensionPointListener<>() {
+                    @Override
+                    public void extensionAdded(@NotNull InstallerTaskFactoryPointBean bean,
+                                               @NotNull PluginDescriptor pluginDescriptor) {
+                        registerFactoryFromBean(bean);
+                    }
+
+                    @Override
+                    public void extensionRemoved(@NotNull InstallerTaskFactoryPointBean bean,
+                                                 @NotNull PluginDescriptor pluginDescriptor) {
+                        unregisterFactory(bean.type);
+                    }
+                },
+                /* invokeForLoadedExtensions */ false,
+                /* parentDisposable */ this);
+    }
+
+    private void registerFactoryFromBean(@NotNull InstallerTaskFactoryPointBean bean) {
+        try {
+            registerFactory(bean.type, bean.getInstance());
+        } catch (Exception e) {
+            LOGGER.warn("Failed to instantiate installerTaskFactory for type='{}'", bean.type, e);
+        }
+    }
+
+    @Override
+    public void dispose() {
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/server/definition/LanguageServerDefinition.java
@@ -42,6 +42,7 @@ import javax.swing.Icon;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -52,7 +53,8 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
 
     private static final int DEFAULT_LAST_DOCUMENTED_DISCONNECTED_TIMEOUT = 5;
 
-    private static final SemanticTokensColorsProvider DEFAULT_SEMANTIC_TOKENS_COLORS_PROVIDER = new DefaultSemanticTokensColorsProvider();
+    @ApiStatus.Internal
+    public static final SemanticTokensColorsProvider DEFAULT_SEMANTIC_TOKENS_COLORS_PROVIDER = new DefaultSemanticTokensColorsProvider();
 
     private final @NotNull String id;
     private final @NotNull String name;
@@ -187,6 +189,30 @@ public abstract class LanguageServerDefinition implements LanguageServerFactory,
 
     public void registerAssociation(List<FileNameMatcher> matchers, String languageId) {
         this.languageIdFileNameMatcherMappings.add(Pair.create(matchers, languageId));
+    }
+
+    @ApiStatus.Internal
+    public void unregisterAssociation(@NotNull Language language) {
+        this.languageIdLanguageMappings.remove(language);
+    }
+
+    @ApiStatus.Internal
+    public void unregisterAssociation(@NotNull FileType fileType) {
+        this.languageIdFileTypeMappings.remove(fileType);
+    }
+
+    @ApiStatus.Internal
+    public void unregisterFileNamePatternAssociation(@NotNull Set<String> presentablePatterns,
+                                                     @Nullable String languageId) {
+        this.languageIdFileNameMatcherMappings.removeIf(p -> {
+            if (!java.util.Objects.equals(p.getSecond(), languageId)) {
+                return false;
+            }
+            Set<String> existing = p.getFirst().stream()
+                    .map(FileNameMatcher::getPresentableString)
+                    .collect(java.util.stream.Collectors.toUnmodifiableSet());
+            return existing.equals(presentablePatterns);
+        });
     }
 
     public Map<Language, String> getLanguageMappings() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -324,7 +324,8 @@
         <!-- Installer task factory -->
         <extensionPoint
                 name="installerTaskFactory"
-                beanClass="com.redhat.devtools.lsp4ij.installation.definition.InstallerTaskFactoryPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.installation.definition.InstallerTaskFactoryPointBean"
+                dynamic="true">
             <with attribute="factoryClass"
                   implements="com.redhat.devtools.lsp4ij.installation.definition.InstallerTaskFactory"/>
         </extensionPoint>
@@ -361,31 +362,36 @@
         <!-- Language server extension point -->
         <extensionPoint
                 name="server"
-                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.ServerExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.ServerExtensionPointBean"
+                dynamic="true">
             <with attribute="factoryClass" implements="com.redhat.devtools.lsp4ij.LanguageServerFactory"/>
         </extensionPoint>
 
         <!-- Language server mappings extension point -->
         <extensionPoint
                 name="languageMapping"
-                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.LanguageMappingExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.LanguageMappingExtensionPointBean"
+                dynamic="true">
             <with attribute="documentMatcher" implements="com.redhat.devtools.lsp4ij.DocumentMatcher"/>
         </extensionPoint>
         <extensionPoint
                 name="fileTypeMapping"
-                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.FileTypeMappingExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.FileTypeMappingExtensionPointBean"
+                dynamic="true">
             <with attribute="documentMatcher" implements="com.redhat.devtools.lsp4ij.DocumentMatcher"/>
         </extensionPoint>
         <extensionPoint
                 name="fileNamePatternMapping"
-                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.FileNamePatternMappingExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.FileNamePatternMappingExtensionPointBean"
+                dynamic="true">
             <with attribute="documentMatcher" implements="com.redhat.devtools.lsp4ij.DocumentMatcher"/>
         </extensionPoint>
 
         <!-- Semantic tokens colors provider extension point -->
         <extensionPoint
                 name="semanticTokensColorsProvider"
-                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.SemanticTokensColorsProviderExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.server.definition.extension.SemanticTokensColorsProviderExtensionPointBean"
+                dynamic="true">
             <with attribute="class"
                   implements="com.redhat.devtools.lsp4ij.features.semanticTokens.SemanticTokensColorsProvider"/>
         </extensionPoint>
@@ -1025,7 +1031,8 @@
         <!-- Debug adapter server extension point -->
         <extensionPoint
                 name="debugAdapterServer"
-                beanClass="com.redhat.devtools.lsp4ij.dap.definitions.extension.DebugAdapterServerExtensionPointBean">
+                beanClass="com.redhat.devtools.lsp4ij.dap.definitions.extension.DebugAdapterServerExtensionPointBean"
+                dynamic="true">
             <with attribute="factoryClass"
                   implements="com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptorFactory"/>
         </extensionPoint>


### PR DESCRIPTION
Allows LSP4IJ and plugins contributing LSP servers to load/unload at runtime without an IDE restart.

Notes:

  - Removing a `semanticTokensColorsProvider` resets the definition to the default provider so the unloading plugin's class is dropped.
  - `LanguageServerWrapper` executors now produce daemon threads with the context classloader pinned to the platform parent loader - required so worker threads don't pin the plugin classloader.
  - `dispose()` waits up to 2s per executor and warns on timeout; the warning is the signal of a classloader leak on unload.
  - `ServerInstallerManager`: factory instantiation failures are now logged instead of silently swallowed (separate from the unload work, but in the same touched code).