### PR TITLE
fix: LSP Console Mappings table is artificially short

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/LanguageServerPanel.java
@@ -277,7 +277,7 @@ public class LanguageServerPanel implements Disposable {
 
     private void addMappingsTab(@NotNull JBTabbedPane tabbedPane,
                                 @NotNull UIConfiguration configuration) {
-        FormBuilder mappingsTab = addTab(tabbedPane, LanguageServerBundle.message("language.server.tab.mappings"));
+        FormBuilder mappingsTab = addTab(tabbedPane, LanguageServerBundle.message("language.server.tab.mappings"), false);
         this.mappingsPanel = new ServerMappingsPanel(mappingsTab, configuration.isServerMappingsEditable());
     }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/ServerMappingsPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/settings/ui/ServerMappingsPanel.java
@@ -50,7 +50,7 @@ public class ServerMappingsPanel {
 
     private void createContent(@NotNull FormBuilder builder, boolean editable) {
         tabbedPane = new JBTabbedPane();
-        builder.addLabeledComponent(LanguageServerBundle.message("language.server.mappings.title"), tabbedPane, true);
+        builder.addLabeledComponentFillVertically(LanguageServerBundle.message("language.server.mappings.title"), tabbedPane);
 
         // Language mappings
         createLanguageMappingsContent(tabbedPane, editable);


### PR DESCRIPTION
fix: LSP Console Mappings table is artificially short

Fixes #1517