### PR TITLE
fix: Type/Call Hierarchy actions disabled when the IDE bundles JetBrains' LSP client

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -743,6 +743,11 @@
         <typeHierarchyProvider
                 language="textmate"
                 implementationClass="com.redhat.devtools.lsp4ij.features.typeHierarchy.LSPTypeHierarchyProvider"/>
+        <!-- Required for LSPPsiElement (Language.ANY), otherwise the JetBrains LSP client provider
+             (registered with language="") shadows the TEXT / textmate ones. -->
+        <typeHierarchyProvider
+                language=""
+                implementationClass="com.redhat.devtools.lsp4ij.features.typeHierarchy.LSPTypeHierarchyProvider"/>
 
         <!-- LSP textDocument/callHierarchy request support -->
         <callHierarchyProvider
@@ -750,6 +755,11 @@
                 implementationClass="com.redhat.devtools.lsp4ij.features.callHierarchy.LSPCallHierarchyProvider"/>
         <callHierarchyProvider
                 language="textmate"
+                implementationClass="com.redhat.devtools.lsp4ij.features.callHierarchy.LSPCallHierarchyProvider"/>
+        <!-- Required for LSPPsiElement (Language.ANY), otherwise the JetBrains LSP client provider
+             (registered with language="") shadows the TEXT / textmate ones. -->
+        <callHierarchyProvider
+                language=""
                 implementationClass="com.redhat.devtools.lsp4ij.features.callHierarchy.LSPCallHierarchyProvider"/>
 
         <!-- LSP Find Usages (LSP) support shows:


### PR DESCRIPTION
The JetBrains LSP client registers its type/call hierarchy providers with language="", which is the language of the LSPPsiElement returned by LSPTargetElementEvaluator for a caret on a word (FakePsiElement.getLanguage() is Language.ANY). BrowseHierarchyActionBase only falls back to the file language when no provider matches the element language, so LSP4IJ's TEXT / textmate providers were never consulted and the actions stayed disabled.

Register the LSP4IJ providers for language="" as well. The platform ones are order="last", so LSP4IJ's are consulted first, and LSPHierarchyProviderBase.getTarget already returns null for files LSP4IJ does not support.

Fixes #1661

Verified with:
- IntelliJ IDEA 2024.2 (Community Edition) Build #IC-242.20224.300, built on August 6, 2024
- IntelliJ IDEA 2026.2.1 Build #IU-262.9437.185, built on August 9, 2026