### PR TITLE
fix: Access from Event Dispatch Thread (EDT) is not allowed; see https://jb.gg/ij-platform-threading for details Current thread: Thread[#118,AWT-EventQueue-0,6,main] 714065616 (EventQueue.isDispatchThread()=true)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensEditorFactoryListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensEditorFactoryListener.java
@@ -142,7 +142,15 @@ public class LSPCodeLensEditorFactoryListener implements EditorFactoryListener {
                 if (ApplicationManager.getApplication().isReadAccessAllowed()) {
                     context.updateViewportLines(newRect);
                 } else {
-                    runCancellableReadAction(() -> context.updateViewportLines(newRect));
+                    // We're on EDT without read access, schedule on background thread
+                    ReadAction.nonBlocking(() -> {
+                                context.updateViewportLines(newRect);
+                                return null;
+                            })
+                            .expireWhen(() -> editor.isDisposed())
+                            .coalesceBy(editor, LSPCodeLensEditorFactoryListener.this, "viewport-init")
+                            .submit(AppExecutorUtil.getAppExecutorService());
+                    return; // Exit early as viewport update will happen asynchronously
                 }
                 // Don't return - continue to process the event normally
             }


### PR DESCRIPTION
fix: Access from Event Dispatch Thread (EDT) is not allowed; see https://jb.gg/ij-platform-threading for details Current thread: Thread[#118,AWT-EventQueue-0,6,main] 714065616 (EventQueue.isDispatchThread()=true)

Fixes #1583