### PR TITLE
fix: use null-safe CompletableFutures.awaitWithCheckCanceled wrapper to prevent NPE when future is null

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPFileListener.java
@@ -13,8 +13,8 @@ package com.redhat.devtools.lsp4ij;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.features.files.AbstractLSPFileListener;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import org.eclipse.lsp4j.*;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -250,7 +250,7 @@ class LSPFileListener extends AbstractLSPFileListener {
                 var didOpen = languageServerWrapper.connect(newFile,
                         languageServerWrapper.createFileConnectionInfo(documentFile, document, true));
                 try {
-                    ProgressIndicatorUtils.awaitWithCheckCanceled(didOpen);
+                    awaitWithCheckCanceled(didOpen);
                 } catch (CancellationException ignore) {
                 }
             }

--- a/src/main/java/com/redhat/devtools/lsp4ij/LSPIJEditorUtils.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/LSPIJEditorUtils.java
@@ -38,9 +38,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * Provides utility methods for editor support behaviors.
@@ -412,7 +412,7 @@ public final class LSPIJEditorUtils {
                     null
             );
             try {
-                ProgressIndicatorUtils.awaitWithCheckCanceled(languageServersFuture);
+                awaitWithCheckCanceled(languageServersFuture);
             } catch (ProcessCanceledException e) {
                 return null;
             } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/client/features/LSPCompletionProposal.java
