### PR TITLE
docs: Add Language 1C (BSL) Plugin link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Here are some projects that use LSP4IJ:
  * [Rell IntelliJ Plugin](https://bitbucket.org/chromawallet/rell-jetbrains)
  * [Dart](https://github.com/flutter/dart-intellij-third-party)
  * [Semantic Web Language Server](https://github.com/SemanticWebLanguageServer/swls)
+ * [Language 1C (BSL) Plugin](https://github.com/1c-syntax/intellij-language-1c-bsl)
 
 ## Requirements
 


### PR DESCRIPTION
Hi there, [Language 1C (BSL) plugin](https://plugins.jetbrains.com/plugin/32659-language-1c-bsl-) was finally published to JB Marketplace. It was rewritten from old lsp4intellij to lsp4ij with a big help from your documentation.

Thank you for your product and quick fixes of bugs found while working with [BSL Language Server](https://1c-syntax.github.io/bsl-language-server/en/)