### PR TITLE
fix: replace Internal PluginManagerCore.getPlugin (since 2026.2 eap) with Manager.getInstance().findEnabledPlugin

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/descriptors/DebugAdapterDescriptorFactory.java
@@ -14,7 +14,7 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunConfigurationOptions;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
@@ -159,7 +159,7 @@ public abstract class DebugAdapterDescriptorFactory implements DebuggableFile {
 
     public static Path getDebugAdapterServerPath(@NotNull String pluginId,
                                                  @NotNull String serverPath) {
-        IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(PluginId.getId(pluginId));
+        IdeaPluginDescriptor descriptor = PluginManager.getInstance().findEnabledPlugin(PluginId.getId(pluginId));
         assert descriptor != null;
         Path pluginPath = descriptor.getPluginPath();
         assert pluginPath != null;

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyTextMateBundleProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/disassembly/DisassemblyTextMateBundleProvider.java
@@ -12,7 +12,7 @@
 package com.redhat.devtools.lsp4ij.dap.disassembly;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.textmate.api.TextMateBundleProvider;
@@ -48,7 +48,7 @@ public class DisassemblyTextMateBundleProvider implements TextMateBundleProvider
 
     private Path getBundlePath() {
         try {
-            IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId("com.redhat.devtools.lsp4ij"));
+            IdeaPluginDescriptor plugin = PluginManager.getInstance().findEnabledPlugin(PluginId.getId("com.redhat.devtools.lsp4ij"));
             String version = plugin.getVersion();
             String path = plugin.getPluginPath() + "/bundles/" + version;
             return copyResourceDirectory(path, List.of("package.json", "syntaxes/disassembly.json"));

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/runInTerminal/integrated/RunInIntegratedTerminalService.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/runInTerminal/integrated/RunInIntegratedTerminalService.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.dap.runInTerminal.integrated;
 
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.util.SystemInfo;
@@ -129,7 +129,7 @@ public class RunInIntegratedTerminalService implements RunInTerminalService {
     @Override
     public boolean isApplicable() {
         PluginId pluginId = PluginId.getId("org.jetbrains.plugins.terminal");
-        return PluginManagerCore.getPlugin(pluginId) != null;
+        return PluginManager.getInstance().findEnabledPlugin(pluginId) != null;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplate.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/launching/templates/LanguageServerTemplate.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.lsp4ij.launching.templates;
 
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.templates.ServerTemplate;
@@ -158,6 +158,6 @@ public class LanguageServerTemplate extends ServerTemplate {
 
     private static boolean isPluginInstalled(String pluginIdString) {
         PluginId pluginId = PluginId.getId(pluginIdString);
-        return PluginManagerCore.getPlugin(pluginId) != null;
+        return PluginManager.getInstance().findEnabledPlugin(pluginId) != null;
     }
 }


### PR DESCRIPTION
fix: replace Internal PluginManagerCore.getPlugin (since 2026.2 eap) with Manager.getInstance().findEnabledPlugin