@@ -60,9 +60,9 @@ import java.util.concurrent.CompletableFuture;
 import static com.redhat.devtools.lsp4ij.features.completion.snippet.LspSnippetVariableConstants.*;
 import static com.redhat.devtools.lsp4ij.features.documentation.LSPDocumentationHelper.convertToHtml;
 import static com.redhat.devtools.lsp4ij.features.documentation.LSPDocumentationHelper.getValidMarkupContents;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import static com.redhat.devtools.lsp4ij.internal.CompletionUtils.computePrefixStartFromInsertText;
 
 /**
@@ -497,7 +497,7 @@ public class LSPCompletionProposal extends LookupElement implements Pointer<LSPC
                     .resolveCompletionItem(item);
         }
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(resolvedCompletionItemFuture);
+            awaitWithCheckCanceled(resolvedCompletionItemFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/DAPDebugProcess.java
@@ -23,7 +23,6 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.ui.AppUIUtil;
@@ -54,6 +53,7 @@ import com.redhat.devtools.lsp4ij.dap.stepping.DAPStepIntoVariant;
 import com.redhat.devtools.lsp4ij.dap.threads.ThreadsPanel;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import com.redhat.devtools.lsp4ij.settings.ui.InstallerPanel;
@@ -135,7 +135,7 @@ public class DAPDebugProcess extends XDebugProcess implements Disposable {
                 try {
                     // Wait for DAP server is ready...
                     serverReadyFuture.track();
-                    ProgressIndicatorUtils.awaitWithCheckCanceled(serverReadyFuture);
+                    awaitWithCheckCanceled(serverReadyFuture);
                     if (CompletableFutures.isDoneNormally(serverReadyFuture)) {
                         // At this step the DAP server is started and ready to consume it with DAP clients
 
@@ -162,7 +162,7 @@ public class DAPDebugProcess extends XDebugProcess implements Disposable {
                         connectToServerFuture = parentClient.connectToServer(indicator);
 
                         // Wait for DAP client is connecting to the DAP server...
-                        ProgressIndicatorUtils.awaitWithCheckCanceled(connectToServerFuture);
+                        awaitWithCheckCanceled(connectToServerFuture);
                         DAPDebugProcess.this.status = Status.STARTED;
 
                         // Refresh Threads panel

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/completion/DAPCompletionProcessor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/completion/DAPCompletionProcessor.java
@@ -24,6 +24,7 @@ import com.redhat.devtools.lsp4ij.dap.client.DAPClient;
 import com.redhat.devtools.lsp4ij.dap.client.DAPStackFrame;
 import com.redhat.devtools.lsp4ij.dap.evaluation.DAPExpressionCodeFragment;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import com.redhat.devtools.lsp4ij.internal.StringUtils;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.debug.CompletionItem;
@@ -37,7 +38,6 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.features.completion.LSPCompletionContributor.getCurrentWord;
 
@@ -76,7 +76,7 @@ public class DAPCompletionProcessor extends CompletionContributor {
                     client.completion(text, position.getLine() + 1, position.getCharacter() + 1, frameId);
 
             try {
-                ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+                awaitWithCheckCanceled(future);
             } catch (ProcessCanceledException ignore) {
                 return;
             } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/dap/stepping/DAPSmartStepIntoHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/dap/stepping/DAPSmartStepIntoHandler.java
@@ -20,7 +20,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.dap.client.DAPClient;
 import com.redhat.devtools.lsp4ij.dap.client.DAPStackFrame;
 import com.redhat.devtools.lsp4ij.dap.client.DAPSuspendContext;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import org.eclipse.lsp4j.debug.StepInTarget;
 import org.eclipse.lsp4j.debug.StepInTargetsResponse;
 import org.jetbrains.annotations.NotNull;
@@ -62,7 +62,7 @@ public class DAPSmartStepIntoHandler extends XSmartStepIntoHandler<DAPStepIntoVa
         CompletableFuture<List<DAPStepIntoVariant>> future = getStepInTargetsFuture(position);
 
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+            awaitWithCheckCanceled(future);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyIncomingCallsTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyIncomingCallsTreeStructure.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP call hierarchy tree structure base for callHierarchy/incomingCalls.
@@ -50,7 +50,7 @@ public class LSPCallHierarchyIncomingCallsTreeStructure extends LSPCallHierarchy
         var params = new CallHierarchyIncomingCallsParams(hierarchyItem);
         CompletableFuture<List<CallHierarchyItemData>> prepareCallHierarchyFuture = callHierarchyIncomingCallsSupport.getCallHierarchyIncomingCalls(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(prepareCallHierarchyFuture);
+            awaitWithCheckCanceled(prepareCallHierarchyFuture);
         } catch (ProcessCanceledException ex) {
             // cancel the LSP requests callHierarchy/incomingCalls
             callHierarchyIncomingCallsSupport.cancel();

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyOutgoingCallsTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyOutgoingCallsTreeStructure.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP call hierarchy tree structure base for callHierarchy/outgoingCalls.
@@ -50,7 +50,7 @@ public class LSPCallHierarchyOutgoingCallsTreeStructure extends LSPCallHierarchy
         var params = new CallHierarchyOutgoingCallsParams(hierarchyItem);
         CompletableFuture<List<CallHierarchyItemData>> prepareCallHierarchyFuture = callHierarchyOutgoingCallsSupport.getCallHierarchyOutgoingCalls(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(prepareCallHierarchyFuture);
+            awaitWithCheckCanceled(prepareCallHierarchyFuture);
         } catch (ProcessCanceledException ex) {
             // cancel the LSP requests callHierarchy/outgoingCalls
             callHierarchyOutgoingCallsSupport.cancel();

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/callHierarchy/LSPCallHierarchyTreeStructureBase.java
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP call hierarchy tree structure base for callHierarchy/incomingCalls / callHierarchy/outgoingCalls.
@@ -65,7 +65,7 @@ public abstract class LSPCallHierarchyTreeStructureBase extends LSPHierarchyTree
         var params = new LSPCallHierarchyPrepareParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<CallHierarchyItemData>> prepareCallHierarchyFuture = prepareCallHierarchySupport.getPrepareCallHierarchies(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(prepareCallHierarchyFuture);
+            awaitWithCheckCanceled(prepareCallHierarchyFuture);
         } catch (ProcessCanceledException ex) {
             // cancel the LSP requests textDocument/prepareCallHierarchy
             prepareCallHierarchySupport.cancel();

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionCodeActionSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/intention/LSPIntentionCodeActionSupport.java
@@ -11,7 +11,6 @@
 package com.redhat.devtools.lsp4ij.features.codeAction.intention;
 
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPRequestConstants;
 import com.redhat.devtools.lsp4ij.LanguageServerItem;
@@ -34,6 +33,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP code action support which loads and caches code actions by consuming:
@@ -151,7 +151,7 @@ public class LSPIntentionCodeActionSupport extends AbstractLSPDocumentFeatureSup
         // See https://github.com/redhat-developer/lsp4ij/issues/1648
         if (future != null) {
             try {
-                ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+                awaitWithCheckCanceled(future);
             } catch (ProcessCanceledException e) {
                 throw e;
             } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/quickfix/LSPLazyCodeActions.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeAction/quickfix/LSPLazyCodeActions.java
@@ -15,7 +15,6 @@ package com.redhat.devtools.lsp4ij.features.codeAction.quickfix;
 
 import com.intellij.codeInsight.intention.IntentionAction;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
@@ -41,6 +40,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * This class returns 20 IJ {@link LSPLazyCodeActionIntentionAction} which does nothing. It loads the LSP code actions
@@ -111,7 +111,7 @@ public class LSPLazyCodeActions implements LSPLazyCodeActionProvider {
         // See https://github.com/redhat-developer/lsp4ij/issues/1648
         var future = lspCodeActionRequest;
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+            awaitWithCheckCanceled(future);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/codeLens/LSPCodeLensProvider.java
@@ -45,11 +45,11 @@ import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.intellij.codeInsight.codeVision.CodeVisionState.Ready;
 import static com.redhat.devtools.lsp4ij.internal.ApplicationUtils.runCancellableReadAction;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP textDocument/codeLens support.
@@ -113,7 +113,7 @@ public class LSPCodeLensProvider implements CodeVisionProvider<Void> {
             LSPCodeLensEditorFactoryListener.setCodelensSupport(editor, codeLensSupport);
             CompletableFuture<CodeLensDataResult> future = fetchCodeLenses(codeLensSupport);
             try {
-                ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+                awaitWithCheckCanceled(future);
             } catch (ProcessCanceledException e) {
                 throw e;
             } catch (CancellationException ignore) {
@@ -150,7 +150,7 @@ public class LSPCodeLensProvider implements CodeVisionProvider<Void> {
                         if (visibleCodeLensToResolve != null) {
                             // Resolve all visible code lens
                             try {
-                                ProgressIndicatorUtils.awaitWithCheckCanceled(visibleCodeLensToResolve);
+                                awaitWithCheckCanceled(visibleCodeLensToResolve);
                             } catch (ProcessCanceledException e) {
                                 throw e;
                             } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/color/LSPColorProvider.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.RangeMarker;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiFile;
@@ -47,6 +46,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.ignoreAllExceptions;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
 
@@ -86,7 +86,7 @@ public class LSPColorProvider extends AbstractLSPInlayHintsProvider {
         CompletableFuture<List<ColorData>> future = colorSupport.getColors(params);
 
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+            awaitWithCheckCanceled(future);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/completion/LSPCompletionContributor.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressManager;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.UserDataHolder;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -44,6 +43,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP completion contributor.
@@ -78,7 +78,7 @@ public class LSPCompletionContributor extends CompletionContributor {
                 .getCompletionSupport();
         CompletableFuture<List<CompletionData>> future = completionSupport.getCompletions(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+            awaitWithCheckCanceled(future);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/declaration/LSPGoToDeclarationAction.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP Go To Declaration.
@@ -51,7 +51,7 @@ public class LSPGoToDeclarationAction extends AbstractLSPGoToAction {
         var params = new LSPDeclarationParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> declarationsFuture = declarationSupport.getDeclarations(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(declarationsFuture);
+            awaitWithCheckCanceled(declarationsFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkCollector.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkCollector.java
@@ -25,7 +25,6 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.client.ExecuteLSPFeatureStatus;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.completion.LSPCompletionContributor;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +38,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * Collects LSP document links and converts them to IntelliJ {@link HighlightInfo}.
@@ -76,7 +76,7 @@ public class LSPDocumentLinkCollector {
         CompletableFuture<List<DocumentLinkData>> documentLinkFuture = documentLinkSupport.getDocumentLinks(params);
 
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(documentLinkFuture);
+            awaitWithCheckCanceled(documentLinkFuture);
         } catch (ProcessCanceledException e) {
             // ProgressIndicator was cancelled (e.g. WriteAction requested or highlighting pass cancelled).
             // Save the future for async fallback via whenReady() callback.

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentLink/LSPDocumentLinkGotoDeclarationHandler.java
@@ -37,10 +37,10 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.features.documentLink.LSPDocumentLinkPsiElement.isHttpUrl;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * {@link GotoDeclarationHandler} implementation used to open LSP document link with CTrl+Click.
@@ -68,7 +68,7 @@ public class LSPDocumentLinkGotoDeclarationHandler implements GotoDeclarationHan
         var params = new DocumentLinkParams(new TextDocumentIdentifier());
         CompletableFuture<List<DocumentLinkData>> documentLinkFuture = documentLinkSupport.getDocumentLinks(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(documentLinkFuture);
+            awaitWithCheckCanceled(documentLinkFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentSymbol/LSPDocumentSymbolStructureViewModel.java
@@ -26,7 +26,6 @@ import com.intellij.util.ArrayUtil;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.documentSymbol.filter.*;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.jetbrains.annotations.NotNull;
@@ -43,6 +42,7 @@ import java.util.stream.Stream;
 
 import static com.redhat.devtools.lsp4ij.features.documentSymbol.LSPDocumentSymbolStructureViewFactory.isSymbolsSupportedByLanguageServer;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP document symbol structure view model.
@@ -181,7 +181,7 @@ public class LSPDocumentSymbolStructureViewModel extends StructureViewModelBase 
             var documentSymbolFuture = documentSymbolSupport.getDocumentSymbols(params);
 
             try {
-                ProgressIndicatorUtils.awaitWithCheckCanceled(documentSymbolFuture);
+                awaitWithCheckCanceled(documentSymbolFuture);
             } catch (ProcessCanceledException e) {
                 throw e;
             } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTargetProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/documentation/LSPDocumentationTargetProvider.java
@@ -12,7 +12,6 @@ package com.redhat.devtools.lsp4ij.features.documentation;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
@@ -41,6 +40,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.features.documentation.LSPDocumentationHelper.getValidMarkupContents;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP {@link DocumentationTargetProvider} implementation used to consume
@@ -73,7 +73,7 @@ public class LSPDocumentationTargetProvider implements DocumentationTargetProvid
         CompletableFuture<List<HoverData>> hoverFuture = hoverSupport.getHover(params);
 
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(hoverFuture);
+            awaitWithCheckCanceled(hoverFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/files/AbstractLSPFileListener.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/files/AbstractLSPFileListener.java
@@ -19,8 +19,8 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.LanguageServerWrapper;
 import com.redhat.devtools.lsp4ij.features.files.watcher.FileSystemWatcherManager;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import org.eclipse.lsp4j.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -245,7 +245,7 @@ public abstract class AbstractLSPFileListener implements FileEditorManagerListen
         try {
             CancellationSupport cancellationSupport = new CancellationSupport();
             future = cancellationSupport.execute(future);
-            ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+            awaitWithCheckCanceled(future);
         } catch (CancellationException ignore) {
 
         }

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
@@ -42,9 +42,9 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP folding range builder.
@@ -118,7 +118,7 @@ public class LSPFoldingRangeBuilder extends CustomFoldingBuilder {
         var params = new FoldingRangeRequestParams(new TextDocumentIdentifier());
         CompletableFuture<List<FoldingRange>> foldingRangesFuture = foldingRangeSupport.getFoldingRanges(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(foldingRangesFuture);
+            awaitWithCheckCanceled(foldingRangesFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/formatting/LSPFormattingSupport.java
@@ -31,7 +31,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.LSPIJUtils.applyEdits;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP formatting and range formatting support.
@@ -56,7 +56,7 @@ public class LSPFormattingSupport extends AbstractLSPDocumentFeatureSupport<LSPF
         LSPFormattingParams params = new LSPFormattingParams(textRange, document, formattingServer, formattingOptions);
         CompletableFuture<List<? extends TextEdit>> formatFuture = this.getFeatureData(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(formatFuture);
+            awaitWithCheckCanceled(formatFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightUsagesHandlerFactory.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/highlight/LSPHighlightUsagesHandlerFactory.java
@@ -16,7 +16,6 @@ import com.intellij.codeInsight.highlighting.HighlightUsagesHandlerFactory;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -41,6 +40,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 
 /**
@@ -85,7 +85,7 @@ public class LSPHighlightUsagesHandlerFactory implements HighlightUsagesHandlerF
         LSPHighlightSupport highlightSupport = LSPFileSupport.getSupport(psiFile).getHighlightSupport();
         CompletableFuture<List<DocumentHighlight>> highlightFuture = highlightSupport.getHighlights(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(highlightFuture);
+            awaitWithCheckCanceled(highlightFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/implementation/LSPGoToImplementationAction.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP Go To Implementation.
@@ -51,7 +51,7 @@ public class LSPGoToImplementationAction extends AbstractLSPGoToAction {
         var params = new LSPImplementationParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> implementationsFuture = implementationSupport.getImplementations(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(implementationsFuture);
+            awaitWithCheckCanceled(implementationsFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/inlayhint/LSPInlayHintsProvider.java
@@ -15,7 +15,6 @@ import com.intellij.codeInsight.hints.declarative.*;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
@@ -38,6 +37,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP textDocument/inlayHint support.
@@ -59,7 +59,7 @@ public class LSPInlayHintsProvider extends AbstractLSPDeclarativeInlayHintsProvi
         CompletableFuture<List<InlayHintData>> future = inlayHintSupport.getInlayHints(params);
 
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+            awaitWithCheckCanceled(future);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPGotoDeclarationHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/navigation/LSPGotoDeclarationHandler.java
@@ -41,10 +41,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.features.LSPPsiElementFactory.toPsiElement;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 public class LSPGotoDeclarationHandler implements GotoDeclarationHandler {
 
@@ -144,7 +144,7 @@ public class LSPGotoDeclarationHandler implements GotoDeclarationHandler {
         var params = new LSPDefinitionParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> definitionsFuture = definitionSupport.getDefinitions(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(definitionsFuture);
+            awaitWithCheckCanceled(definitionsFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/references/LSPGoToReferenceAction.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP Go To Reference.
@@ -51,7 +51,7 @@ public class LSPGoToReferenceAction extends AbstractLSPGoToAction {
         var params = new LSPReferenceParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> referencesFuture = referenceSupport.getReferences(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(referencesFuture);
+            awaitWithCheckCanceled(referencesFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPSelectionRangeSupport.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/selectionRange/LSPSelectionRangeSupport.java
@@ -22,7 +22,6 @@ import com.redhat.devtools.lsp4ij.client.indexing.ProjectIndexingManager;
 import com.redhat.devtools.lsp4ij.features.AbstractLSPDocumentFeatureSupport;
 import com.redhat.devtools.lsp4ij.internal.CancellationSupport;
 import com.redhat.devtools.lsp4ij.internal.CompletableFutures;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SelectionRange;
@@ -38,6 +37,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP selectionRange support which loads and caches selection ranges by consuming:
@@ -73,7 +73,7 @@ public class LSPSelectionRangeSupport extends AbstractLSPDocumentFeatureSupport<
         var params = new LSPSelectionRangeParams(textDocumentIdentifier, Collections.singletonList(position), offset);
         CompletableFuture<List<SelectionRange>> selectionRangesFuture = selectionRangeSupport.getSelectionRanges(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(selectionRangesFuture);
+            awaitWithCheckCanceled(selectionRangesFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/semanticTokens/LSPSemanticTokensHighlightVisitor.java
@@ -14,7 +14,6 @@ package com.redhat.devtools.lsp4ij.features.semanticTokens;
 import com.intellij.codeInsight.daemon.impl.HighlightVisitor;
 import com.intellij.codeInsight.daemon.impl.analysis.HighlightInfoHolder;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
@@ -34,6 +33,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP 'textDocument/semanticTokens' support by implementing IntelliJ {@link HighlightVisitor}.
@@ -170,7 +170,7 @@ public class LSPSemanticTokensHighlightVisitor implements HighlightVisitor {
      *
      * <p>
      * This method is called from {@link #analyze}, which runs inside a read action.
-     * {@code ProgressIndicatorUtils.awaitWithCheckCanceled} integrates with
+     * {@code awaitWithCheckCanceled} integrates with
      * IntelliJ's concurrency model: when a write action is requested, the current
      * progress indicator is cancelled → ProcessCanceledException is thrown →
      * the read lock is released → the write action can proceed immediately.
@@ -200,7 +200,7 @@ public class LSPSemanticTokensHighlightVisitor implements HighlightVisitor {
         try {
             // Wait for the LSP future while cooperating with IntelliJ's lock model.
             // See class Javadoc for a detailed explanation of why this is safe.
-            ProgressIndicatorUtils.awaitWithCheckCanceled(semanticTokensFuture);
+            awaitWithCheckCanceled(semanticTokensFuture);
 
         } catch (ProcessCanceledException e) {
             // A write action requested priority, or the pass was cancelled for another

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPParameterInfoHandler.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/signatureHelp/LSPParameterInfoHandler.java
@@ -16,7 +16,6 @@ package com.redhat.devtools.lsp4ij.features.signatureHelp;
 import com.intellij.codeInsight.CodeInsightBundle;
 import com.intellij.lang.parameterInfo.*;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
@@ -32,6 +31,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP implementation of {@link ParameterInfoHandler} to support
@@ -102,7 +102,7 @@ public class LSPParameterInfoHandler implements ParameterInfoHandler<LSPSignatur
         CompletableFuture<SignatureHelp> future = signatureHelpSupport.getSignatureHelp(params);
 
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+            awaitWithCheckCanceled(future);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeDefinition/LSPGoToTypeDefinitionAction.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP Go To TypeDefinition.
@@ -51,7 +51,7 @@ public class LSPGoToTypeDefinitionAction extends AbstractLSPGoToAction {
         var params = new LSPTypeDefinitionParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> typeDefinitionsFuture = typeDefinitionSupport.getTypeDefinitions(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(typeDefinitionsFuture);
+            awaitWithCheckCanceled(typeDefinitionsFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySubtypesTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySubtypesTreeStructure.java
@@ -17,7 +17,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyNodeDescriptor;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.lsp4j.TypeHierarchySubtypesParams;
 import org.jetbrains.annotations.NotNull;
@@ -50,7 +50,7 @@ public class LSPTypeHierarchySubtypesTreeStructure extends LSPTypeHierarchyTreeS
         var params = new TypeHierarchySubtypesParams(hierarchyItem);
         CompletableFuture<List<TypeHierarchyItemData>> prepareTypeHierarchyFuture = typeHierarchySubtypesSupport.getTypeHierarchySubtypes(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(prepareTypeHierarchyFuture);
+            awaitWithCheckCanceled(prepareTypeHierarchyFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySupertypesTreeStructure.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchySupertypesTreeStructure.java
@@ -17,7 +17,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyNodeDescriptor;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.lsp4j.TypeHierarchySupertypesParams;
 import org.jetbrains.annotations.NotNull;
@@ -50,7 +50,7 @@ public class LSPTypeHierarchySupertypesTreeStructure extends LSPTypeHierarchyTre
         var params = new TypeHierarchySupertypesParams(hierarchyItem);
         CompletableFuture<List<TypeHierarchyItemData>> prepareTypeHierarchyFuture = typeHierarchySupertypesSupport.getTypeHierarchySupertypes(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(prepareTypeHierarchyFuture);
+            awaitWithCheckCanceled(prepareTypeHierarchyFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/typeHierarchy/LSPTypeHierarchyTreeStructureBase.java
@@ -21,7 +21,6 @@ import com.redhat.devtools.lsp4ij.LSPFileSupport;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyNodeDescriptor;
 import com.redhat.devtools.lsp4ij.features.hierarchy.LSPHierarchyTreeStructureBase;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * LSP type hierarchy tree structure base for typeHierarchy/subtypes / typeHierarchy/supertypes.
@@ -64,7 +64,7 @@ public abstract class LSPTypeHierarchyTreeStructureBase extends LSPHierarchyTree
         var params = new LSPTypeHierarchyPrepareParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<TypeHierarchyItemData>> prepareTypeHierarchyFuture = prepareTypeHierarchySupport.getPrepareTypeHierarchies(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(prepareTypeHierarchyFuture);
+            awaitWithCheckCanceled(prepareTypeHierarchyFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException ignore) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceImplementationsSearch.java
@@ -39,9 +39,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * Implements the IDE's standard Go To Implementation(s) action using LSP textDocument/implementation. -->
@@ -98,7 +98,7 @@ public class LSPWorkspaceImplementationsSearch extends QueryExecutorBase<PsiElem
         LSPImplementationSupport implementationSupport = LSPFileSupport.getSupport(file).getImplementationSupport();
         CompletableFuture<List<LocationData>> implementationsFuture = implementationSupport.getImplementations(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(implementationsFuture);
+            awaitWithCheckCanceled(implementationsFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceTypeDeclarationProvider.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/workspaceSymbol/LSPWorkspaceTypeDeclarationProvider.java
@@ -40,9 +40,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
 
 import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.isDoneNormally;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 /**
  * Implements the IDE's standard Go To Type Declaration action using LSP textDocument/typeDefinition. -->
@@ -91,7 +91,7 @@ public class LSPWorkspaceTypeDeclarationProvider implements TypeDeclarationPlace
         var params = new LSPTypeDefinitionParams(new TextDocumentIdentifier(), LSPIJUtils.toPosition(offset, document), offset);
         CompletableFuture<List<LocationData>> typeDefinitionsFuture = typeDefinitionSupport.getTypeDefinitions(params);
         try {
-            ProgressIndicatorUtils.awaitWithCheckCanceled(typeDefinitionsFuture);
+            awaitWithCheckCanceled(typeDefinitionsFuture);
         } catch (ProcessCanceledException e) {
             throw e;
         } catch (CancellationException e) {

--- a/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/internal/CompletableFutures.java
@@ -125,6 +125,13 @@ public class CompletableFutures {
         });
     }
 
+    public static void awaitWithCheckCanceled(@Nullable Future<?> future) {
+        if (future == null) {
+            return;
+        }
+        ProgressIndicatorUtils.awaitWithCheckCanceled(future);
+    }
+
     public static CompletableFuture<Void> allOf(CompletableFuture<?>... cfs) {
         var allOff = CompletableFuture.allOf(cfs);
         CancellationSupport.forwardCancellation(allOff, cfs);

--- a/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/usages/LSPUsageSearcher.java
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import com.intellij.openapi.progress.util.ProgressIndicatorUtils;
+import static com.redhat.devtools.lsp4ij.internal.CompletableFutures.awaitWithCheckCanceled;
 
 import static com.redhat.devtools.lsp4ij.internal.ApplicationUtils.runCancellableReadAction;
 import static com.redhat.devtools.lsp4ij.usages.LSPFindUsagesHandlerFactory.isUsageSupportedByLanguageServer;
@@ -164,7 +164,7 @@ public class LSPUsageSearcher extends CustomUsageSearcher {
             // 3. Wait for the future OUTSIDE of the ReadAction
             // This allows the ForkJoinPool background threads to freely acquire ReadActions
             // to resolve the PSI elements during mapping!
-            ProgressIndicatorUtils.awaitWithCheckCanceled(usagesFuture);
+            awaitWithCheckCanceled(usagesFuture);
             if (usagesFuture.isDone()) {
                 List<LSPUsagePsiElement> usages = usagesFuture.getNow(null);
                 if (usages != null && !usages.isEmpty()) {


### PR DESCRIPTION
fix: use null-safe CompletableFutures.awaitWithCheckCanceled wrapper to prevent NPE when future is null

AbstractLSPFeatureSupport.getFeatureData() can return null due to a race condition with cancel(). All callers passing the result to ProgressIndicatorUtils.awaitWithCheckCanceled would throw IllegalArgumentException on the @NotNull parameter.