### PR TITLE
fix: Show all codeaction (and not only the first)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionAction.java
@@ -40,8 +40,8 @@ public abstract class LSPIntentionAction extends LSPLazyCodeActionIntentionActio
      * This method is invoked frequently as the user moves the caret or edits the file.
      *
      * @param project the current project
-     * @param editor the current editor
-     * @param file the current PSI file
+     * @param editor  the current editor
+     * @param file    the current PSI file
      * @return true if the intention is available at the current caret position
      */
     @Override
@@ -56,14 +56,8 @@ public abstract class LSPIntentionAction extends LSPLazyCodeActionIntentionActio
 
         // Create parameters for the current caret position/selection
         CodeActionParams params = createCodeActionParams(editor, file);
-
-        // Only trigger a new textDocument/codeAction request if the position changed
-        // This optimization avoids redundant LSP calls when IntelliJ polls isAvailable() multiple times
-        if (intentionCodeActionSupport.hasChanged(params)) {
-            super.setLazyCodeActions(intentionCodeActionSupport);
-            intentionCodeActionSupport.getCodeActions(params);
-        }
-
+        super.setLazyCodeActions(intentionCodeActionSupport);
+        intentionCodeActionSupport.getCodeActions(params);
         // Delegate to parent to check if the specific code action at this index is available
         return super.isAvailable(project, editor, file);
     }
@@ -73,7 +67,7 @@ public abstract class LSPIntentionAction extends LSPLazyCodeActionIntentionActio
      * These parameters are used for the textDocument/codeAction request.
      *
      * @param editor the editor containing the caret position
-     * @param file the PSI file being edited
+     * @param file   the PSI file being edited
      * @return the LSP code action parameters with range, context, and document identifier
      */
     private static CodeActionParams createCodeActionParams(@NotNull Editor editor,

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionCodeActionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionCodeActionSupport.java
@@ -145,33 +145,31 @@ public class LSPIntentionCodeActionSupport extends AbstractLSPDocumentFeatureSup
      */
     @Override
     public @Nullable Either<CodeActionData, Boolean> getCodeActionAt(int index) {
+        var future = super.getValidLSPFuture();
         // This method is called by IntelliJ when checking if intentions (light bulb) should be displayed.
         // We must NOT block the EDT, as it would freeze the UI.
         // See: https://github.com/redhat-developer/lsp4ij/issues/1545
-        if (EDT.isCurrentThreadEdt()) {
-            return null;
-        }
-
-        // Wait for the textDocument/codeAction LSP request to complete.
-        // waitUntilDone() will:
-        // - Poll in 25ms increments without blocking continuously
-        // - Check for cancellation via ProgressManager
-        // - Detect if the PSI file was modified during the wait
-        // - Display a progress indicator if it takes more than 5 seconds
-        var future = super.getValidLSPFuture();
-        try {
-            waitUntilDone(future, super.getFile());
-        } catch (PsiFileChangedException e) {
-            // The file was modified while waiting - cancel the now-obsolete LSP request
-            cancel();
-        } catch (ProcessCanceledException e) {
-            // User or IDE canceled the operation - propagate the cancellation
-            throw e;
-        } catch (CancellationException e) {
-            return null;
-        } catch (ExecutionException e) {
-            LOGGER.error("Error while consuming LSP 'textDocument/codeAction' request", e);
-            return null;
+        if (!EDT.isCurrentThreadEdt()) {
+            // Wait for the textDocument/codeAction LSP request to complete.
+            // waitUntilDone() will:
+            // - Poll in 25ms increments without blocking continuously
+            // - Check for cancellation via ProgressManager
+            // - Detect if the PSI file was modified during the wait
+            // - Display a progress indicator if it takes more than 5 seconds
+            try {
+                waitUntilDone(future, super.getFile());
+            } catch (PsiFileChangedException e) {
+                // The file was modified while waiting - cancel the now-obsolete LSP request
+                cancel();
+            } catch (ProcessCanceledException e) {
+                // User or IDE canceled the operation - propagate the cancellation
+                throw e;
+            } catch (CancellationException e) {
+                return null;
+            } catch (ExecutionException e) {
+                LOGGER.error("Error while consuming LSP 'textDocument/codeAction' request", e);
+                return null;
+            }
         }
 
         if (isDoneNormally(future)) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/quickfix/LSPLazyCodeActions.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/quickfix/LSPLazyCodeActions.java
@@ -168,7 +168,7 @@ public class LSPLazyCodeActions implements LSPLazyCodeActionProvider {
                                                         CodeAction codeAction = ca.getRight();
                                                         return codeAction.getKind() == null ||
                                                                 codeAction.getKind().isEmpty() ||
-                                                                CodeActionKind.QuickFix.equals(codeAction.getKind());
+                                                                codeAction.getKind().startsWith(CodeActionKind.QuickFix);
                                                     }
                                                     return true;
                                                 })


### PR DESCRIPTION
fix: Show all codeaction (and not only the first)

See https://github.com/redhat-developer/lsp4ij/issues/1545#issuecomment-4537109761