### PR TITLE
fix: On-type formatting: onTypeFormatting request is sent before didChange (position can be past synced end-of-line)

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/DocumentContentSynchronizer.java
@@ -155,12 +155,25 @@ public class DocumentContentSynchronizer implements DocumentListener, Disposable
         }
     }
 
-    private void sendDidChangeEvents() {
+    /**
+     * Flushes any pending textDocument/didChange notifications to the language server.
+     * This ensures the server has an up-to-date view of the document before other requests.
+     * <p>
+     * This method should be called before sending requests that depend on the current
+     * document state (e.g., onTypeFormatting) to avoid out-of-bounds position errors.
+     *
+     * @return a CompletableFuture that completes when the didChange notification has been sent
+     */
+    public CompletableFuture<Void> flushPendingChanges() {
+        return sendDidChangeEvents();
+    }
+
+    private CompletableFuture<Void> sendDidChangeEvents() {
         List<TextDocumentContentChangeEvent> events;
         synchronized (changeEvents) {
             if (changeEvents.isEmpty()) {
                 // Don't send didChange notification with empty contentChanges.
-                return;
+                return CompletableFuture.completedFuture(null);
             }
             events = new ArrayList<>(changeEvents);
             changeEvents.clear();
@@ -176,6 +189,7 @@ public class DocumentContentSynchronizer implements DocumentListener, Disposable
             return ls;
         });
         processPullDiagnosticIfNeeded(didChange, version);
+        return didChange.thenApply(ls -> null);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPOnTypeFormattingSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPOnTypeFormattingSupport.java
@@ -11,10 +11,14 @@
 
 package com.redhat.devtools.lsp4ij.features.formatting;
 
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.containers.ContainerUtil;
+import com.redhat.devtools.lsp4ij.DocumentContentSynchronizer;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
+import com.redhat.devtools.lsp4ij.OpenedDocument;
+import com.redhat.devtools.lsp4ij.client.features.FileUriSupport;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
@@ -22,6 +26,7 @@ import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.TextEdit;
 import org.jetbrains.annotations.NotNull;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -64,14 +69,20 @@ public class LSPOnTypeFormattingSupport extends AbstractLSPDocumentFeatureSuppor
                         return CompletableFuture.completedFuture(Collections.emptyList());
                     }
 
-                    // Collect list of textDocument/onTypeFormatting future for each language servers
-                    List<CompletableFuture<List<TextEdit>>> textEditsPerServerFutures = languageServers
-                            .stream()
-                            .map(languageServer -> getTextEditsFor(params, file, languageServer, cancellationSupport))
-                            .toList();
+                    // Flush pending didChange notifications before sending onTypeFormatting requests
+                    // to ensure the server has an up-to-date document with the typed character already synced.
+                    // This prevents out-of-bounds position errors (issue #1589).
+                    return flushPendingChangesForLanguageServers(file, languageServers)
+                            .thenCompose(v -> {
+                                // Collect list of textDocument/onTypeFormatting future for each language servers
+                                List<CompletableFuture<List<TextEdit>>> textEditsPerServerFutures = languageServers
+                                        .stream()
+                                        .map(languageServer -> getTextEditsFor(params, file, languageServer, cancellationSupport))
+                                        .toList();
 
-                    // Merge list of textDocument/onTypeFormatting future in one future which return the list of text edits
-                    return CompletableFutures.mergeInOneFuture(textEditsPerServerFutures, cancellationSupport);
+                                // Merge list of textDocument/onTypeFormatting future in one future which return the list of text edits
+                                return CompletableFutures.mergeInOneFuture(textEditsPerServerFutures, cancellationSupport);
+                            });
                 });
     }
 
@@ -93,6 +104,45 @@ public class LSPOnTypeFormattingSupport extends AbstractLSPDocumentFeatureSuppor
                     ContainerUtil.addAllNotNull(filteredTextEdits, textEdits);
                     return filteredTextEdits;
                 });
+    }
+
+    /**
+     * Flushes pending didChange notifications for all language servers that will handle the onTypeFormatting request.
+     * This ensures each server has received the typed character before receiving the formatting request,
+     * preventing out-of-bounds position errors.
+     *
+     * @param file the PSI file
+     * @param languageServers the language servers that will handle the onTypeFormatting request
+     * @return a CompletableFuture that completes when all didChange notifications have been sent
+     */
+    private static CompletableFuture<Void> flushPendingChangesForLanguageServers(@NotNull PsiFile file,
+                                                                                   @NotNull List<LanguageServerItem> languageServers) {
+        VirtualFile virtualFile = file.getVirtualFile();
+        if (virtualFile == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        List<CompletableFuture<Void>> flushFutures = new ArrayList<>();
+
+        for (LanguageServerItem languageServer : languageServers) {
+            URI fileUri = FileUriSupport.getFileUri(virtualFile, languageServer.getClientFeatures());
+            if (fileUri == null) {
+                continue;
+            }
+
+            OpenedDocument openedDocument = languageServer.getServerWrapper().getOpenedDocument(fileUri);
+            if (openedDocument == null) {
+                continue;
+            }
+
+            DocumentContentSynchronizer synchronizer = openedDocument.getSynchronizer();
+            if (synchronizer != null) {
+                flushFutures.add(synchronizer.flushPendingChanges());
+            }
+        }
+
+        // Wait for all flush operations to complete
+        return CompletableFuture.allOf(flushFutures.toArray(new CompletableFuture[0]));
     }
 
 }


### PR DESCRIPTION
fix: On-type formatting: onTypeFormatting request is sent before didChange (position can be past synced end-of-line)

Fixes #1589