### PR TITLE
fix: read goToLocations mode argument as JsonPrimitive (enable peek/gotoAndPeek)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/commands/editor/GoToLocationsAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/commands/editor/GoToLocationsAction.java
@@ -11,6 +11,7 @@
 package com.redhat.devtools.lsp4ij.commands.editor;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonPrimitive;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
@@ -89,11 +90,7 @@ public class GoToLocationsAction extends LSPCommandAction {
         }
 
         // Get the fourth argument (mode: "goto" | "peek" | "gotoAndPeek")
-        String mode = MODE_GOTO; // default
-        Object modeArg = command.getArgumentAt(3);
-        if (modeArg instanceof String) {
-            mode = (String) modeArg;
-        }
+        String mode = resolveMode(command.getArgumentAt(3));
 
         DataContext dataContext = e.getDataContext();
         LanguageServerItem languageServer = dataContext.getData(CommandExecutor.LSP_COMMAND_LANGUAGE_SERVER);
@@ -120,6 +117,29 @@ public class GoToLocationsAction extends LSPCommandAction {
                 handleGoto(locations, project);
                 break;
         }
+    }
+
+    /**
+     * Resolves the optional {@code mode} argument of {@code editor.action.goToLocations} /
+     * {@code editor.action.peekLocations}.
+     * <p>
+     * Command arguments are Gson JSON elements, so a JSON string arrives as a {@link JsonPrimitive}
+     * rather than a {@link String}; a {@code null} or non-string argument falls back to
+     * {@link #MODE_GOTO}.
+     *
+     * @param modeArg the raw fourth command argument (may be {@code null})
+     * @return {@code "goto"}, {@code "peek"} or {@code "gotoAndPeek"} (or the raw string if any);
+     * never {@code null}
+     */
+    static String resolveMode(@Nullable Object modeArg) {
+        if (modeArg instanceof JsonPrimitive primitive && primitive.isString()) {
+            return primitive.getAsString();
+        }
+        if (modeArg instanceof String stringMode) {
+            // Tolerate an already-decoded String (e.g. programmatic invocation).
+            return stringMode;
+        }
+        return MODE_GOTO;
     }
 
     /**

--- a/src/test/java/com/redhat/devtools/lsp4ij/commands/editor/GoToLocationsActionTest.java
+++ b/src/test/java/com/redhat/devtools/lsp4ij/commands/editor/GoToLocationsActionTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.lsp4ij.commands.editor;
+
+import com.google.gson.JsonPrimitive;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link GoToLocationsAction#resolveMode(Object)}.
+ */
+public class GoToLocationsActionTest {
+
+    @Test
+    public void jsonPrimitivePeekIsResolved() {
+        // Command arguments are Gson JSON elements: the mode arrives as a JsonPrimitive.
+        Assert.assertEquals("peek", GoToLocationsAction.resolveMode(new JsonPrimitive("peek")));
+    }
+
+    @Test
+    public void jsonPrimitiveGotoAndPeekIsResolved() {
+        Assert.assertEquals("gotoAndPeek", GoToLocationsAction.resolveMode(new JsonPrimitive("gotoAndPeek")));
+    }
+
+    @Test
+    public void jsonPrimitiveGotoIsResolved() {
+        Assert.assertEquals("goto", GoToLocationsAction.resolveMode(new JsonPrimitive("goto")));
+    }
+
+    @Test
+    public void alreadyDecodedStringIsResolved() {
+        Assert.assertEquals("peek", GoToLocationsAction.resolveMode("peek"));
+    }
+
+    @Test
+    public void nullArgumentDefaultsToGoto() {
+        Assert.assertEquals("goto", GoToLocationsAction.resolveMode(null));
+    }
+
+    @Test
+    public void nonStringPrimitiveDefaultsToGoto() {
+        Assert.assertEquals("goto", GoToLocationsAction.resolveMode(new JsonPrimitive(42)));
+    }
+}


### PR DESCRIPTION
Fixes #1588

## Problem

`GoToLocationsAction` reads the optional `mode` argument (`"goto"` | `"peek"` | `"gotoAndPeek"`) with `instanceof String`. Command arguments are Gson `JsonElement`s (the action reads the locations argument as `(JsonArray) command.getArgumentAt(2)`), so the mode string arrives as a `JsonPrimitive`. The check never matched, `mode` stayed at its `"goto"` default, and the action always navigated to the first location — `"peek"` and `"gotoAndPeek"` were unreachable.

## Fix

Read the mode from the `JsonPrimitive` via `getAsString()`, keeping a fallback for an already-decoded `String`:

```java
if (modeArg instanceof JsonPrimitive primitive && primitive.isString()) {
    mode = primitive.getAsString();
} else if (modeArg instanceof String stringMode) {
    mode = stringMode;
}
```

## Notes

- Single-file change; no behavior change for the `"goto"` default path.
