### PR TITLE
fix: cancel LSP future only when Psi file change content

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
@@ -31,6 +31,7 @@ import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.client.features.LSPCompletionFeature;
 import com.redhat.devtools.lsp4ij.client.features.LSPCompletionProposal;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.NotNull;
@@ -75,16 +76,17 @@ public class LSPCompletionContributor extends CompletionContributor {
                 offset,
                 autoPopup ? getCompletionChar(offset, document) : null,
                 autoPopup);
-        CompletableFuture<List<CompletionData>> future = LSPFileSupport.getSupport(psiFile)
-                .getCompletionSupport()
-                .getCompletions(params);
+        var completionSupport = LSPFileSupport.getSupport(psiFile)
+                .getCompletionSupport();
+        CompletableFuture<List<CompletionData>> future = completionSupport.getCompletions(params);
         try {
             // Wait until the future is finished and stop the wait if there are some ProcessCanceledException.
             waitUntilDone(future, psiFile);
-        } catch (
-                ProcessCanceledException ignore) {//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            return;
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/completion requests.
+            completionSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
         } catch (CancellationException ignore) {
             return;
         } catch (ExecutionException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
@@ -19,6 +19,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -54,12 +55,12 @@ public class LSPGoToDeclarationAction extends AbstractLSPGoToAction {
         CompletableFuture<List<LocationData>> declarationsFuture = declarationSupport.getDeclarations(params);
         try {
             waitUntilDone(declarationsFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests textDocument/declaration
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/declaration requests.
             declarationSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/declaration
-            declarationSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/declaration' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkAnnotator.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkAnnotator.java
@@ -28,6 +28,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.client.ExecuteLSPFeatureStatus;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPExternalAnnotator;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.jetbrains.annotations.NotNull;
@@ -69,14 +70,12 @@ public class LSPDocumentLinkAnnotator extends AbstractLSPExternalAnnotator<List<
         CompletableFuture<List<DocumentLinkData>> documentLinkFuture = documentLinkSupport.getDocumentLinks(params);
         try {
             waitUntilDone(documentLinkFuture, psiFile);
-        } catch (ProcessCanceledException e) {//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/documentLink requests.
             documentLinkSupport.cancel();
-            return null;
-        } catch (CancellationException e) {
-            // cancel the LSP requests textDocument/documentLink
-            documentLinkSupport.cancel();
-            return null;
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/documentLink' request", e);
             return null;

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
@@ -26,15 +26,20 @@ import com.intellij.util.ArrayUtil;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.documentSymbol.filter.*;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
 import static com.redhat.devtools.lsp4ij.features.documentSymbol.LSPDocumentSymbolStructureViewFactory.isSymbolsSupportedByLanguageServer;
@@ -45,6 +50,8 @@ import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.waitUntilDo
  * LSP document symbol structure view model.
  */
 public class LSPDocumentSymbolStructureViewModel extends StructureViewModelBase implements StructureViewModel.ElementInfoProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LSPDocumentSymbolStructureViewModel.class);
 
     public LSPDocumentSymbolStructureViewModel(@NotNull PsiFile psiFile, @Nullable Editor editor) {
         super(psiFile, editor, new LSPFileStructureViewElement(psiFile));
@@ -174,12 +181,17 @@ public class LSPDocumentSymbolStructureViewModel extends StructureViewModelBase 
             LSPDocumentSymbolSupport documentSymbolSupport = fileSupport.getDocumentSymbolSupport();
             var params = new DocumentSymbolParams(new TextDocumentIdentifier());
             var documentSymbolFuture = documentSymbolSupport.getDocumentSymbols(params);
+
             try {
                 waitUntilDone(documentSymbolFuture, psiFile);
+            } catch (PsiFileChangedException e) {
+                // The file content has changed, cancel the LSP textDocument/documentSymbol requests.
+                documentSymbolSupport.cancel();
             } catch (ProcessCanceledException e) {
                 throw e;
-            } catch (Exception e) {
-                return Collections.emptyList();
+            } catch (CancellationException ignore) {
+            } catch (ExecutionException e) {
+                LOGGER.error("Error while consuming LSP 'textDocument/documentSymbol' request", e);
             }
 
             if (isDoneNormally(documentSymbolFuture)) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTargetProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTargetProvider.java
@@ -23,6 +23,7 @@ import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.client.ExecuteLSPFeatureStatus;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.Range;
@@ -75,13 +76,14 @@ public class LSPDocumentationTargetProvider implements DocumentationTargetProvid
 
         try {
             waitUntilDone(hoverFuture, psiFile);
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/hover requests.
+            hoverSupport.cancel();
         } catch (ProcessCanceledException e) {
-            // cancel the LSP requests textDocument/hover
-            hoverSupport.cancel();
-        } catch (CancellationException e) {
-            // cancel the LSP requests textDocument/hover
-            hoverSupport.cancel();
-        } catch (ExecutionException e) {
+            throw e;
+        } catch (CancellationException ignore) {
+        }
+        catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/hover' request", e);
         }
 

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
@@ -22,6 +22,7 @@ import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -58,10 +59,7 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
         CompletableFuture<List<? extends TextEdit>> formatFuture = this.getFeatureData(params);
         try {
             waitUntilDone(formatFuture, getFile());
-        } catch (
-                ProcessCanceledException e) {//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            //handleError(formattingRequest, e);
+        } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {
             // cancel the LSP requests textDocument/formatting / textDocument/rangeFormatting
@@ -83,7 +81,7 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
 
     private static void handleError(@NotNull AsyncFormattingRequest formattingRequest,
                                     @NotNull Throwable error) {
-        if (error instanceof ProcessCanceledException || error instanceof CancellationException) {
+        if (error instanceof CancellationException) {
             // Ignore the error
             formattingRequest.onTextReady(formattingRequest.getDocumentText());
         } else {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
@@ -19,6 +19,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -54,12 +55,12 @@ public class LSPGoToImplementationAction extends AbstractLSPGoToAction {
         CompletableFuture<List<LocationData>> implementationsFuture = implementationSupport.getImplementations(params);
         try {
             waitUntilDone(implementationsFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests textDocument/implementation
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/implementation requests.
             implementationSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/implementation
-            implementationSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/implementation' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPGotoDeclarationHandler.java
@@ -28,6 +28,7 @@ import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServersRegistry;
 import com.redhat.devtools.lsp4ij.features.semanticTokens.viewProvider.LSPSemanticTokensFileViewProvider;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -146,12 +147,12 @@ public class LSPGotoDeclarationHandler implements GotoDeclarationHandler {
         CompletableFuture<List<LocationData>> definitionsFuture = definitionSupport.getDefinitions(params);
         try {
             waitUntilDone(definitionsFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests textDocument/definition
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/definition requests.
             definitionSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/definition
-            definitionSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/definition' request", e);
         }
@@ -188,8 +189,8 @@ public class LSPGotoDeclarationHandler implements GotoDeclarationHandler {
      * @return true if the target is at the same location as the source, false otherwise
      */
     private static boolean isAlreadyAtDeclaration(@NotNull PsiElement target,
-                                                    @NotNull PsiFile sourcePsiFile,
-                                                    int sourceOffset) {
+                                                  @NotNull PsiFile sourcePsiFile,
+                                                  int sourceOffset) {
         // Get the file containing the target element
         PsiFile targetFile = target.getContainingFile();
         if (targetFile == null) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
@@ -19,6 +19,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -54,12 +55,12 @@ public class LSPGoToReferenceAction extends AbstractLSPGoToAction {
         CompletableFuture<List<LocationData>> referencesFuture = referenceSupport.getReferences(params);
         try {
             waitUntilDone(referencesFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests textDocument/references
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/references requests.
             referenceSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/references
-            referenceSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/references' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPSelectionRangeSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPSelectionRangeSupport.java
@@ -22,6 +22,7 @@ import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SelectionRange;
@@ -76,14 +77,12 @@ public class LSPSelectionRangeSupport extends AbstractLSPDocumentFeatureSupport<
         CompletableFuture<List<SelectionRange>> selectionRangesFuture = selectionRangeSupport.getSelectionRanges(params);
         try {
             waitUntilDone(selectionRangesFuture, file, timeout);
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/documentColor requests.
+            selectionRangeSupport.cancel();
         } catch (ProcessCanceledException e) {
-            //Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
-            selectionRangeSupport.cancel();
-            return Collections.emptyList();
-        } catch (CancellationException e) {
-            // cancel the LSP requests textDocument/selectionRanges
-            selectionRangeSupport.cancel();
+            throw e;
+        } catch (CancellationException ignore) {
             return Collections.emptyList();
         } catch (TimeoutException e) {
             // Ignore timeout error

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
@@ -222,7 +222,7 @@ public class LSPSemanticTokensHighlightVisitor implements HighlightVisitor {
         } catch (CancellationException e) {
             // The CompletableFuture itself was cancelled (e.g. the file was closed,
             // or the language server shut down). Nothing to do — propagate as-is.
-            throw e;
+            return null;
         }
 
         // Primary staleness check: if the file was modified while we were waiting,

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPParameterInfoHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPParameterInfoHandler.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -105,10 +106,12 @@ public class LSPParameterInfoHandler implements ParameterInfoHandler<LSPSignatur
         try {
             // Wait until the future is finished and stop the wait if there are some ProcessCanceledException.
             waitUntilDone(future, psiElement.getContainingFile());
-        } catch (ProcessCanceledException ignore) {//Since 2024.2 ProcessCanceledException extends CancellationException so we can't use multicatch to keep backward compatibility
-            //TODO delete block when minimum required version is 2024.2
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/signatureHelp requests.
+            signatureHelpSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
         } catch (CancellationException ignore) {
-            // Do nothing
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/signatureHelp' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
@@ -19,6 +19,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerBundle;
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPGoToAction;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -54,12 +55,12 @@ public class LSPGoToTypeDefinitionAction extends AbstractLSPGoToAction {
         CompletableFuture<List<LocationData>> typeDefinitionsFuture = typeDefinitionSupport.getTypeDefinitions(params);
         try {
             waitUntilDone(typeDefinitionsFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests textDocument/typeDefinition
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/typeDefinition requests.
             typeDefinitionSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/typeDefinition
-            typeDefinitionSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/typeDefinition' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySubtypesTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySubtypesTreeStructure.java
@@ -17,6 +17,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyNodeDescriptor;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.lsp4j.TypeHierarchySubtypesParams;
 import org.jetbrains.annotations.NotNull;
@@ -53,12 +54,12 @@ public class LSPTypeHierarchySubtypesTreeStructure extends LSPTypeHierarchyTreeS
         CompletableFuture<List<TypeHierarchyItemData>> prepareTypeHierarchyFuture = typeHierarchySubtypesSupport.getTypeHierarchySubtypes(params);
         try {
             waitUntilDone(prepareTypeHierarchyFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests typeHierarchy/subtypes
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP typeHierarchy/subtypes requests.
             typeHierarchySubtypesSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests typeHierarchy/subtypes
-            typeHierarchySubtypesSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'typeHierarchy/subtypes' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySupertypesTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySupertypesTreeStructure.java
@@ -17,6 +17,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyNodeDescriptor;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.lsp4j.TypeHierarchySupertypesParams;
 import org.jetbrains.annotations.NotNull;
@@ -53,12 +54,12 @@ public class LSPTypeHierarchySupertypesTreeStructure extends LSPTypeHierarchyTre
         CompletableFuture<List<TypeHierarchyItemData>> prepareTypeHierarchyFuture = typeHierarchySupertypesSupport.getTypeHierarchySupertypes(params);
         try {
             waitUntilDone(prepareTypeHierarchyFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests typeHierarchy/supertypes
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP typeHierarchy/supertypes requests.
             typeHierarchySupertypesSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests typeHierarchy/supertypes
-            typeHierarchySupertypesSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'typeHierarchy/supertypes' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
@@ -21,6 +21,7 @@ import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyNodeDescriptor;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyTreeStructureBase;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.jetbrains.annotations.NotNull;
@@ -67,12 +68,12 @@ public abstract class LSPTypeHierarchyTreeStructureBase extends LSPHierarchyTree
         CompletableFuture<List<TypeHierarchyItemData>> prepareTypeHierarchyFuture = prepareTypeHierarchySupport.getPrepareTypeHierarchies(params);
         try {
             waitUntilDone(prepareTypeHierarchyFuture, psiFile);
-        } catch (ProcessCanceledException ex) {
-            // cancel the LSP requests textDocument/prepareTypeHierarchy
+        } catch (PsiFileChangedException e) {
+            // The file content has changed, cancel the LSP textDocument/prepareTypeHierarchy requests.
             prepareTypeHierarchySupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/prepareTypeHierarchy
-            prepareTypeHierarchySupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException ignore) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/prepareTypeHierarchy' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
@@ -28,6 +28,7 @@ import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.LSPPsiElementFactory;
 import com.redhat.devtools.lsp4ij.features.implementation.LSPImplementationParams;
 import com.redhat.devtools.lsp4ij.features.implementation.LSPImplementationSupport;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.ui.LSP4IJUiUtils;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -35,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -99,12 +101,12 @@ public class LSPWorkspaceImplementationsSearch extends QueryExecutorBase<PsiElem
         CompletableFuture<List<LocationData>> implementationsFuture = implementationSupport.getImplementations(params);
         try {
             waitUntilDone(implementationsFuture, file);
-        } catch (ProcessCanceledException ex) {
+        } catch (PsiFileChangedException e) {
             // cancel the LSP requests textDocument/implementation
             implementationSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/implementation
-            implementationSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException e) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/implementation' request", e);
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceTypeDeclarationProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceTypeDeclarationProvider.java
@@ -28,6 +28,7 @@ import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.LSPPsiElementFactory;
 import com.redhat.devtools.lsp4ij.features.typeDefinition.LSPTypeDefinitionParams;
 import com.redhat.devtools.lsp4ij.features.typeDefinition.LSPTypeDefinitionSupport;
+import com.redhat.devtools.lsp4ij.internal.PsiFileChangedException;
 import com.redhat.devtools.lsp4ij.ui.LSP4IJUiUtils;
 import com.redhat.devtools.lsp4ij.usages.LocationData;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -93,12 +94,12 @@ public class LSPWorkspaceTypeDeclarationProvider implements TypeDeclarationPlace
         CompletableFuture<List<LocationData>> typeDefinitionsFuture = typeDefinitionSupport.getTypeDefinitions(params);
         try {
             waitUntilDone(typeDefinitionsFuture, file);
-        } catch (ProcessCanceledException ex) {
+        } catch (PsiFileChangedException e) {
             // cancel the LSP requests textDocument/typeDefinition
             typeDefinitionSupport.cancel();
-        } catch (CancellationException ex) {
-            // cancel the LSP requests textDocument/typeDefinition
-            typeDefinitionSupport.cancel();
+        } catch (ProcessCanceledException e) {
+            throw e;
+        } catch (CancellationException e) {
         } catch (ExecutionException e) {
             LOGGER.error("Error while consuming LSP 'textDocument/typeDefinition' request", e);
         }


### PR DESCRIPTION
fix: cancel LSP future only when Psi file change content