### PR TITLE
fix: Golang DAP: fmt.Println()/fmt.Println("")/fmt.Print("\n") are not displayed in the DAP output

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/client/DAPClient.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/client/DAPClient.java
@@ -297,7 +297,7 @@ public class DAPClient implements IDebugProtocolClient, Disposable {
     @Override
     public void output(OutputEventArguments args) {
         String output = args.getOutput();
-        if (StringUtils.isNotBlank(output)) {
+        if (!StringUtils.isEmpty(output)) {
             debugProcess.print(output, getContentType(args.getCategory()));
         }
     }


### PR DESCRIPTION
fix: Golang DAP: fmt.Println()/fmt.Println("")/fmt.Print("\n") are not displayed in the DAP output

Fixes #1651