### PR TITLE
fix: support IntelliJ IDEA 2026.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,7 +182,6 @@ intellijPlatform {
                 types = listOf(IntelliJPlatformType.IntellijIdea)
                 channels = listOf(ProductRelease.Channel.RELEASE) // Only stable releases
                 sinceBuild = "242" // From your minimum supported version
-                untilBuild = "262.*" // Up to current major version
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,7 +175,7 @@ intellijPlatform {
     }
 
     pluginVerification {
-        // MISSING_DEPENDENCIES also fails for unavailable optional dependencies; see https://youtrack.jetbrains.com/issue/MP-2974.
+        // MISSING_DEPENDENCIES also fails for unavailable optional="true" dependencies; see https://youtrack.jetbrains.com/issue/MP-2974.
         failureLevel = listOf(INVALID_PLUGIN, COMPATIBILITY_PROBLEMS)
         verificationReportsFormats = listOf(MARKDOWN, PLAIN)
         ides {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,7 +175,8 @@ intellijPlatform {
     }
 
     pluginVerification {
-        failureLevel = listOf(INVALID_PLUGIN, COMPATIBILITY_PROBLEMS, MISSING_DEPENDENCIES)
+        // MISSING_DEPENDENCIES also fails for unavailable optional dependencies; see https://youtrack.jetbrains.com/issue/MP-2974.
+        failureLevel = listOf(INVALID_PLUGIN, COMPATIBILITY_PROBLEMS)
         verificationReportsFormats = listOf(MARKDOWN, PLAIN)
         ides {
             select {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,7 +182,7 @@ intellijPlatform {
                 types = listOf(IntelliJPlatformType.IntellijIdea)
                 channels = listOf(ProductRelease.Channel.RELEASE) // Only stable releases
                 sinceBuild = "242" // From your minimum supported version
-                untilBuild = "261.*" // Up to current major version
+                untilBuild = "262.*" // Up to current major version
             }
         }
     }

--- a/src/main/resources/META-INF/plugin-structure-view.xml
+++ b/src/main/resources/META-INF/plugin-structure-view.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<idea-plugin>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -347,6 +347,7 @@
     </description>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="plugin-structure-view.xml">intellij.structureView.plugin</depends>
     <depends optional="true" config-file="plugin-textmate.xml">org.jetbrains.plugins.textmate</depends>
     <depends optional="true" config-file="plugin-telemetry.xml">com.redhat.devtools.intellij.telemetry</depends>
     <depends optional="true" config-file="plugin-json.xml">com.intellij.modules.json</depends>


### PR DESCRIPTION
Fixes #1633.

## What changed

- Declare an optional dependency on the bundled `intellij.structureView.plugin` and add its required optional configuration descriptor.
- Remove the Plugin Verifier upper build bound so stable releases after `261.*`, including 2026.2, are covered.
- Omit the coarse `MISSING_DEPENDENCIES` failure level because Plugin Verifier also applies it to unavailable optional dependencies ([MP-2974](https://youtrack.jetbrains.com/issue/MP-2974)); invalid plugins and compatibility problems remain fatal.

## Root cause

`PsiTreeElementBase` and `StructureViewWrapperImpl` still exist in IntelliJ IDEA 2026.2.1. Their class files moved from the IDE core classpath in 2026.1 to `plugins/platform-structureView-plugin/lib/modules/intellij.platform.structureView.jar` in 2026.2. Because LSP4IJ did not declare the owning bundled plugin, those classes were outside LSP4IJ's dependency-visible classpath. The dependency is optional so the same plugin archive remains compatible with 2026.1, where that bundled plugin ID is absent and the classes are still supplied by the core classpath.

The 262.9437 source and product descriptors identify [`intellij.structureView.plugin`](https://github.com/JetBrains/intellij-community/blob/eaefd49405a1a53d7ec2f0c7eed81b2d8628e219/platform/structure-view-impl/plugin/resources/META-INF/plugin.xml#L4-L12) as the owning plugin and expose its [`intellij.platform.structureView` module publicly](https://github.com/JetBrains/intellij-community/blob/eaefd49405a1a53d7ec2f0c7eed81b2d8628e219/platform/structure-view-impl/resources/intellij.platform.structureView.xml#L1-L27).

## Before and after

I built upstream `main` at `d1a91b422cf8f72a73ddbdda0ea3a6ae32caead5` with `./gradlew clean buildPlugin` and checked the resulting `lsp4ij-0.20.2-SNAPSHOT.zip` using JetBrains Plugin Verifier 1.408 against the exact IntelliJ IDEA Ultimate 2026.2.1 build `IU-262.9437.185`.

Before:

```text
IU-262.9437.185 against com.redhat.devtools.lsp4ij:0.20.2-SNAPSHOT: 2 compatibility problems.
Package 'com.intellij.ide.structureView.impl.common' is not found along with its class com.intellij.ide.structureView.impl.common.PsiTreeElementBase.
Method StructureViewEditorFeature.lambda$collectUiRunnable$0() references an unresolved class com.intellij.ide.impl.StructureViewWrapperImpl.
```

After changing only the plugin dependency metadata and verifier range:

```text
IU-262.9437.185 against com.redhat.devtools.lsp4ij:0.20.2-SNAPSHOT: Compatible.
```

The 2026.1.5 control remains compatible:

```text
IU-261.27258.48 against com.redhat.devtools.lsp4ij:0.20.2-SNAPSHOT: Compatible.
intellij.structureView.plugin (optional): Dependency is not resolved.
```

## Validation

- `./gradlew clean buildPlugin` — passed.
- `./gradlew verifyPluginStructure verifyPluginProjectConfiguration` — passed; the project configuration task retains its existing Java 17 versus platform 2024.2 warning.
- Plugin Verifier 1.408 against `IU-262.9437.185` — compatible.
- Plugin Verifier 1.408 against `IU-261.27258.48` — compatible, with the expected missing optional dependency note.
- `./gradlew test` — 441 tests executed, with 7 unrelated failures where the IntelliJ test harness rejected macOS temporary files as outside its allowed VFS roots; 3 tests were skipped.
