### PR TITLE
feat: add Candor Language Server template

### DIFF
--- a/src/main/resources/templates/lsp/candor-lsp/README.md
+++ b/src/main/resources/templates/lsp/candor-lsp/README.md
@@ -1,0 +1,25 @@
+You can use the [candor language server](https://candor.poly.io) to see each function's **side-effect
+map** where the code is:
+
+ * **CodeLens** on every effectful function: `⚡ Db, Net · blast radius 12` — the effects it (transitively)
+   performs and how many functions are affected if it changes;
+ * **Diagnostics**: the repo's architecture policy (e.g. "the domain layer does no I/O") checked live —
+   a violation is a squiggle at the offending function;
+ * **Hover**: effect provenance — the call chain through which an inherited effect reaches its source.
+
+The server renders a **candor report** — it does not analyse source itself. Produce one with any candor
+engine (JVM bytecode / TypeScript / Rust / Swift; see [candor.poly.io](https://candor.poly.io)), e.g.:
+
+**jbang candor@tombaldwin/candor-java target/classes --json .candor/report.json**   (JVM)
+
+**npx -y candor-ts src --out .candor/report**   (TypeScript/JavaScript)
+
+Setup:
+* [Install Node.js](https://nodejs.org/en/download)
+* Open a terminal and execute:
+
+**npm install -g candor-ts**
+
+It will install the `candor-lsp` executable (the language server ships in the candor-ts package). The
+server resolves the report at `<project>/.candor/report` and the policy from the checked-in
+`.candor/config` — no per-project server configuration is needed.

--- a/src/main/resources/templates/lsp/candor-lsp/installer.json
+++ b/src/main/resources/templates/lsp/candor-lsp/installer.json
@@ -1,0 +1,36 @@
+{
+  "id": "candor-lsp",
+  "name": "Candor Language Server",
+  "executeOnStartServer": false,
+  "properties": {
+    "workingDir" : "$USER_HOME$/.lsp4ij/lsp/candor-lsp/node_modules"
+  },
+  "check": {
+    "exec": {
+      "name": "Trying current command",
+      "command": "${server.command}",
+      "timeout": 2000
+    }
+  },
+  "run": {
+    "exec": {
+      "name": "Install Candor Language Server",
+      "workingDir": "${workingDir}",
+      "ignoreStderr": true,
+      "command": {
+        "windows": "npm.cmd install candor-ts --force",
+        "default": "npm install candor-ts --force"
+      },
+      "onSuccess": {
+        "configureServer": {
+          "name": "Configure Candor Language Server command",
+          "command": {
+            "windows": "${workingDir}/.bin/candor-lsp.cmd",
+            "default": "${workingDir}/.bin/candor-lsp"
+          },
+          "update": true
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/templates/lsp/candor-lsp/template.json
+++ b/src/main/resources/templates/lsp/candor-lsp/template.json
@@ -1,0 +1,67 @@
+{
+  "id": "candor-lsp",
+  "name": "Candor Language Server",
+  "programArgs": {
+    "windows": "cmd /C candor-lsp.cmd",
+    "default": "candor-lsp"
+  },
+  "fileTypeMappings": [
+    {
+      "fileType": {
+        "name": "JAVA",
+        "patterns": [
+          "*.java"
+        ]
+      },
+      "languageId": "java"
+    },
+    {
+      "fileType": {
+        "name": "Kotlin",
+        "patterns": [
+          "*.kt",
+          "*.kts"
+        ]
+      },
+      "languageId": "kotlin"
+    },
+    {
+      "fileType": {
+        "name": "TypeScript",
+        "patterns": [
+          "*.ts",
+          "*.tsx"
+        ]
+      },
+      "languageId": "typescript"
+    },
+    {
+      "fileType": {
+        "name": "JavaScript",
+        "patterns": [
+          "*.js",
+          "*.jsx",
+          "*.mjs"
+        ]
+      },
+      "languageId": "javascript"
+    },
+    {
+      "fileType": {
+        "name": "Rust",
+        "patterns": [
+          "*.rs"
+        ]
+      },
+      "languageId": "rust"
+    },
+    {
+      "fileType": {
+        "patterns": [
+          "*.swift"
+        ]
+      },
+      "languageId": "swift"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a template for the [candor](https://candor.poly.io) language server — a per-function **side-effect map** rendered in-editor from a precomputed report:

- **CodeLens** on each effectful function: `⚡ Db, Net · blast radius 12` (transitive effects + how many functions are affected by a change);
- **Diagnostics**: the repo's checked-in architecture policy (e.g. *the domain layer performs no I/O*) evaluated live, a violation squiggled at the offending function;
- **Hover**: effect provenance — the call chain through which an inherited effect reaches its source.

The server is engine-agnostic (one report format covers JVM bytecode, TypeScript/JavaScript, Rust and Swift) and ships as `candor-lsp` in the [candor-ts npm package](https://www.npmjs.com/package/candor-ts). The template + installer follow the `typescript-language-server` pattern (npm install into the lsp4ij working dir, then configure the `.bin` command); `template.json` maps the file types the report can cover.

Tested locally: both JSON files parse, and the server negotiates codeLens/hover/diagnostics over LSP stdio (its behavioral suite runs in the candor-ts repo).