### PR TITLE
fix: CodeLens: clicking a resolved code lens does not run its "command" — LSP4IJ re-issues codeLens/resolve instead of executing it

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCodeLensFeature.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCodeLensFeature.java
@@ -45,7 +45,7 @@ public class LSPCodeLensFeature extends AbstractLSPDocumentFeature {
     /**
      * Returns true if the file associated with a language server can support codelens and false otherwise.
      *
-     * @param file    the Psi file.
+     * @param file the Psi file.
      * @return true if the file associated with a language server can support codelens and false otherwise.
      */
     public boolean isCodeLensSupported(@NotNull PsiFile file) {
@@ -89,12 +89,12 @@ public class LSPCodeLensFeature extends AbstractLSPDocumentFeature {
         }
 
     }
+
     /**
      * Create an IntelliJ {@link CodeVisionEntry} from the given LSP CodeLens and null otherwise (to ignore the LSP CodeLens).
      *
-     * @param codeLens       the LSP codeLens.
-     * @param providerId     the code vision provider Id.
-     * @param codeLensContext        the LSP CodeLens context.
+     * @param providerId      the code vision provider Id.
+     * @param codeLensContext the LSP CodeLens context.
      * @return an IntelliJ {@link CodeVisionEntry} from the given LSP CodeLens and null otherwise (to ignore the LSP CodeLens).
      */
     @Nullable
@@ -107,8 +107,7 @@ public class LSPCodeLensFeature extends AbstractLSPDocumentFeature {
             return null;
         }
         Command command = codeLens.getCommand();
-        String commandId = command.getCommand();
-        if (StringUtils.isEmpty(commandId)) {
+        if (!isClickable(codeLens)) {
             // Create a simple text code vision.
             return new TextCodeVisionEntry(text, providerId, null, text, text, Collections.emptyList());
         }
@@ -116,22 +115,21 @@ public class LSPCodeLensFeature extends AbstractLSPDocumentFeature {
         return new ClickableTextCodeVisionEntry(text, providerId, (e, editor) -> {
             LSPCommandContext context = new LSPCommandContext(command, codeLensContext.getPsiFile(), LSPCommandContext.ExecutedBy.CODE_LENS, editor, codeLensContext.getLanguageServer())
                     .setInputEvent(e);
-            if (codeLensContext.isResolveCodeLensSupported()) {
-                codeLensContext.getLanguageServer()
-                        .getTextDocumentService()
-                        .resolveCodeLens(codeLens)
-                        .thenAcceptAsync(resolvedCodeLens -> {
-                                    if (resolvedCodeLens != null) {
-                                        UIUtil.invokeLaterIfNeeded(() ->
-                                                CommandExecutor.executeCommand(context));
-                                    }
-                                }
-                        );
-            } else {
-                CommandExecutor.executeCommand(context);
-            }
+            UIUtil.invokeLaterIfNeeded(() -> CommandExecutor.executeCommand(context));
             return null;
         }, null, text, text, Collections.emptyList());
+    }
+
+    /**
+     * Returns true if it is a clickable code vision entry and false otherwise.
+     *
+     * @param codeLens the LSP codelens
+     * @return true if it is a clickable code vision entry and false otherwise.
+     */
+    public boolean isClickable(@NotNull CodeLens codeLens) {
+        Command command = codeLens.getCommand();
+        String commandId = command.getCommand();
+        return !StringUtils.isEmpty(commandId) || codeLens.getData() != null;
     }
 
     /**
@@ -167,7 +165,7 @@ public class LSPCodeLensFeature extends AbstractLSPDocumentFeature {
 
     @Override
     public void setServerCapabilities(@Nullable ServerCapabilities serverCapabilities) {
-        if(codeLensCapabilityRegistry != null) {
+        if (codeLensCapabilityRegistry != null) {
             codeLensCapabilityRegistry.setServerCapabilities(serverCapabilities);
         }
     }

--- a/src/main/java/com/redhat/devtools/lsp4ij/commands/editor/GoToLocationsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/commands/editor/GoToLocationsAction.java
@@ -1,0 +1,169 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.commands.editor;
+
+import com.google.gson.JsonArray;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.commands.CommandExecutor;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
+import com.redhat.devtools.lsp4ij.commands.LSPCommandAction;
+import com.redhat.devtools.lsp4ij.usages.LSPUsageType;
+import com.redhat.devtools.lsp4ij.usages.LSPUsagesManager;
+import com.redhat.devtools.lsp4ij.usages.LocationData;
+import org.eclipse.lsp4j.Location;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Emulates Visual Studio Code's "editor.action.goToLocations" and "editor.action.peekLocations" commands.
+ *
+ * This action handles navigation to LSP locations with support for different modes:
+ * - "goto": navigate directly to location (single) or first location (multiple)
+ * - "peek": show locations in a popup
+ * - "gotoAndPeek": navigate and show popup
+ */
+public class GoToLocationsAction extends LSPCommandAction {
+
+    private static final String MODE_GOTO = "goto";
+    private static final String MODE_PEEK = "peek";
+    private static final String MODE_GOTO_AND_PEEK = "gotoAndPeek";
+
+    @Override
+    protected void commandPerformed(@NotNull LSPCommand command, @NotNull AnActionEvent e) {
+        Project project = e.getProject();
+        if (project == null) {
+            return;
+        }
+
+        // "editor.action.goToLocations" / "editor.action.peekLocations" command has 4 arguments:
+        // - URI (argument 0)
+        // - Position (argument 1)
+        // - List of Location (argument 2)
+        // - Mode: "goto" | "peek" | "gotoAndPeek" (argument 3, optional, default: "goto")
+
+        // Example:
+        /*
+          "command": {
+            "title": "injected: MyService (Provider.os)",
+            "command": "editor.action.goToLocations",
+            "arguments": [
+              "file:///project/Consumer.os",
+              { "line": 6, "character": 6 },
+              [
+                {
+                  "uri": "file:///project/Provider.os",
+                  "range": {
+                    "start": { "line": 6, "character": 10 },
+                    "end": { "line": 6, "character": 28 }
+                  }
+                }
+              ],
+              "goto"
+            ]
+          }
+         */
+
+        // Get the third argument (List of Location)
+        JsonArray array = (JsonArray) command.getArgumentAt(2);
+        if (array == null || array.isEmpty()) {
+            return;
+        }
+
+        // Get the fourth argument (mode: "goto" | "peek" | "gotoAndPeek")
+        String mode = MODE_GOTO; // default
+        Object modeArg = command.getArgumentAt(3);
+        if (modeArg instanceof String) {
+            mode = (String) modeArg;
+        }
+
+        DataContext dataContext = e.getDataContext();
+        LanguageServerItem languageServer = dataContext.getData(CommandExecutor.LSP_COMMAND_LANGUAGE_SERVER);
+
+        // Get LSP4J Location from the JSON locations array
+        final List<LocationData> locations = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            locations.add(new LocationData(JSONUtils.toModel(array.get(i), Location.class), languageServer));
+        }
+
+        // Handle different modes
+        switch (mode) {
+            case MODE_GOTO:
+                handleGoto(locations, project);
+                break;
+            case MODE_PEEK:
+                handlePeek(locations, dataContext, (MouseEvent) e.getInputEvent(), project);
+                break;
+            case MODE_GOTO_AND_PEEK:
+                handleGotoAndPeek(locations, dataContext, (MouseEvent) e.getInputEvent(), project);
+                break;
+            default:
+                // Unknown mode, default to goto
+                handleGoto(locations, project);
+                break;
+        }
+    }
+
+    /**
+     * Navigate to the first location directly
+     */
+    private void handleGoto(@NotNull List<LocationData> locations, @NotNull Project project) {
+        if (!locations.isEmpty()) {
+            LocationData location = locations.get(0);
+            ApplicationManager.getApplication().invokeLater(() ->
+                LSPIJUtils.openInEditor(location.location(), location.languageServer().getClientFeatures(), project)
+            );
+        }
+    }
+
+    /**
+     * Show locations in a popup (same as showReferences)
+     */
+    private void handlePeek(@NotNull List<LocationData> locations,
+                           @NotNull DataContext dataContext,
+                           @Nullable MouseEvent event,
+                           @NotNull Project project) {
+        LSPUsagesManager.getInstance(project).findShowUsagesInPopup(
+            locations,
+            LSPUsageType.References, // Using References as the usage type for peek
+            dataContext,
+            event
+        );
+    }
+
+    /**
+     * Navigate to the first location AND show popup
+     */
+    private void handleGotoAndPeek(@NotNull List<LocationData> locations,
+                                   @NotNull DataContext dataContext,
+                                   @Nullable MouseEvent event,
+                                   @NotNull Project project) {
+        // First navigate to the location
+        handleGoto(locations, project);
+        // Then show the popup
+        handlePeek(locations, dataContext, event, project);
+    }
+
+    @Override
+    protected @NotNull ActionUpdateThread getCommandPerformedThread() {
+        return ActionUpdateThread.EDT;
+    }
+}

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
@@ -248,7 +248,7 @@ public class LSPCodeLensProvider implements CodeVisionProvider<Void> {
                     .toList(); // Collect the futures in a list.
 
             // Return a CompletableFuture that completes when all resolve futures are done.
-            return CompletableFutures.allOf(resolveFutures.toArray(new CompletableFuture[0]));
+            return CompletableFutures.allOf(resolveFutures.toArray(new CompletableFuture[resolveFutures.size()]));
         }
 
         // If no code lenses need to be resolved, return null.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -940,6 +940,8 @@
                 class="com.redhat.devtools.lsp4ij.commands.editor.ShowReferencesAction"/>
         <action id="editor.action.triggerParameterHints"
                 class="com.redhat.devtools.lsp4ij.commands.editor.TriggerParameterHintsAction"/>
+        <action id="editor.action.goToLocations"
+                class="com.redhat.devtools.lsp4ij.commands.editor.GoToLocationsAction"/>
     </actions>
 
     <!-- LSP consoles -->


### PR DESCRIPTION
fix: CodeLens: clicking a resolved code lens does not run its "command" — LSP4IJ re-issues codeLens/resolve instead of executing it

Fixes #1585

This PR:

 * remove the codeLens/resolve call when command is clicked
 * define `editor.action.goToLocations` to emulate this vscode command

//cc @nixel2007 I cannot test  `editor.action.goToLocations`  please tell me  if it is working liek vscode.