### PR TITLE
fix: Run file test.go using DAP, message is not displayed when printed to standard output

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/console/DAPConsoleView.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/console/DAPConsoleView.java
@@ -94,7 +94,7 @@ public class DAPConsoleView extends ConsoleViewImpl {
             }
             return s;
         }
-        return null;
+        return text;
     }
 
     private static boolean isContentLengthDapTrace(@NotNull String text) {


### PR DESCRIPTION
fix: Run file test.go using DAP, message is not displayed when printed to standard output

Fixes #1561

<img width="496" height="242" alt="image" src="https://github.com/user-attachments/assets/20d6327d-2fc7-4ded-91b1-1ee6f34ce915" />