### PR TITLE
docs: add BBj Language Support for IntelliJ to "Who is using LSP4IJ?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Here are some projects that use LSP4IJ:
  * [Semantic Web Language Server](https://github.com/SemanticWebLanguageServer/swls)
  * [Language 1C (BSL) Plugin](https://github.com/1c-syntax/intellij-language-1c-bsl)
  * [ARO Programming Language](https://github.com/arolang/aro)
+ * [BBj Language Support for IntelliJ](https://github.com/BBx-Kitchen/bbj-language-server)
 
 ## Requirements
 


### PR DESCRIPTION
Our BBj plugin uses LSP4IJ on the IntelliJ side, and you kindly asked us to add it (see BBx-Kitchen/bbj-language-server#384).

This adds the BBj language server's IntelliJ plugin to the "Who is using LSP4IJ?" list.

- Repo: https://github.com/BBx-Kitchen/bbj-language-server
- The BBj Language Server powers both a VS Code extension and an IntelliJ plugin from a single shared Langium-based language server; the IntelliJ plugin wraps it via LSP4IJ.

Thanks for LSP4IJ! 🙌