### PR TITLE
fix: Register it with a proper 'parentDisposable' or ensure that it's always disposed by direct Disposer.dispose() call.

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/console/LSPConsoleToolWindowPanel.java
@@ -224,6 +224,7 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
 
     private void createUI() {
         explorer = new LanguageServerExplorer(this);
+        Disposer.register(this, explorer);
         var scrollPane = new JBScrollPane(explorer);
         this.consoles = new ConsolesPanel();
 


### PR DESCRIPTION
fix: Register it with a proper 'parentDisposable' or ensure that it's always disposed by direct Disposer.dispose() call.

Fixes #1571