### PR TITLE
fix: 'Docker: Dockerfile Build Debugging' template broken on Windows

### DIFF
--- a/src/main/resources/templates/dap/buildx-dockerfile/template.json
+++ b/src/main/resources/templates/dap/buildx-dockerfile/template.json
@@ -2,6 +2,7 @@
   "id": "buildx-dockerfile",
   "name": "Docker: Dockerfile Build Debugging",
   "launch": {
+    "windows": "docker.exe buildx dap build",
     "default": "docker buildx dap build"
   },
   "env": {


### PR DESCRIPTION
fix: 'Docker: Dockerfile Build Debugging' template broken on Windows

Fixes #1481