### PR TITLE
docs: remove Rell plugin from Who is using LSP4IJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Here are some projects that use LSP4IJ:
  * [Rider Unreal Angelscript](https://github.com/scriptacus/rider-unreal-angelscript)
  * [agnix](https://github.com/agent-sh/agnix)
  * [Xonsh plugin for JetBrains IDEs](https://github.com/nahoj/xonsh-jetbrains)
- * [Rell IntelliJ Plugin](https://bitbucket.org/chromawallet/rell-jetbrains)
  * [Dart](https://github.com/flutter/dart-intellij-third-party)
  * [Semantic Web Language Server](https://github.com/SemanticWebLanguageServer/swls)
  * [Language 1C (BSL) Plugin](https://github.com/1c-syntax/intellij-language-1c-bsl)


### PR DESCRIPTION
The Rell IntelliJ Plugin no longer uses LSP4IJ. It switched to the internal IntelliJ LSP support, so it's removed from the "Who is using LSP4IJ?" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)