### PR TITLE
fix: diagnostics not displaying in Remote Development (Gateway)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LanguageServerWrapper.java
@@ -1409,7 +1409,8 @@ public class LanguageServerWrapper implements Disposable {
         if (fileUri == null) {
             return;
         }
-        boolean isOpen = FileEditorManager.getInstance(getProject()).isFileOpen(file);
+        boolean isOpen = getOpenedDocument(fileUri, false) != null
+                || FileEditorManager.getInstance(getProject()).isFileOpen(file);
         final LSPDocumentBase openedOrClosedDocument = isOpen ? getOpenedDocument(fileUri, true) : getClosedDocument(fileUri, true);
         if (openedOrClosedDocument == null) {
             return;


### PR DESCRIPTION
Diagnostics not showing up in remote development, fixes https://github.com/redhat-developer/lsp4ij/issues/1567

Root cause seems to be `isFileOpen` always returns false. The doc comment isn't super clear to me but `isFileOpenWithRemotes` seems to indicate there might be a gap here.
```
  /**
   * @return {@code true} if {@code file} is opened in the host editor, {@code false} otherwise.
   */
  public abstract boolean isFileOpen(@NotNull VirtualFile file);

  /**
   * @return {@code true} if {@code file} is opened, {@code false} otherwise.
   * Unlike {@link #isFileOpen(VirtualFile)} includes files which were opened
   * by all guests during a collaborative development session.
   */
  @ApiStatus.Experimental
  public boolean isFileOpenWithRemotes(@NotNull VirtualFile file) {
      return isFileOpen(file);
  }
```

Add an additional check to see if we just called open on the file. 

Tested by installing and validating that the diagnostics do show correctly after this fix. 