### PR TITLE
fix: don't display hover for empty inlay hint

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsProvider.java
@@ -159,7 +159,7 @@ public class LSPInlayHintsProvider extends AbstractLSPDeclarativeInlayHintsProvi
             }
             index++;
         }
-        sink.addPresentation(position, null, tooltip.toString(), true, builder -> {
+        sink.addPresentation(position, null, hasTooltip ? tooltip.toString() : null, true, builder -> {
             for (var build: builds) {
                 build.accept(builder);
             }


### PR DESCRIPTION
fix: don't display hover for empty inlay hint