### PR TITLE
fix: defer ServerStatus.stopping until grace period expires

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -633,9 +633,9 @@ public class LanguageServerWrapper implements Disposable {
     }
 
     private void startStopTimer() {
-        updateStatus(ServerStatus.stopping);
         int delayMs = (int) TimeUnit.SECONDS.toMillis(serverDefinition.getLastDocumentDisconnectedTimeout());
         getStopAlarm().addRequest(() -> {
+            updateStatus(ServerStatus.stopping);
             try {
                 stop();
             } catch (Throwable t) {


### PR DESCRIPTION
startStopTimer() was setting ServerStatus.stopping immediately when the lastDocumentDisconnectedTimeout timer started, not when the server actually began shutting down. This caused the LSP console to display "stopping pid:..." with a spinner for the entire grace period, even though the server was still fully functional and accepting connections. With the default 5-second timeout this was barely noticeable, but with longer timeouts (e.g. 180s for expensive-to-start servers) the UI was misleading — users could think the server was broken or unresponsive. Move updateStatus(ServerStatus.stopping) inside the alarm callback, just before stop(). The server now stays in 'started' status during the grace period and only transitions to 'stopping' when shutdown actually begins.

FIX=#1553