### PR TITLE
fix: Golang DAP: fmt.Println()/fmt.Println("")/fmt.Print("\n") are not displayed in the DAP output

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
@@ -366,7 +366,7 @@ public class DAPDebugProcess extends XDebugProcess implements Disposable {
     }
 
     public void print(@Nullable String message, @NotNull ConsoleViewContentType type) {
-        if (message == null || StringUtils.isBlank(message)) {
+        if (StringUtils.isEmpty(message)) {
             return;
         }
         if (message.charAt(message.length() - 1) != '\n') {


### PR DESCRIPTION
fix: Golang DAP: fmt.Println()/fmt.Println("")/fmt.Print("\n") are not displayed in the DAP output

Fixes #1651