### PR TITLE
docs: update rust-analyzer semantic tokens section #1302

### DIFF
--- a/docs/user-defined-ls/rust-analyzer.md
+++ b/docs/user-defined-ls/rust-analyzer.md
@@ -37,12 +37,14 @@ You need to adjust this command to point to the location of the extracted Rust A
  
 ## Syntax coloration
 
-Today LSP4IJ doesn't support `textDocument/semanticTokens` ([please vote at issue 238](https://github.com/redhat-developer/lsp4ij/issues/238)), the demo
-uses the [Rust TextMate grammar](https://github.com/microsoft/vscode/blob/main/extensions/rust/syntaxes/rust.tmLanguage.json)
-that you can configure in IntelliJ via the `Editor / TextMate Bundles` settings.
+LSP4IJ supports [`textDocument/semanticTokens`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens).
+See [Semantic Tokens support](../UserGuide.md#semantic-tokens-support) for color settings and the Semantic Tokens Inspector.
+
+You can also add the [Rust TextMate grammar](https://github.com/microsoft/vscode/blob/main/extensions/rust/syntaxes/rust.tmLanguage.json)
+in IntelliJ via the `Editor / TextMate Bundles` settings:
 
 ![Rust TextMate Bundles](../images/user-defined-ls/rust-analyzer/RustTextMate.png)
 
-You need to clone https://github.com/microsoft/vscode and reference this folder
+Clone https://github.com/microsoft/vscode and reference this folder
 (which contains the [package.json](https://github.com/microsoft/vscode/tree/main/extensions/rust))
-to benefit from syntax coloration and language configuration (matching brackets, etc).
+for extra syntax coloration and language configuration (matching brackets, etc).


### PR DESCRIPTION
#238 closed and LSP4IJ already implements `textDocument/semanticTokens`. This drops the vote link and points at the User Guide instead. TextMate steps stay as optional extra highlighting.

Fixes #1302
